### PR TITLE
On component editor window close action ask user if he wants to save

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
@@ -709,9 +709,9 @@ class ComponentEditorWindow(ComponentEditorWindowBase):
         entry.configure(style="entry_input_valid.TEntry")
         return True
 
-    def save_data(self) -> None:
+    def validate_and_save_component_json(self) -> None:
         if self.validate_data():
-            ComponentEditorWindowBase.save_data(self)
+            ComponentEditorWindowBase.validate_and_save_component_json(self)
 
     def validate_data(self) -> bool:  # pylint: disable=too-many-branches
         invalid_values = False

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
@@ -711,7 +711,7 @@ class ComponentEditorWindow(ComponentEditorWindowBase):
 
     def validate_and_save_component_json(self) -> None:
         if self.validate_data():
-            ComponentEditorWindowBase.validate_and_save_component_json(self)
+            super().validate_and_save_component_json()
 
     def validate_data(self) -> bool:  # pylint: disable=too-many-branches
         invalid_values = False

--- a/tests/test_frontend_tkinter_component_editor_base.py
+++ b/tests/test_frontend_tkinter_component_editor_base.py
@@ -25,7 +25,7 @@ def editor_with_mocked_root() -> ComponentEditorWindowBase:
     """Create a mock ComponentEditorWindowBase for testing."""
     # Create the class without initialization
     with patch.object(ComponentEditorWindowBase, "__init__", return_value=None):
-        editor = ComponentEditorWindowBase()
+        editor = ComponentEditorWindowBase()  # pylint: disable=no-value-for-parameter
 
         # Set up all required attributes manually
         editor.root = MagicMock()
@@ -45,7 +45,7 @@ def editor_with_mocked_root() -> ComponentEditorWindowBase:
 
 
 @patch("tkinter.messagebox.askyesnocancel")
-def test_on_closing_save(mock_dialog, editor_with_mocked_root) -> None:
+def test_on_closing_save(mock_dialog, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the on_closing method when user chooses to save."""
     mock_dialog.return_value = True  # User selects "Yes"
 
@@ -63,7 +63,7 @@ def test_on_closing_save(mock_dialog, editor_with_mocked_root) -> None:
 
 
 @patch("tkinter.messagebox.askyesnocancel")
-def test_on_closing_no_save(mock_dialog, editor_with_mocked_root) -> None:
+def test_on_closing_no_save(mock_dialog, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the on_closing method when user chooses not to save."""
     mock_dialog.return_value = False  # User selects "No"
 
@@ -82,7 +82,7 @@ def test_on_closing_no_save(mock_dialog, editor_with_mocked_root) -> None:
 
 
 @patch("tkinter.messagebox.askyesnocancel")
-def test_on_closing_cancel(mock_dialog, editor_with_mocked_root) -> None:
+def test_on_closing_cancel(mock_dialog, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the on_closing method when user cancels."""
     mock_dialog.return_value = None  # User selects "Cancel"
 
@@ -98,7 +98,7 @@ def test_on_closing_cancel(mock_dialog, editor_with_mocked_root) -> None:
         mock_exit.assert_not_called()
 
 
-def test_update_json_data(editor_with_mocked_root) -> None:
+def test_update_json_data(editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the update_json_data method."""
     # Test when Format version is not in data
     editor_with_mocked_root.data = {}
@@ -111,7 +111,7 @@ def test_update_json_data(editor_with_mocked_root) -> None:
     assert editor_with_mocked_root.data["Format version"] == 2
 
 
-def test_add_entry_or_combobox(editor_with_mocked_root) -> None:
+def test_add_entry_or_combobox(editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the add_entry_or_combobox method."""
     with patch("tkinter.ttk.Entry") as mock_entry:
         mock_entry_instance = MagicMock()
@@ -125,7 +125,7 @@ def test_add_entry_or_combobox(editor_with_mocked_root) -> None:
         assert result == mock_entry_instance
 
 
-def test_set_component_value_and_update_ui(editor_with_mocked_root) -> None:
+def test_set_component_value_and_update_ui(editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the _set_component_value_and_update_ui method."""
     # Setup test data
     editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "old_value"}}}
@@ -133,7 +133,7 @@ def test_set_component_value_and_update_ui(editor_with_mocked_root) -> None:
     editor_with_mocked_root.entry_widgets = {("Motor", "Type"): mock_entry}
 
     # Call the method
-    editor_with_mocked_root._set_component_value_and_update_ui(("Motor", "Type"), "new_value")
+    editor_with_mocked_root._set_component_value_and_update_ui(("Motor", "Type"), "new_value")  # pylint: disable=protected-access
 
     # Assert data was updated
     assert editor_with_mocked_root.data["Components"]["Motor"]["Type"] == "new_value"
@@ -145,7 +145,7 @@ def test_set_component_value_and_update_ui(editor_with_mocked_root) -> None:
 
 
 @patch("tkinter.messagebox.askyesno")
-def test_validate_and_save_component_json_yes(mock_dialog, editor_with_mocked_root) -> None:
+def test_validate_and_save_component_json_yes(mock_dialog, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test when user confirms saving component data."""
     mock_dialog.return_value = True
 
@@ -159,7 +159,7 @@ def test_validate_and_save_component_json_yes(mock_dialog, editor_with_mocked_ro
 
 
 @patch("tkinter.messagebox.askyesno")
-def test_validate_and_save_component_json_no(mock_dialog, editor_with_mocked_root) -> None:
+def test_validate_and_save_component_json_no(mock_dialog, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test when user cancels saving component data."""
     mock_dialog.return_value = False
 
@@ -172,7 +172,7 @@ def test_validate_and_save_component_json_no(mock_dialog, editor_with_mocked_roo
     editor_with_mocked_root.save_component_json.assert_not_called()
 
 
-def test_save_component_json(editor_with_mocked_root) -> None:
+def test_save_component_json(editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the save_component_json method with successful save."""
     # Setup test data
     editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "brushless"}}}
@@ -195,7 +195,7 @@ def test_save_component_json(editor_with_mocked_root) -> None:
 
 
 @patch("ardupilot_methodic_configurator.frontend_tkinter_component_editor_base.show_error_message")
-def test_save_component_json_failure(mock_error_message, editor_with_mocked_root) -> None:
+def test_save_component_json_failure(mock_error_message, editor_with_mocked_root) -> None:  # pylint: disable=redefined-outer-name
     """Test the save_component_json method with failed save."""
     # Setup test data
     editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "brushless"}}}

--- a/tests/test_frontend_tkinter_component_editor_base.py
+++ b/tests/test_frontend_tkinter_component_editor_base.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+"""
+Component editor GUI tests.
+
+This file is part of Ardupilot methodic configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import contextlib
+import tkinter as tk
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.frontend_tkinter_component_editor_base import ComponentEditorWindowBase
+
+
+@pytest.fixture
+def editor_with_mocked_root() -> ComponentEditorWindowBase:
+    """Create a mock ComponentEditorWindowBase for testing."""
+    # Create the class without initialization
+    with patch.object(ComponentEditorWindowBase, "__init__", return_value=None):
+        editor = ComponentEditorWindowBase()
+
+        # Set up all required attributes manually
+        editor.root = MagicMock()
+        editor.main_frame = MagicMock()
+        editor.scroll_frame = MagicMock()
+        editor.scroll_frame.view_port = MagicMock()
+
+        # Mock filesystem and methods
+        editor.local_filesystem = MagicMock(spec=LocalFilesystem)
+        editor.local_filesystem.vehicle_dir = "dummy_vehicle_dir"
+
+        # Setup test data
+        editor.entry_widgets = {}
+        editor.data = {"Components": {"Motor": {"Type": "brushless", "KV": 1000}}}
+
+        yield editor
+
+
+@patch("tkinter.messagebox.askyesnocancel")
+def test_on_closing_save(mock_dialog, editor_with_mocked_root) -> None:
+    """Test the on_closing method when user chooses to save."""
+    mock_dialog.return_value = True  # User selects "Yes"
+
+    # Create a replacement for save_component_json
+    editor_with_mocked_root.save_component_json = MagicMock()
+
+    # Patch sys_exit in the module where it's imported
+    with patch("ardupilot_methodic_configurator.frontend_tkinter_component_editor_base.sys_exit") as mock_exit:
+        with contextlib.suppress(SystemExit):
+            editor_with_mocked_root.on_closing()
+
+        # Verify save was called
+        editor_with_mocked_root.save_component_json.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+
+@patch("tkinter.messagebox.askyesnocancel")
+def test_on_closing_no_save(mock_dialog, editor_with_mocked_root) -> None:
+    """Test the on_closing method when user chooses not to save."""
+    mock_dialog.return_value = False  # User selects "No"
+
+    # Create a replacement for save_component_json to avoid actual save logic
+    editor_with_mocked_root.save_component_json = MagicMock()
+
+    # Patch sys_exit in the module where it's imported
+    with patch("ardupilot_methodic_configurator.frontend_tkinter_component_editor_base.sys_exit") as mock_exit:
+        with contextlib.suppress(SystemExit):
+            editor_with_mocked_root.on_closing()
+
+        # Verify save was NOT called but window was destroyed
+        editor_with_mocked_root.save_component_json.assert_not_called()
+        editor_with_mocked_root.root.destroy.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+
+@patch("tkinter.messagebox.askyesnocancel")
+def test_on_closing_cancel(mock_dialog, editor_with_mocked_root) -> None:
+    """Test the on_closing method when user cancels."""
+    mock_dialog.return_value = None  # User selects "Cancel"
+
+    # Make sure save_component_json is a MagicMock for this test
+    editor_with_mocked_root.save_component_json = MagicMock()
+
+    with patch("ardupilot_methodic_configurator.frontend_tkinter_component_editor_base.sys_exit") as mock_exit:
+        editor_with_mocked_root.on_closing()
+
+        # Verify neither save nor destroy were called
+        editor_with_mocked_root.save_component_json.assert_not_called()
+        editor_with_mocked_root.root.destroy.assert_not_called()
+        mock_exit.assert_not_called()
+
+
+def test_update_json_data(editor_with_mocked_root) -> None:
+    """Test the update_json_data method."""
+    # Test when Format version is not in data
+    editor_with_mocked_root.data = {}
+    editor_with_mocked_root.update_json_data()
+    assert editor_with_mocked_root.data["Format version"] == 1
+
+    # Test when Format version is already in data
+    editor_with_mocked_root.data = {"Format version": 2}
+    editor_with_mocked_root.update_json_data()
+    assert editor_with_mocked_root.data["Format version"] == 2
+
+
+def test_add_entry_or_combobox(editor_with_mocked_root) -> None:
+    """Test the add_entry_or_combobox method."""
+    with patch("tkinter.ttk.Entry") as mock_entry:
+        mock_entry_instance = MagicMock()
+        mock_entry.return_value = mock_entry_instance
+
+        entry_frame = MagicMock()
+        result = editor_with_mocked_root.add_entry_or_combobox(42, entry_frame, ("Motor", "Type", "brushless"))
+
+        mock_entry.assert_called_once_with(entry_frame)
+        mock_entry_instance.insert.assert_called_once_with(0, "42")
+        assert result == mock_entry_instance
+
+
+def test_set_component_value_and_update_ui(editor_with_mocked_root) -> None:
+    """Test the _set_component_value_and_update_ui method."""
+    # Setup test data
+    editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "old_value"}}}
+    mock_entry = MagicMock()
+    editor_with_mocked_root.entry_widgets = {("Motor", "Type"): mock_entry}
+
+    # Call the method
+    editor_with_mocked_root._set_component_value_and_update_ui(("Motor", "Type"), "new_value")
+
+    # Assert data was updated
+    assert editor_with_mocked_root.data["Components"]["Motor"]["Type"] == "new_value"
+
+    # Assert UI was updated
+    mock_entry.delete.assert_called_once_with(0, tk.END)
+    mock_entry.insert.assert_called_once_with(0, "new_value")
+    mock_entry.config.assert_called_once_with(state="disabled")
+
+
+@patch("tkinter.messagebox.askyesno")
+def test_validate_and_save_component_json_yes(mock_dialog, editor_with_mocked_root) -> None:
+    """Test when user confirms saving component data."""
+    mock_dialog.return_value = True
+
+    # Create a replacement for save_component_json to avoid actual save logic
+    editor_with_mocked_root.save_component_json = MagicMock()
+
+    editor_with_mocked_root.validate_and_save_component_json()
+
+    mock_dialog.assert_called_once()
+    editor_with_mocked_root.save_component_json.assert_called_once()
+
+
+@patch("tkinter.messagebox.askyesno")
+def test_validate_and_save_component_json_no(mock_dialog, editor_with_mocked_root) -> None:
+    """Test when user cancels saving component data."""
+    mock_dialog.return_value = False
+
+    # Create a replacement for save_component_json to avoid actual save logic
+    editor_with_mocked_root.save_component_json = MagicMock()
+
+    editor_with_mocked_root.validate_and_save_component_json()
+
+    mock_dialog.assert_called_once()
+    editor_with_mocked_root.save_component_json.assert_not_called()
+
+
+def test_save_component_json(editor_with_mocked_root) -> None:
+    """Test the save_component_json method with successful save."""
+    # Setup test data
+    editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "brushless"}}}
+    mock_entry = MagicMock()
+    mock_entry.get.return_value = "new_value"
+    editor_with_mocked_root.entry_widgets = {("Motor", "Type"): mock_entry}
+    editor_with_mocked_root.local_filesystem.save_vehicle_components_json_data.return_value = (False, "")
+
+    # For this test we need to use the real save_component_json, not a mock
+    original_method = ComponentEditorWindowBase.save_component_json
+    editor_with_mocked_root.save_component_json = lambda: original_method(editor_with_mocked_root)
+
+    # Call the method
+    editor_with_mocked_root.save_component_json()
+
+    # Assert data was updated and saved
+    assert editor_with_mocked_root.data["Components"]["Motor"]["Type"] == "new_value"
+    editor_with_mocked_root.local_filesystem.save_vehicle_components_json_data.assert_called_once()
+    editor_with_mocked_root.root.destroy.assert_called_once()
+
+
+@patch("ardupilot_methodic_configurator.frontend_tkinter_component_editor_base.show_error_message")
+def test_save_component_json_failure(mock_error_message, editor_with_mocked_root) -> None:
+    """Test the save_component_json method with failed save."""
+    # Setup test data
+    editor_with_mocked_root.data = {"Components": {"Motor": {"Type": "brushless"}}}
+    mock_entry = MagicMock()
+    mock_entry.get.return_value = "new_value"
+    editor_with_mocked_root.entry_widgets = {("Motor", "Type"): mock_entry}
+    editor_with_mocked_root.local_filesystem.save_vehicle_components_json_data.return_value = (True, "Error message")
+
+    # For this test we need to use the real save_component_json, not a mock
+    original_method = ComponentEditorWindowBase.save_component_json
+    editor_with_mocked_root.save_component_json = lambda: original_method(editor_with_mocked_root)
+
+    # Call the method
+    editor_with_mocked_root.save_component_json()
+
+    # Assert error message was shown
+    mock_error_message.assert_called_once()
+    editor_with_mocked_root.root.destroy.assert_called_once()
+
+
+def test_add_argparse_arguments() -> None:
+    """Test adding command line arguments."""
+    parser = MagicMock()
+
+    result = ComponentEditorWindowBase.add_argparse_arguments(parser)
+
+    parser.add_argument.assert_called_once()
+    assert result == parser


### PR DESCRIPTION
This pull request includes significant changes to the `ardupilot_methodic_configurator` project, focusing on enhancing the component editor and adding comprehensive tests. The most important changes include renaming methods for clarity, handling window closing events, and adding new tests.

fixes #250
fixes #248 

Enhancements to component editor:

* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py`](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabL116-R121): Renamed `save_data` to `validate_and_save_component_json` and added a new method `save_component_json` to separate validation and saving logic. [[1]](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabL116-R121) [[2]](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabL201-R206) [[3]](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabR220-R222)
* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py`](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabR251-R263): Added `on_closing` method to handle window closing events, prompting the user to save changes before exiting.
* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py`](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabR20): Imported `sys_exit` to handle application exit after closing the window.

Changes in `frontend_tkinter_component_editor`:

* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor.py`](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41L712-R714): Updated method calls to use the new `validate_and_save_component_json` method.

Addition of tests:

* [`tests/test_frontend_tkinter_component_editor_base.py`](diffhunk://#diff-9266c56e86ddb9645dabb33740afddfdd16727aa4dbe47781bce9f8812f96e47R1-R226): Added comprehensive tests for the component editor, including tests for the new `on_closing` method and validation/saving logic.