### PR TITLE
Restrict CI permissions. Create PR instead of pushing to master

### DIFF
--- a/.github/workflows/bump_version_and_tag.yml
+++ b/.github/workflows/bump_version_and_tag.yml
@@ -13,12 +13,14 @@ on:
         type: string
 
 permissions:
-  contents: write # to trigger the windows_build and python-publish workflows
+  contents: read
 
 jobs:
   bump-version:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to trigger the windows_build and python-publish workflows
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -14,11 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   extract_strings:
     permissions:
-      contents: read
-      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+      contents: write       # for creating branches and commits
+      pull-requests: write  # for creating PRs
     runs-on: ubuntu-latest
     env:
       PYGETTEXT_DOMAIN: ardupilot_methodic_configurator
@@ -78,3 +81,4 @@ jobs:
           body: |
             Update .pot file with new un-translated string(s) from the source code
             Merge .pot file strings into existing .po files
+          delete-branch: true

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   mypy:
     name: mypy

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   pylint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -11,6 +11,9 @@ on:
       - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,6 +15,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && !github.event.pull_request) || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -5,9 +5,15 @@ on:
     - cron: "0 0 * * *"  # Runs daily at midnight
   workflow_dispatch:      # Allows manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # For creating branches and commits
+      pull-requests: write  # For creating pull requests
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -24,8 +30,10 @@ jobs:
         uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          labels: deps, automated-pr
           branch: renovate/pre-commit-hooks
           title: "chore(deps): update pre-commit hooks"
           commit-message: "chore(deps): update pre-commit hooks"
           body: |
             Updates pre-commit hook versions in .pre-commit-config.yaml
+          delete-branch: true

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   reuse:
 

--- a/.github/workflows/update_flightcontroller_ids.yml
+++ b/.github/workflows/update_flightcontroller_ids.yml
@@ -3,7 +3,7 @@ name: Update Flight Controller IDs
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 1 * * 3'  # Every Wednesday at 1:30 AM
+    - cron: '30 3 * * 1,4'  # Every Monday and Thursday at 3:30 AM
 
 permissions:
   contents: read
@@ -12,6 +12,7 @@ jobs:
   update-ids:
     permissions:
       contents: write  # for Git to git push
+      pull-requests: write  # for creating PRs
     runs-on: ubuntu-latest
 
     steps:
@@ -37,21 +38,28 @@ jobs:
       - name: Update flight controller IDs
         run: python update_flight_controller_ids.py
 
-      - name: Commit changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stage changes
+        id: stage_changes
         run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
           git add ardupilot_methodic_configurator/middleware_fc_ids.py
-          if [ -n "$(git status --porcelain)" ]; then
-            CHANGED_LINES=$(git diff --staged | grep -E "^[\+\-]" | wc -l)
-            if [ $CHANGED_LINES -gt 3 ]; then
-              git commit -m "chore(flightcontroller): Updated ArduPilot flight controller IDs [skip ci]"
-              git push
-            else
-              echo "Not enough changes to commit (only $CHANGED_LINES lines changed)"
-            fi
+          CHANGED_LINES=$(git diff --staged | grep -E "^[\+\-]" | wc -l)
+          echo "CHANGED_LINES=$CHANGED_LINES" >> $GITHUB_OUTPUT
+          if [ $CHANGED_LINES -gt 3 ]; then
+            echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
           else
-            echo "No changes to commit"
+            echo "Not enough changes to commit (only $CHANGED_LINES lines changed)"
+            echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Create Pull Request
+        if: steps.stage_changes.outputs.HAS_CHANGES == 'true'
+        uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: flightcontroller-IDs, automated-pr
+          branch: update/flight-controller-ids
+          title: "Update ArduPilot flight controller IDs"
+          commit-message: "chore(flightcontroller): Updated ArduPilot flight controller IDs"
+          body: |
+            This PR updates the ArduPilot flight controller IDs from the upstream ArduPilot repository.
+          delete-branch: true

--- a/.github/workflows/update_magfit_pdef_xml.yml
+++ b/.github/workflows/update_magfit_pdef_xml.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     paths:
-    - 24_inflight_magnetometer_fit_setup.pdef.xml'
-    - ardupilot_methodic_configurator/vehicle_templates/**
+    - '24_inflight_magnetometer_fit_setup.pdef.xml'
+    - 'ardupilot_methodic_configurator/vehicle_templates/**'
 
 permissions:
   contents: read
@@ -13,7 +13,8 @@ permissions:
 jobs:
   update-magfit-pdef-xml:
     permissions:
-      contents: write  # for Git to git push
+      contents: write  # for creating branches and commits
+      pull-requests: write  # for creating PRs
     runs-on: ubuntu-latest
 
     steps:
@@ -28,21 +29,33 @@ jobs:
       - name: Update 24_inflight_magnetometer_fit_setup.pdef.xml file in all vehicle templates
         run: python copy_magfit_pdef_to_template_dirs.py
 
-      - name: Commit changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stage changes and check if PR needed
+        id: check_changes
         run: |
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
           git add ardupilot_methodic_configurator/vehicle_templates/**/24_inflight_magnetometer_fit_setup.pdef.xml
           if [ -n "$(git status --porcelain)" ]; then
             CHANGED_LINES=$(git diff --staged | grep -E "^[\+\-]" | wc -l)
+            echo "CHANGED_LINES=$CHANGED_LINES" >> $GITHUB_OUTPUT
             if [ $CHANGED_LINES -gt 3 ]; then
-              git commit -m "chore(parameter_metadata): Updated 24_inflight_magnetometer_fit_setup.pdef.xml files in the vehicle templates"
-              git push
+              echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
             else
-              echo "Not enough changes to commit (only $CHANGED_LINES lines changed)"
+              echo "Not enough changes to create PR (only $CHANGED_LINES lines changed)"
+              echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
             fi
           else
-            echo "No changes to commit"
+            echo "No changes detected"
+            echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.HAS_CHANGES == 'true'
+        uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: templates, automated-pr
+          branch: update/magfit-pdef-xml
+          title: "Update magfit pdef XML files"
+          commit-message: "chore(parameter_metadata): Updated 24_inflight_magnetometer_fit_setup.pdef.xml files in the vehicle templates"
+          body: |
+            This PR updates the 24_inflight_magnetometer_fit_setup.pdef.xml files in all vehicle templates.
+          delete-branch: true

--- a/.github/workflows/update_mo_files.yml
+++ b/.github/workflows/update_mo_files.yml
@@ -11,11 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   compile-mo-files:
     permissions:
-      contents: read
-      pull-requests: write  # for create-pull-request action
+      contents: write       # for creating branches and commits
+      pull-requests: write  # for creating PRs
     runs-on: ubuntu-latest
     env:
       MO_FILES_CHANGED: false
@@ -57,4 +60,4 @@ jobs:
           commit-message: "chore(translations): Compile translation .mo files from the .po files"
           body: |
             This PR Compiles .mo files based on the latest changes to .po translation files.
-
+          delete-branch: true


### PR DESCRIPTION
This pull request includes various changes to multiple GitHub Actions workflow files, primarily focusing on updating permissions and improving automation for creating pull requests. The most important changes are summarized below:

### Permissions Updates:
* [`.github/workflows/bump_version_and_tag.yml`](diffhunk://#diff-fbcb32501342e19f048cf36761f62c5f8c3a2bd0c9ebb2ae579c8d606eee6f7cL16-R23): Changed `contents` permission from `write` to `read` and added `contents: write` permission within the job.
* [`.github/workflows/i18n-extract.yml`](diffhunk://#diff-2d579475fad26e1d128dc2d45de56003325cc16a838bd385822f9179d1254b6eR17-R24): Added `contents: read` permission and updated job permissions to `contents: write` and `pull-requests: write`.
* `.github/workflows/markdown-lint.yml`, `.github/workflows/mypy.yml`, `.github/workflows/pylint.yml`, `.github/workflows/pyright.yml`, `.github/workflows/pytest.yml`, `.github/workflows/reuse.yml`: Added `contents: read` permission. [[1]](diffhunk://#diff-b55c2fb5426c85bdbb50b8cb32fc054c06e0c178c4fecdfa5be50d6ca17600a1R11-R13) [[2]](diffhunk://#diff-07730f31c368f5e0af82cb7d820dc37ae6a752a0a226f7aee9ebac72dfe41459R12-R14) [[3]](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3R12-R14) [[4]](diffhunk://#diff-c4c9ca49d94adafafcc4766fd9f13580e2859e5481e4477ffdc43c37b3712ce3R14-R16) [[5]](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aR18-R20) [[6]](diffhunk://#diff-0842f7c432064fc07a5425db75a8776018f2c046e13c85d0bc13890a66e9a230R7-R9)
* [`.github/workflows/renovate_pre_commit_hooks.yml`](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R8-R16): Added `contents: read` permission and updated job permissions to include `contents: write` and `pull-requests: write`. [[1]](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R8-R16) [[2]](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R33-R39)
* `.github/workflows/update_flightcontroller_ids.yml`, `.github/workflows/update_magfit_pdef_xml.yml`, `.github/workflows/update_mo_files.yml`: Updated job permissions to include `pull-requests: write`. [[1]](diffhunk://#diff-e6eb94b6907e2e3c10f73c0daeb5b7ab82b04697f6c9c750d049c5295947912eR15) [[2]](diffhunk://#diff-cba19c4a40aaeb93cc8163bcfd75e08f31518053f2e9ab08e6d3bdc3560bb873L7-R17) [[3]](diffhunk://#diff-079456a054c5d473e34523ec3c59b6eee56654682a5e4a0bdefcacfdd7809c61R14-R21)

### Automation Improvements:
* [`.github/workflows/update_flightcontroller_ids.yml`](diffhunk://#diff-e6eb94b6907e2e3c10f73c0daeb5b7ab82b04697f6c9c750d049c5295947912eL40-R65): Replaced commit step with staging changes and creating a pull request if changes are detected.
* [`.github/workflows/update_magfit_pdef_xml.yml`](diffhunk://#diff-cba19c4a40aaeb93cc8163bcfd75e08f31518053f2e9ab08e6d3bdc3560bb873L31-R61): Replaced commit step with staging changes and creating a pull request if changes are detected.
* [`.github/workflows/update_mo_files.yml`](diffhunk://#diff-079456a054c5d473e34523ec3c59b6eee56654682a5e4a0bdefcacfdd7809c61L60-R63): Added step to delete the branch after creating a pull request.
* [`.github/workflows/i18n-extract.yml`](diffhunk://#diff-2d579475fad26e1d128dc2d45de56003325cc16a838bd385822f9179d1254b6eR84): Added step to delete the branch after creating a pull request.
* [`.github/workflows/renovate_pre_commit_hooks.yml`](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R33-R39): Added step to delete the branch after creating a pull request.