### PR TITLE
Add ESC temperature to the checklist.

### DIFF
--- a/TUNING_GUIDE_ArduCopter.md
+++ b/TUNING_GUIDE_ArduCopter.md
@@ -651,12 +651,13 @@ Land and disarm.
 ### 7.1.1 Check for Motor Output Oscillation
 
 After landing from your first hover flight, immediately check the motors for excessive heat.
-Hot motors indicate a [potential oscillation problem](https://ardupilot.org/copter/docs/initial-tuning-flight.html#initial-aircraft-tune)
+Hot motors indicate a [potential output oscillation problem](https://ardupilot.org/copter/docs/initial-tuning-flight.html#initial-aircraft-tune)
 that needs to be addressed.
 
-**Signs of oscillation issues:**
+**Signs of output oscillation issues:**
 
 - Excessively hot motors after flight
+- Excessively hot ESCs after flight
 - Audible vibrations/oscillations during flight
 - Visible shaking of the vehicle
 - Hard to control or sluggish behavior
@@ -664,7 +665,7 @@ that needs to be addressed.
 **If you observe any of these signs:**
 
 1. [Download the `.bin` dataflash log](https://ardupilot.org/copter/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.html) from your flight
-2. Review the `RATE.*out` values in the log
+2. Review the `RATE.*out` values in the log and the ESC temperatures if you have ESC tememetry
 3. If you see high (> 0.15) or oscillating `RATE.*out` values:
    - Identify which PID gains need reduction to eliminate oscillations
      - typically one of these: `ATC_RAT_PIT_D`, `ATC_RAT_PIT_I`, `ATC_RAT_PIT_P`, `ATC_RAT_RLL_D`, `ATC_RAT_RLL_I`, `ATC_RAT_RLL_P`
@@ -709,7 +710,7 @@ Here's an example of corrected output:
 
 ![Rate and vert accel gains Parameters](images/blog/no_rcout_oscillations.jpg)
 
-With oscillations eliminated, you can proceed with further tuning steps.
+With output oscillations eliminated, you can proceed with further tuning steps.
 
 # 8. Minimalistic mandatory tuning
 


### PR DESCRIPTION
This pull request includes updates to the `TUNING_GUIDE_ArduCopter.md` file to clarify terminology and add additional checks for potential issues. The most important changes include refining the description of oscillation problems and adding checks for ESC temperatures.

Clarifications and additional checks:

* [`TUNING_GUIDE_ArduCopter.md`](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL654-R668): Updated the terminology from "oscillation" to "output oscillation" to provide clearer guidance.
* [`TUNING_GUIDE_ArduCopter.md`](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL654-R668): Added "Excessively hot ESCs after flight" as a sign of output oscillation issues.
* [`TUNING_GUIDE_ArduCopter.md`](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL654-R668): Included a check for ESC temperatures if telemetry is available when reviewing `RATE.*out` values.
* [`TUNING_GUIDE_ArduCopter.md`](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL712-R713): Updated an example to refer to "output oscillations" for consistency.