### PR TITLE
Warn about invalid apm.pdef.xml parameter metadata, but do not crash

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -208,7 +208,15 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 try:
                     param_info["Values"] = {int(k): v for k, v in param_info["values"].items()}
                 except ValueError:
-                    param_info["Values"] = {float(k): v for k, v in param_info["values"].items()}
+                    try:
+                        param_info["Values"] = {float(k): v for k, v in param_info["values"].items()}
+                    except ValueError:
+                        logging_warning(_("Could not convert values to int or float for %s"), param_name)
+                        logging_warning(
+                            _("Parameter %s has invalid metadata. Please file a bug at %s"),
+                            param_name,
+                            "https://github.com/ArduPilot/ardupilot/issues",
+                        )
                 # print(param_info['Values'])
 
             prefix_parts = [


### PR DESCRIPTION
This pull request includes an important change to the `ardupilot_methodic_configurator/backend_filesystem.py` file to improve error handling and logging when converting parameter values.

Error handling and logging improvements:

* [`ardupilot_methodic_configurator/backend_filesystem.py`](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716R211-R219): Added a nested try-except block to handle cases where parameter values cannot be converted to either integers or floats. If both conversions fail, a warning is logged, and users are prompted to file a bug report.