### PR TITLE
Improve error messages when saving vehicle_components.json file

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -233,8 +233,9 @@ class ComponentEditorWindowBase(BaseWindow):
             current_data[path[-1]] = value
 
         # Save the updated data back to the JSON file
-        if self.local_filesystem.save_vehicle_components_json_data(self.data, self.local_filesystem.vehicle_dir):
-            show_error_message(_("Error"), _("Failed to save data to file. Is the destination write protected?"))
+        failed, msg = self.local_filesystem.save_vehicle_components_json_data(self.data, self.local_filesystem.vehicle_dir)
+        if failed:
+            show_error_message(_("Error"), _("Failed to save data to file.") + "\n" + msg)
         else:
             logging_info(_("Vehicle component data saved successfully."))
         self.root.destroy()

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -82,7 +82,7 @@ class TestVehicleComponents(unittest.TestCase):
     def test_save_vehicle_components_json_data_valid(self, mock_validate, mock_json_dump, mock_file) -> None:
         mock_validate.return_value = (True, "")
 
-        result = self.vehicle_components.save_vehicle_components_json_data(self.valid_component_data, "/test/dir")
+        result, _msg = self.vehicle_components.save_vehicle_components_json_data(self.valid_component_data, "/test/dir")
 
         assert not result  # False means success
         expected_path = os.path.join("/test/dir", "vehicle_components.json")
@@ -93,7 +93,7 @@ class TestVehicleComponents(unittest.TestCase):
     def test_save_vehicle_components_json_data_invalid(self, mock_validate) -> None:
         mock_validate.return_value = (False, "Validation error")
 
-        result = self.vehicle_components.save_vehicle_components_json_data(self.invalid_component_data, "/test/dir")
+        result, _msg = self.vehicle_components.save_vehicle_components_json_data(self.invalid_component_data, "/test/dir")
 
         assert result  # True means failure
 


### PR DESCRIPTION
This pull request includes changes to improve error handling and messaging when saving vehicle components data in the `ardupilot_methodic_configurator` project. The most important changes include modifying the return type of the `save_vehicle_components_json_data` method, updating the error messages in the frontend, and adjusting the corresponding tests.

Improvements to error handling and messaging:

* [`ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py`](diffhunk://#diff-4d082af14c1239b3a9772b04b19d0ba7bc6a11c6675c8dae7d127dcb65ab7d92L103-R152): Modified the `save_vehicle_components_json_data` method to return a tuple of `(bool, str)` indicating whether an error occurred and the error message. Added detailed error messages for different exceptions.

Frontend updates:

* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py`](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabL236-R238): Updated the `save_data` method to handle the new return type of `save_vehicle_components_json_data` and display detailed error messages in the UI.

Test adjustments:

* [`tests/test_backend_filesystem_vehicle_components.py`](diffhunk://#diff-8c424135c193ff93090364a9e2f78626833099dc0230a31ceebcfe880cf0875aL85-R85): Adjusted the tests for `save_vehicle_components_json_data` to handle the new return type and validate the error handling logic. [[1]](diffhunk://#diff-8c424135c193ff93090364a9e2f78626833099dc0230a31ceebcfe880cf0875aL85-R85) [[2]](diffhunk://#diff-8c424135c193ff93090364a9e2f78626833099dc0230a31ceebcfe880cf0875aL96-R96)