### PR TITLE
fix(templates): Fix issue #249

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -99,8 +99,6 @@ def component_editor(
     vehicle_dir_window: Union[None, VehicleDirectorySelectionWindow],
 ) -> None:
     component_editor_window = ComponentEditorWindow(__version__, local_filesystem)
-    if vehicle_dir_window and vehicle_dir_window.blank_component_data.get():
-        local_filesystem.wipe_component_info()
     if (
         vehicle_dir_window
         and vehicle_dir_window.configuration_template

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -99,12 +99,17 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         if vehicle_dir is not None:
             self.re_init(vehicle_dir, vehicle_type)
 
-    def re_init(self, vehicle_dir: str, vehicle_type: str) -> None:
+    def re_init(self, vehicle_dir: str, vehicle_type: str, blank_component_data: bool = False) -> None:
         self.vehicle_dir = vehicle_dir
         self.doc_dict = {}
 
         if not self.load_vehicle_components_json_data(vehicle_dir):
             return
+
+        if blank_component_data:
+            self.wipe_component_info()
+            if self.vehicle_components and "Components" in self.vehicle_components:
+                self.save_vehicle_components_json_data(self.vehicle_components, self.vehicle_dir)
 
         if not self.fw_version:
             self.fw_version = self.get_fc_fw_version_from_vehicle_components_json()

--- a/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
@@ -477,7 +477,7 @@ class VehicleDirectorySelectionWindow(BaseWindow):  # pylint: disable=too-many-i
         self.local_filesystem.vehicle_dir = new_vehicle_dir
 
         try:
-            self.local_filesystem.re_init(new_vehicle_dir, self.local_filesystem.vehicle_type)
+            self.local_filesystem.re_init(new_vehicle_dir, self.local_filesystem.vehicle_type, self.blank_component_data.get())
         except SystemExit as exp:
             messagebox.showerror(_("Fatal error reading parameter files"), f"{exp}")
             raise

--- a/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -1168,11 +1168,11 @@ msgstr "Fahrzeugkomponentendaten erfolgreich gespeichert."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Do you want to save the changes before closing?"
-msgstr ""
+msgstr "Möchten Sie die Änderungen vor dem Schließen speichern?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Save Changes?"
-msgstr ""
+msgstr "Änderungen speichern?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:277
 msgid ""

--- a/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -1160,11 +1160,11 @@ msgstr "Dati dei componenti del veicolo salvati con successo."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Do you want to save the changes before closing?"
-msgstr ""
+msgstr "Vuoi salvare le modifiche prima di chiudere?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Save Changes?"
-msgstr ""
+msgstr "Salvare le modifiche?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:277
 msgid ""

--- a/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -1136,11 +1136,11 @@ msgstr "機体コンポーネントデータが正常に保存されました。
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Do you want to save the changes before closing?"
-msgstr ""
+msgstr "閉じる前に変更を保存しますか？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Save Changes?"
-msgstr ""
+msgstr "変更を保存しますか？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:277
 msgid ""

--- a/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -1147,11 +1147,11 @@ msgstr "Dados do componente do veículo salvos com sucesso."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Do you want to save the changes before closing?"
-msgstr ""
+msgstr "Deseja guardar as alterações antes de fechar?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Save Changes?"
-msgstr ""
+msgstr "Guardar alterações?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:277
 msgid ""

--- a/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -1124,11 +1124,11 @@ msgstr "载具组件数据保存成功。"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Do you want to save the changes before closing?"
-msgstr ""
+msgstr "是否在关闭前保存更改？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:253
 msgid "Save Changes?"
-msgstr ""
+msgstr "保存更改？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:277
 msgid ""


### PR DESCRIPTION
Fixes #249

This pull request includes changes to the `ardupilot_methodic_configurator` project to enhance the handling of component data during vehicle initialization and creation. The most important changes include modifying the `re_init` method to support a new parameter for wiping component data and updating related method calls to incorporate this new parameter.

Enhancements to vehicle initialization:

* [`ardupilot_methodic_configurator/backend_filesystem.py`](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L102-R112): Modified the `re_init` method to include a new `blank_component_data` parameter, which, when set to `True`, wipes the component information and saves the vehicle components JSON data.

Updates to method calls:

* [`ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py`](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L480-R480): Updated the `create_new_vehicle_from_template` method to pass the `blank_component_data` parameter to the `re_init` method.
* [`ardupilot_methodic_configurator/__main__.py`](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fL102-L103): Removed the redundant check and call to `wipe_component_info` since it is now handled by the `re_init` method.