### PR TITLE
Blank parameter change reason

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -229,8 +229,8 @@
             "id": "languageCode",
             "type": "pickString",
             "description": "Select language code:",
-            "options": ["en", "zh_CN", "pt", "de"],
-            "default": "zh_CN"
+            "options": ["all", "zh_CN", "pt", "de", "it", "ja"],
+            "default": "all"
         },
         {
             "id": "outputFile",
@@ -254,7 +254,7 @@
             "id": "poOutputFile",
             "type": "promptString",
             "description": "Enter output .po file name:",
-            "default": "ardupilot_methodic_configurator_new.po"
+            "default": "ardupilot_methodic_configurator.po"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -142,7 +142,7 @@
             "group": "build"
         },
         {
-            "label": "pytest with coverage",
+            "label": "pytest with coverage MD",
             "type": "shell",
             "command": "pytest --cov=ardupilot_methodic_configurator --cov-report=xml:tests/coverage.xml --md=tests/results.md",
             "group": {
@@ -173,6 +173,56 @@
                 ]
             }
         },
+        {
+            "label": "pytest with coverage HTML (Linux)",
+            "type": "shell",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "-m",
+                "coverage",
+                "run",
+                "-m",
+                "pytest",
+                "&",
+                "${command:python.interpreterPath}",
+                "-m",
+                "coverage",
+                "html",
+                "&",
+                "firefox",
+                "htmlcov/index.html"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": {
+                "owner": "python",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": [
+                    {
+                        "regexp": "^(.+):(\\d+): (\\w+): (.+)$",
+                        "file": 1,
+                        "line": 2,
+                        "severity": 3,
+                        "message": 4
+                    }
+                ]
+            }
+        },
+        {
+            "label": "pytest with coverage HTML (Windows)",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-Command",
+                "coverage run -m pytest; coverage html; Start-Process firefox -ArgumentList 'htmlcov/index.html'"
+            ]
+        }
     ],
     "inputs": [
         {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -333,15 +333,22 @@ Add the language to the end of the `LANGUAGE_CHOICES` array in the `ardupilot_me
 For example, to add support for German:
 
 ```python
-LANGUAGE_CHOICES = ['en', 'zh_CN', 'pt', 'de']
+LANGUAGE_CHOICES = ["en", "zh_CN", "pt", "de", "it", "ja"]
 ```
 
 Add it also to the test on `tests\test_internationalization.py` file:
 
 ```python
     def test_language_choices(self) -> None:
-        expected_languages = ["en", "zh_CN", "pt", "de", "it"]
+        expected_languages = ["en", "zh_CN", "pt", "de", "it", "ja"]
         assert expected_languages == LANGUAGE_CHOICES
+```
+
+and `.vscode\tasks.json` file:
+
+```json
+            "description": "Select language code:",
+            "options": ["all", "zh_CN", "pt", "de", "it", "ja"],
 ```
 
 ### 3. Create a New PO File

--- a/SetupDeveloperPC.bat
+++ b/SetupDeveloperPC.bat
@@ -182,28 +182,29 @@ goto :eof
 
 :: Define paths
 set "PROFILE_PATH=%USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-set "MODULE_PATH=C:\Program^ Files^ ^(x86^)\ardupilot_methodic_configurator\ardupilot_methodic_configurator_command_line_completion.psm1"
+set "MODULE_PATH=C:\Program Files (x86)\ardupilot_methodic_configurator\ardupilot_methodic_configurator_command_line_completion.psm1"
 
 :: Create profile directory if it doesn't exist
-if not exist "%USERPROFILE%\Documents\WindowsPowerShell" (
-    mkdir "%USERPROFILE%\Documents\WindowsPowerShell"
+if not exist "!USERPROFILE!\Documents\WindowsPowerShell" (
+    mkdir "!USERPROFILE!\Documents\WindowsPowerShell"
 )
 
 :: Check if module exists
-if not exist "%MODULE_PATH%" (
-    echo Error: Module file not found at %MODULE_PATH%
+if not exist "!MODULE_PATH!" (
+    echo Error: Module file not found at !MODULE_PATH!
     pause
     exit /b 1
 )
 
 :: Add import line to profile if it doesn't exist
-powershell -Command "if (-not (Test-Path '%PROFILE_PATH%')) { New-Item -Path '%PROFILE_PATH%' -Force } else { $content = Get-Content '%PROFILE_PATH%'; if ($content -notcontains 'Import-Module \"%MODULE_PATH%\"') { Add-Content '%PROFILE_PATH%' 'Import-Module \"%MODULE_PATH%\"' }}"
+powershell -NoProfile -Command "$ProfilePath='!PROFILE_PATH!'.Replace('\','\\'); $ModulePath='!MODULE_PATH!'.Replace('\','\\'); if (-not (Test-Path $ProfilePath)) { New-Item -Path $ProfilePath -Force | Out-Null }; $content = Get-Content $ProfilePath -ErrorAction SilentlyContinue; if (-not ($content -contains \"Import-Module `\"$ModulePath`\"\")) { Add-Content $ProfilePath \"Import-Module `\"$ModulePath`\"\" }"
 
-if %errorLevel% equ 0 (
+if !ERRORLEVEL! equ 0 (
     echo PowerShell profile updated successfully.
     echo Please restart PowerShell for changes to take effect.
 ) else (
     echo Failed to update PowerShell profile.
+    exit /b 1
 )
 
 goto :eof

--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -99,7 +99,7 @@ def component_editor(
     vehicle_dir_window: Union[None, VehicleDirectorySelectionWindow],
 ) -> None:
     component_editor_window = ComponentEditorWindow(__version__, local_filesystem)
-    if vehicle_dir_window and vehicle_dir_window.blank_template_data.get():
+    if vehicle_dir_window and vehicle_dir_window.blank_component_data.get():
         local_filesystem.wipe_component_info()
     if (
         vehicle_dir_window

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -458,7 +458,9 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
     def directory_exists(directory: str) -> bool:
         return os_path.exists(directory) and os_path.isdir(directory)
 
-    def copy_template_files_to_new_vehicle_dir(self, template_dir: str, new_vehicle_dir: str) -> str:
+    def copy_template_files_to_new_vehicle_dir(
+        self, template_dir: str, new_vehicle_dir: str, blank_change_reason: bool
+    ) -> str:
         # Copy the template files to the new vehicle directory
         try:
             if not os_path.exists(template_dir):
@@ -482,7 +484,14 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                     continue
                 source = os_path.join(template_dir, item)
                 dest = os_path.join(new_vehicle_dir, item)
-                if os_path.isdir(source):
+                if blank_change_reason and item.endswith(".param"):
+                    # Blank the change reason in the template files, strip the comments that start with #
+                    with open(source, encoding="utf-8") as file:
+                        lines = file.readlines()
+                    with open(dest, "w", encoding="utf-8") as file:
+                        for line in lines:
+                            file.write(line.split("#")[0].strip() + "\n")
+                elif os_path.isdir(source):
                     shutil_copytree(source, dest)
                 else:
                     shutil_copy2(source, dest)

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
@@ -650,7 +650,7 @@ class ComponentEditorWindow(ComponentEditorWindowBase):
         except ValueError as _e:
             if is_focusout_event:
                 _paths_str = ">".join(list(path))
-                error_msg = _("Invalid value '{value}' for {_paths_str}\n{e}")
+                error_msg = _("Invalid value '{value}' for {_paths_str}\n{_e}")
                 show_error_message(_("Error"), error_msg.format(**locals()))
             return False
         entry.configure(style="entry_input_valid.TEntry")

--- a/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
@@ -235,10 +235,11 @@ class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-i
             + __version__
             + _(" - Select vehicle configuration directory")
         )
-        self.root.geometry("800x625")  # Set the window size
-        self.blank_template_data = tk.BooleanVar(value=False)
+        self.root.geometry("800x655")  # Set the window size
+        self.blank_component_data = tk.BooleanVar(value=False)
         self.infer_comp_specs_and_conn_from_fc_params = tk.BooleanVar(value=False)
         self.use_fc_params = tk.BooleanVar(value=False)
+        self.blank_change_reason = tk.BooleanVar(value=False)
         self.configuration_template: str = ""  # will be set to a string if a template was used
 
         # Explain why we are here
@@ -290,14 +291,15 @@ class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-i
             is_template_selection=True,
         )
         self.template_dir.container_frame.pack(expand=False, fill=tk.X, padx=3, pady=5, anchor=tk.NW)
-        blank_template_data_checkbox = ttk.Checkbutton(
+        blank_component_data_checkbox = ttk.Checkbutton(
             option1_label_frame,
-            variable=self.blank_template_data,
-            text=_("Blank template data"),
+            variable=self.blank_component_data,
+            text=_("Blank component data"),
         )
-        blank_template_data_checkbox.pack(anchor=tk.NW)
+        blank_component_data_checkbox.pack(anchor=tk.NW)
         show_tooltip(
-            blank_template_data_checkbox, _("Create a new blank vehicle configuration, with no data from the template.")
+            blank_component_data_checkbox,
+            _("Create a new blank vehicle configuration, with no component data from the template."),
         )
         infer_comp_specs_and_conn_from_fc_params_checkbox = ttk.Checkbutton(
             option1_label_frame,
@@ -330,6 +332,16 @@ class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-i
                 "Only makes sense if your FC has already been correctly configured.\n\n"
             )
             + _("This option is only available when a flight controller is connected."),
+        )
+        blank_change_reason_checkbox = ttk.Checkbutton(
+            option1_label_frame,
+            variable=self.blank_change_reason,
+            text=_("Blank parameter change reason"),
+        )
+        blank_change_reason_checkbox.pack(anchor=tk.NW)
+        show_tooltip(
+            blank_change_reason_checkbox,
+            _("Do not use the parameters change reason from the template."),
         )
         if not fc_connected:
             self.infer_comp_specs_and_conn_from_fc_params.set(False)
@@ -454,7 +466,9 @@ class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-i
             messagebox.showerror(_("New vehicle directory"), error_msg)
             return
 
-        error_msg = self.local_filesystem.copy_template_files_to_new_vehicle_dir(template_dir, new_vehicle_dir)
+        error_msg = self.local_filesystem.copy_template_files_to_new_vehicle_dir(
+            template_dir, new_vehicle_dir, self.blank_change_reason.get()
+        )
         if error_msg:
             messagebox.showerror(_("Copying template files"), error_msg)
             return

--- a/tests/test_annotate_params.sh
+++ b/tests/test_annotate_params.sh
@@ -19,6 +19,6 @@ for pkg in "${REQUIRED_PKGS[@]}"; do
     fi
 done
 
-PYTHONPATH=../ardupilot_methodic_configurator python -m coverage run -m unittest test_annotate_params.py
+PYTHONPATH=../ardupilot_methodic_configurator python -m coverage run -m pytest test_annotate_params.py
 python -m coverage html
 firefox htmlcov/annotate_params_py.html

--- a/tests/test_param_pid_adjustment_update.sh
+++ b/tests/test_param_pid_adjustment_update.sh
@@ -19,6 +19,6 @@ for pkg in "${REQUIRED_PKGS[@]}"; do
     fi
 done
 
-PYTHONPATH=../ardupilot_methodic_configurator python -m coverage run -m unittest test_param_pid_adjustment_update.py
+PYTHONPATH=../ardupilot_methodic_configurator python -m coverage run -m pytest test_param_pid_adjustment_update.py
 python -m coverage html
 firefox htmlcov/param_pid_adjustment_update_py.html


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and usability of the `ardupilot_methodic_configurator` project. The most important changes include updates to the test configurations, enhancements to the template copying process, and adjustments to the internationalization settings.

### Test Configurations:
* [`.vscode/tasks.json`](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR176-R233): Added new tasks for running `pytest` with coverage reports in both HTML format for Linux and Windows environments.
* `tests/test_annotate_params.sh` and `tests/test_param_pid_adjustment_update.sh`: Changed the test runner from `unittest` to `pytest` for better compatibility and reporting. [[1]](diffhunk://#diff-58255db78cd23b42df2c5c8acabcaaf7bbca3238ec1ff822d7626713ac44bf62L22-R22) [[2]](diffhunk://#diff-f05e9a15dc2bf253c724601021ed48e0e22cf6663dbeb6f5ae6d0183bcb2f36eL22-R22)

### Template Copying Process:
* [`ardupilot_methodic_configurator/backend_filesystem.py`](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L461-R463): Enhanced the `copy_template_files_to_new_vehicle_dir` method to include an option to blank out the change reason in parameter files. [[1]](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L461-R463) [[2]](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L485-R494)
* [`tests/test_backend_filesystem.py`](diffhunk://#diff-d70408d19ee3e8b72fdd16038116aa2fd69309c4212950291e596b400723dba4R692-R735): Added tests to verify the new functionality of blanking out change reasons in parameter files.

### Internationalization Settings:
* `.vscode/tasks.json` and `ARCHITECTURE.md`: Updated language options to include Italian and Japanese, and reflected these changes in the documentation and configuration files. [[1]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL207-R257) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL336-R353)

### Bug Fixes:
* [`ardupilot_methodic_configurator/__main__.py`](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fL102-R102): Corrected a typo from `blank_template_data` to `blank_component_data` to ensure proper functionality.
* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor.py`](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41L653-R653): Fixed an error message formatting issue.

### Miscellaneous:
* [`SetupDeveloperPC.bat`](diffhunk://#diff-da4aac37e2fce3d8c673754249943d1e871ef006149d324544eddc00ee020ca3L185-R207): Improved the script to handle paths with spaces correctly and updated error handling.