### PR TITLE
Avoid 404 pages if the flight controller README.md file does not exist

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -34,6 +34,7 @@ from ardupilot_methodic_configurator import _, __version__
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
 from ardupilot_methodic_configurator.backend_filesystem_program_settings import ProgramSettings
 from ardupilot_methodic_configurator.backend_flightcontroller import FlightController
+from ardupilot_methodic_configurator.backend_internet import verify_and_open_url
 from ardupilot_methodic_configurator.common_arguments import add_common_arguments
 from ardupilot_methodic_configurator.frontend_tkinter_component_editor import ComponentEditorWindow
 from ardupilot_methodic_configurator.frontend_tkinter_connection_selection import ConnectionSelectionWindow
@@ -128,11 +129,16 @@ def component_editor(
         and flight_controller.info.firmware_type != _("Unknown")
         and flight_controller.info.firmware_type != ""
     ):
-        url = (
-            "https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/"
-            f"{flight_controller.info.firmware_type}/README.md"
-        )
-        webbrowser_open(url=url, new=0, autoraise=True)
+        firmware_type = flight_controller.info.firmware_type
+        url = f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{firmware_type}/README.md"
+        url_found = verify_and_open_url(url)
+        if not url_found and firmware_type.endswith("-bdshot"):
+            firmware_type = firmware_type[:-7]
+            url = (
+                f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{firmware_type}/README.md"
+            )
+            url_found = verify_and_open_url(url)
+
     component_editor_window.root.mainloop()
 
     source_param_values: Union[dict[str, float], None] = (


### PR DESCRIPTION
This pull request introduces a new function `verify_and_open_url` to the `ardupilot_methodic_configurator` project, which verifies if a URL is accessible and opens it in the default web browser if successful. Additionally, several tests have been added to ensure the function works correctly under different conditions.

New functionality:

* [`ardupilot_methodic_configurator/backend_internet.py`](diffhunk://#diff-a8715254fad02f2903e2f2c68f8de5501bf52c2f6aab3fb2d3c091202cb59b40R200-R245): Added the `verify_and_open_url` function to verify URL accessibility and open it in the default web browser.

Integration into existing code:

* [`ardupilot_methodic_configurator/__main__.py`](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fR132-R141): Integrated the `verify_and_open_url` function into the `component_editor` function to handle URL verification and opening.

Testing:

* [`tests/test_backend_internet.py`](diffhunk://#diff-cac1301db16f0603a1319597fd8741a09c9298a3448ff5b23800c77ad89d0f83R298-R419): Added multiple tests for the `verify_and_open_url` function, including tests for successful URL verification, empty URL handling, HTTP errors, request exceptions, timeouts, browser exceptions, and proxy handling.