### PR TITLE
Add missing vehicle_components_schema.json file

### DIFF
--- a/windows/ardupilot_methodic_configurator.iss
+++ b/windows/ardupilot_methodic_configurator.iss
@@ -87,6 +87,7 @@ Source: "..\windows\ardupilot_methodic_configurator.ico"; DestDir: "{app}"; Flag
 Source: "..\ardupilot_methodic_configurator\ArduPilot_icon.png"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\ArduPilot_logo.png"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\configuration_steps_*.json"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
+Source: "..\ardupilot_methodic_configurator\vehicle_components_schema.json"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\LICENSES\*.*"; DestDir: "{app}\LICENSES"; Flags: ignoreversion
 Source: "..\credits\*.*"; DestDir: "{app}\credits"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\locale\*.mo"; DestDir: "{app}\_internal\ardupilot_methodic_configurator\locale"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
This pull request includes a small change to the `windows/ardupilot_methodic_configurator.iss` file. The change adds a new source file to the installation script.

* [`windows/ardupilot_methodic_configurator.iss`](diffhunk://#diff-8c51dfc5bddb9d3c3c14f0685ab9e542fa6c9439911fcd5d0bd9bcc785ae4200R90): Added the `vehicle_components_schema.json` file to the list of source files to be included in the installation.