### PR TITLE
Fix Image Rendering in 6.13 and better looking data in 10.1

### DIFF
--- a/TUNING_GUIDE_ArduCopter.md
+++ b/TUNING_GUIDE_ArduCopter.md
@@ -562,13 +562,13 @@ We used an oversized test stand to test the motors. Since the test stand was too
 - Mamba Systems F45_128k BLHeli32 4in1 ESC
 - HQProp "DUCT-76MMX8" propellers
 
-![motor_test_stand_with_drone_cropped|316x499](images/blog/motor_test_stand_with_drone_cropped.jpg)
+<img width="316" height="499" src="images/blog/motor_test_stand_with_drone_cropped.jpg" alt="motor_test_stand_with_drone_cropped" />
 
 We fixed and updated Cell G8 as well as the plot's Data range of the [original ArduPilot Wiki Spreadsheet](https://docs.google.com/spreadsheets/d/1_75aZqiT_K1CdduhUe4-DjRgx3Alun4p8V2pt6vM5P8/edit#gid=0) creating [this corrected version](images/blog/ArduPilot_Motor_Thrust_Fit.ods)
 
 We imported the data into the spreadsheet and created this graph:
 
-![motor_thrust_chart|690x389](images/blog/motor_thrust_chart.PNG)
+<img width="690" height="389" src="images/blog/motor_thrust_chart.PNG" alt="motor_thrust_chart" />
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `15_motor.param` file
 
@@ -1008,8 +1008,8 @@ and the side area looks like this:
 Divided by 1,000,000 to convert from mm² to m², the frontal area is 0.01097 m² and the side area is 0.01455 m².
 The weight of our drone is 560g, therefore the ballistic coefficients are
 
-- [EK3_DRAG_BCOEF_X](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-bcoef-x) = 0.56 kg / 0.01097 m² = 51.0399
-- [EK3_DRAG_BCOEF_Y](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-bcoef-y) = 0.56 kg / 0.01455 m² = 38.4798
+> [EK3_DRAG_BCOEF_X](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-bcoef-x) = 0.56 kg / 0.01097 m² = 51.0399 <br>
+> [EK3_DRAG_BCOEF_Y](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-bcoef-y) = 0.56 kg / 0.01455 m² = 38.4798 <br>
 
 Use *ArduPilot Methodic Configurator* to edit and upload the `40_windspeed_estimation.param` file to the FC.
 
@@ -1030,45 +1030,45 @@ It should look like this:
 Get the current wind speed, that is the GPS speed when AccY reaches zero and the GPS speed has stabilized.
 In this case, it is:
 
-- windspeed = 2.35 [m/s]
+> windspeed = 2.35 [m/s]
 
 Next, get the groundspeed at the start of the test.
 That is the GPS speed when the vehicle starts to decelerate after the little bit of jitter is over.
 In this case, it is:
 
-- groundspeed = 3.9 [m/s]
+> groundspeed = 3.9 [m/s]
 
 With this information, you can calculate the vehicle's airspeed, which is:
 
-- airspeed = windspeed + groundspeed = 6.25 [m/s]
+> airspeed = windspeed + groundspeed = 6.25 [m/s]
 
 Next get the maximum acceleration during the test, which is the acceleration at the time of the groundspeed measurement.
 In this case, it is:
 
-- max_accel = 4.2 [m/s²]
+> max_accel = 4.2 [m/s²]
 
 With the air density at the time of testing and the previously calculated ballistic drag coefficient (`EK3_DRAG_BCOEF_X` for front and back, `EK3_DRAG_BCOEF_Y` for left and right side) you can now calculate the bluff body drag, which is 1/2 * air density * airspeed^2 / BCOEF.
 In this case, it is:
 
-- Bluff body drag = 0.5 * 1.260 [kg/m³] * (6.25 [m/s])² / 38.4798 [kg/m²] = 0.6395 [m/s²]
+> Bluff body drag = 0.5 * 1.260 [kg/m³] * (6.25 [m/s])² / 38.4798 [kg/m²] = 0.6395 [m/s²]
 
 With that, you can now calculate the momentum drag, which is max_accel - bluff body drag.
 In this case, it is:
 
-- Momentum drag = 4.2 [m/s²] - 0.6395 [m/s²] = 3.5605 [m/s²]
+> Momentum drag = 4.2 [m/s²] - 0.6395 [m/s²] = 3.5605 [m/s²]
 
 Now you can calculate the momentum drag coefficient `EK3_DRAG_MCOEF`, which is momentum drag / airspeed.
 In this case, it is:
 
-- [EK3_DRAG_MCOEF](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-mcoef) = 3.5605 [m/s²] / 6.25 [m/s] = 0.5697 [1/s]
+> [EK3_DRAG_MCOEF](https://ardupilot.org/copter/docs/parameters.html#ek3-drag-mcoef) = 3.5605 [m/s²] / 6.25 [m/s] = 0.5697 [1/s]
 
 For better accuracy, you should do that for all directions and take the average. In our case, we got:
 
-- front: 0.4628 [1/s]
-- back: 0.4757 [1/s]
-- left: 0.5426 [1/s]
-- right: 0.5697 [1/s]
-- average: 0.5127 [1/s]
+> front: 0.4628 [1/s] <br>
+> back: 0.4757 [1/s] <br>
+> left: 0.5426 [1/s] <br>
+> right: 0.5697 [1/s] <br>
+> average: 0.5127 [1/s] <br>
 
 Note that these are quite high values due to the ducts around the props.
 For a normal copter with open propellers, it should be in the range of 0.1 to 0.2.


### PR DESCRIPTION
I don't know if any of you have visited the website, but section 6.13 had two images that were not rendered at all. I have corrected it.

In section 10.1, the data is easily mixed with the text, which makes it boring to hook into the example. I hope you like my proposal in this regard.