### PR TITLE
Do not add apm.pdef.xml files to git

### DIFF
--- a/.github/workflows/update_vehicle_templates.yml
+++ b/.github/workflows/update_vehicle_templates.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Check for changes
         shell: pwsh
         run: |
-          git add ardupilot_methodic_configurator/vehicle_templates/**/*
+          git add ardupilot_methodic_configurator/vehicle_templates/**/*.param
+          git add ardupilot_methodic_configurator/vehicle_templates/**/*.json
           if ($(git status --porcelain)) {
             "TEMPLATES_CHANGED=true" | Out-File -FilePath $env:GITHUB_ENV -Append
           } else {


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/update_vehicle_templates.yml` file to refine the file types being tracked for changes in the vehicle templates directory.

Changes in `jobs:`:

* [`.github/workflows/update_vehicle_templates.yml`](diffhunk://#diff-7c38991ace082c212b93eaaf4c47c57b1253e060a15a5a5f69cae67a0c1b98b3L56-R57): Updated the `git add` command to specifically track `.param` and `.json` files within the `ardupilot_methodic_configurator/vehicle_templates` directory.