### PR TITLE
Deactivate deprecated real-time ruff linter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,5 @@
       },
       "editor.defaultFormatter": "charliermarsh.ruff"
     },
-    "ruff.lint.run": "onSave",
     "files.eol": "\n"
 }


### PR DESCRIPTION
This pull request includes a small change to the `.vscode/settings.json` file. The change removes the line `"ruff.lint.run": "onSave",`, which previously configured the Ruff linter to run on file save. 

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L60): Removed the `"ruff.lint.run": "onSave",` setting.