### PR TITLE
Allow blank component editor, allow separate component inference

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -99,13 +99,15 @@ def component_editor(
     vehicle_dir_window: Union[None, VehicleDirectorySelectionWindow],
 ) -> None:
     component_editor_window = ComponentEditorWindow(__version__, local_filesystem)
+    if vehicle_dir_window and vehicle_dir_window.blank_template_data.get():
+        local_filesystem.wipe_component_info()
     if (
         vehicle_dir_window
         and vehicle_dir_window.configuration_template
-        and vehicle_dir_window.use_fc_params.get()
+        and vehicle_dir_window.infer_comp_specs_and_conn_from_fc_params.get()
         and flight_controller.fc_parameters
     ):
-        # copy vehicle parameters to component editor values
+        # Infer vehicle component specifications and connections from FC parameters
         component_editor_window.set_values_from_fc_parameters(flight_controller.fc_parameters, local_filesystem.doc_dict)
     component_editor_window.populate_frames()
     component_editor_window.set_vehicle_type_and_version(vehicle_type, flight_controller.info.flight_sw_version_and_type)

--- a/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
@@ -176,3 +176,40 @@ class VehicleComponents:
     def get_vehicle_image_filepath(relative_template_path: str) -> str:
         template_default_dir = ProgramSettings.get_templates_base_dir()
         return os_path.join(template_default_dir, relative_template_path, "vehicle.jpg")
+
+    def wipe_component_info(self) -> None:
+        """
+        Wipe the vehicle components data by clearing all data from the vehicle_components dictionary.
+
+        This resets the internal state without affecting any files.
+        Preserves the complete structure of the dictionary including all branches and leaves,
+        but sets leaf values to empty values based on their type.
+        """
+        if self.vehicle_components is not None:
+            self._recursively_clear_dict(self.vehicle_components)
+
+    def _recursively_clear_dict(self, data: Union[dict, list, float, bool, str]) -> None:
+        """
+        Recursively clear leaf values in a nested dictionary while preserving structure.
+
+        :param data: Dictionary to clear
+        """
+        if not isinstance(data, dict):
+            return
+
+        for key, value in data.items():
+            if isinstance(value, dict):
+                # If it's a dictionary, recurse deeper
+                self._recursively_clear_dict(value)
+            elif isinstance(value, list):
+                # If it's a list, preserve it but empty it
+                data[key] = []
+            elif isinstance(value, (int, float)):
+                # For numerical values, set to 0
+                data[key] = 0 if isinstance(value, int) else 0.0
+            elif isinstance(value, bool):
+                # For boolean values, set to False
+                data[key] = False
+            else:
+                # For strings and other types, set to empty string or None
+                data[key] = "" if isinstance(value, str) else None

--- a/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
@@ -216,7 +216,7 @@ class VehicleDirectorySelectionWidgets(DirectorySelectionWidgets):
         return False
 
 
-class VehicleDirectorySelectionWindow(BaseWindow):
+class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-instance-attributes
     """
     A window for selecting a vehicle directory with intermediate parameter files.
 
@@ -236,6 +236,8 @@ class VehicleDirectorySelectionWindow(BaseWindow):
             + _(" - Select vehicle configuration directory")
         )
         self.root.geometry("800x625")  # Set the window size
+        self.blank_template_data = tk.BooleanVar(value=False)
+        self.infer_comp_specs_and_conn_from_fc_params = tk.BooleanVar(value=False)
         self.use_fc_params = tk.BooleanVar(value=False)
         self.configuration_template: str = ""  # will be set to a string if a template was used
 
@@ -262,7 +264,7 @@ class VehicleDirectorySelectionWindow(BaseWindow):
     def close_and_quit(self) -> None:
         sys_exit(0)
 
-    def create_option1_widgets(
+    def create_option1_widgets(  # pylint: disable=too-many-locals
         self, initial_template_dir: str, initial_base_dir: str, initial_new_dir: str, fc_connected: bool
     ) -> None:
         # Option 1 - Create a new vehicle configuration directory based on an existing template
@@ -288,6 +290,32 @@ class VehicleDirectorySelectionWindow(BaseWindow):
             is_template_selection=True,
         )
         self.template_dir.container_frame.pack(expand=False, fill=tk.X, padx=3, pady=5, anchor=tk.NW)
+        blank_template_data_checkbox = ttk.Checkbutton(
+            option1_label_frame,
+            variable=self.blank_template_data,
+            text=_("Blank template data"),
+        )
+        blank_template_data_checkbox.pack(anchor=tk.NW)
+        show_tooltip(
+            blank_template_data_checkbox, _("Create a new blank vehicle configuration, with no data from the template.")
+        )
+        infer_comp_specs_and_conn_from_fc_params_checkbox = ttk.Checkbutton(
+            option1_label_frame,
+            variable=self.infer_comp_specs_and_conn_from_fc_params,
+            text=_("Infer component specifications and FC connections from FC parameters, not from template files"),
+        )
+        infer_comp_specs_and_conn_from_fc_params_checkbox.pack(anchor=tk.NW)
+        show_tooltip(
+            infer_comp_specs_and_conn_from_fc_params_checkbox,
+            _(
+                "When creating a new vehicle configuration, extract component specifications\n"
+                "and connection information directly from the connected flight controller\n"
+                "instead of using the specifications defined in the template files.\n"
+                "This helps ensure the configuration accurately matches your actual hardware.\n"
+                "But you will not see the information from the correctly configured vehicle template.\n\n"
+            )
+            + _("This option is only available when a flight controller is connected."),
+        )
         use_fc_params_checkbox = ttk.Checkbutton(
             option1_label_frame,
             variable=self.use_fc_params,
@@ -299,10 +327,13 @@ class VehicleDirectorySelectionWindow(BaseWindow):
             _(
                 "Use the parameter values from the connected flight controller instead of the\n"
                 "template files when creating a new vehicle configuration directory from a template.\n"
-                "This option is only available when a flight controller is connected"
-            ),
+                "Only makes sense if your FC has already been correctly configured.\n\n"
+            )
+            + _("This option is only available when a flight controller is connected."),
         )
         if not fc_connected:
+            self.infer_comp_specs_and_conn_from_fc_params.set(False)
+            infer_comp_specs_and_conn_from_fc_params_checkbox.config(state=tk.DISABLED)
             self.use_fc_params.set(False)
             use_fc_params_checkbox.config(state=tk.DISABLED)
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and user interface of the ArduPilot Methodic Configurator. The key updates focus on adding new options for vehicle configuration and improving the internal handling of component data.

### Enhancements to Vehicle Configuration Options:
* Added two new options, `blank_template_data` and `infer_comp_specs_and_conn_from_fc_params`, to the `VehicleDirectorySelectionWindow` class, allowing users to create a blank vehicle configuration or infer component specifications from flight controller parameters. (`[[1]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8R239-R240)`, `[[2]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8R293-R318)`, `[[3]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L302-R336)`)

### Internal Data Handling Improvements:
* Introduced the `wipe_component_info` method in `backend_filesystem_vehicle_components.py` to clear vehicle component data while preserving the dictionary structure. This method ensures that the internal state is reset without affecting any files. (`[ardupilot_methodic_configurator/backend_filesystem_vehicle_components.pyR179-R215](diffhunk://#diff-4d082af14c1239b3a9772b04b19d0ba7bc6a11c6675c8dae7d127dcb65ab7d92R179-R215)`)

### Code Quality Improvements:
* Disabled the pylint warning for too many instance attributes in the `VehicleDirectorySelectionWindow` class to maintain code readability and manageability. (`[ardupilot_methodic_configurator/frontend_tkinter_directory_selection.pyL219-R219](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L219-R219)`)
* Disabled the pylint warning for too many local variables in the `create_option1_widgets` method to improve code clarity. (`[ardupilot_methodic_configurator/frontend_tkinter_directory_selection.pyL265-R267](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L265-R267)`)

### Additional Logic in Component Editor:
* Updated the `component_editor` function to wipe component info if `blank_template_data` is selected and to infer component specs and connections from flight controller parameters if the corresponding option is enabled. (`[ardupilot_methodic_configurator/__main__.pyR102-R110](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fR102-R110)`)