### PR TITLE
Migrate renovate configuration

### DIFF
--- a/.github/workflows/gitavscan.yml
+++ b/.github/workflows/gitavscan.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read  # Default limited permission
+
 jobs:
   gitavscan:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -6,14 +6,14 @@ on:
   workflow_dispatch:      # Allows manual trigger
 
 permissions:
-  contents: read
+  contents: read  # Default limited permission
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # For creating branches and commits
-      pull-requests: write  # For creating pull requests
+      contents: write      # Job-specific permission for creating branches
+      pull-requests: write # Job-specific permission for creating PRs
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "enabledManagers": ["pre-commit"],
   "packageRules": [
     {


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows and the Renovate configuration to improve permissions and update configuration settings.

Improvements to GitHub workflows:

* [`.github/workflows/gitavscan.yml`](diffhunk://#diff-3f851474414ec7ea0b7f8ded7ca51c357ef37ab338b7d7e93c3a619f5f139417R10-R12): Added default limited permission for contents to the `release` workflow.
* [`.github/workflows/renovate_pre_commit_hooks.yml`](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9L9-R16): Updated comments for permissions to clarify job-specific permissions for creating branches and pull requests.

Updates to Renovate configuration:

* [`renovate-config.json`](diffhunk://#diff-26dbe544619f8f0e948aabd7f14bb061b657807812430c7b5f0b1ae8972550bdL2-R2): Changed the extends configuration from `config:base` to `config:recommended`.