### PR TITLE
Multiple components can have connection "None"

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
@@ -733,7 +733,7 @@ class ComponentEditorWindow(ComponentEditorWindowBase):
                     invalid_values = True
                     continue
                 if "FC Connection" in path and "Type" in path:
-                    if value in fc_serial_connection and value not in {"CAN1", "CAN2", "I2C1", "I2C2", "I2C3", "I2C4"}:
+                    if value in fc_serial_connection and value not in {"CAN1", "CAN2", "I2C1", "I2C2", "I2C3", "I2C4", "None"}:
                         if path[0] in {"Telemetry", "RC Receiver"} and fc_serial_connection[value] in {
                             "Telemetry",
                             "RC Receiver",


### PR DESCRIPTION
So do not flag it as duplicated
fixes #265

This pull request includes a small but important change to the `validate_data` method in the `ardupilot_methodic_configurator/frontend_tkinter_component_editor.py` file. The change adds "None" to the set of valid connection types for flight controllers.

* [`ardupilot_methodic_configurator/frontend_tkinter_component_editor.py`](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41L736-R736): Added "None" to the set of valid connection types in the `validate_data` method.