### PR TITLE
Customer requirements to annotate all files at once

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -666,7 +666,9 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 if error_msg:
                     return error_msg
                 self.merge_forced_or_derived_parameters(param_filename, self.derived_parameters, existing_fc_params)
-            Par.export_to_param(Par.format_params(param_dict), os_path.join(self.vehicle_dir, param_filename))
+            self.export_to_param(
+                param_dict, param_filename, annotate_doc=bool(ProgramSettings.get_setting("annotate_docs_into_param_files"))
+            )
         return ""
 
     def merge_forced_or_derived_parameters(

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -85,7 +85,7 @@ class ComponentEditorWindowBase(BaseWindow):
         intro_frame.pack(side=tk.TOP, fill="x", expand=False)
 
         style = ttk.Style()
-        style.configure("bigger.TLabel", font=("TkDefaultFont", 14))
+        style.configure("bigger.TLabel", font=("TkDefaultFont", 13))
         style.configure("comb_input_invalid.TCombobox", fieldbackground="red")
         style.configure("comb_input_valid.TCombobox", fieldbackground="white")
         style.configure("entry_input_invalid.TEntry", fieldbackground="red")
@@ -93,9 +93,9 @@ class ComponentEditorWindowBase(BaseWindow):
         style.configure("Optional.TLabelframe", borderwidth=2)
         style.configure("Optional.TLabelframe.Label", foreground="gray")
 
-        explanation_text = _("Please configure all vehicle component properties in this window.\n")
-        explanation_text += _("Scroll down and make sure you do not miss a property.\n")
-        explanation_text += _("Saving the result will write to the vehicle_components.json file.")
+        explanation_text = _("Please configure properties of the vehicle components.\n")
+        explanation_text += _("Labels for optional properties are displayed in gray text.\n")
+        explanation_text += _("Scroll down to ensure that you do not overlook any properties.\n")
         explanation_label = ttk.Label(intro_frame, text=explanation_text, wraplength=800, justify=tk.LEFT)
         explanation_label.configure(style="bigger.TLabel")
         explanation_label.pack(side=tk.LEFT, padx=(10, 10), pady=(10, 0), anchor=tk.NW)
@@ -119,7 +119,10 @@ class ComponentEditorWindowBase(BaseWindow):
         self.save_button = ttk.Button(
             save_frame, text=_("Save data and start configuration"), command=self.validate_and_save_component_json
         )
-        show_tooltip(self.save_button, _("Save component data and start parameter value configuration and tuning."))
+        show_tooltip(
+            self.save_button,
+            _("Save component data to the vehicle_components.json file\nand start parameter value configuration and tuning."),
+        )
         self.save_button.pack(pady=7)
         if UsagePopupWindow.should_display("component_editor"):
             self.root.after(10, self.__display_component_editor_usage_instructions(self.root))  # type: ignore[arg-type]
@@ -144,12 +147,13 @@ class ComponentEditorWindowBase(BaseWindow):
         instructions_text = RichText(
             usage_popup_window.main_frame, wrap=tk.WORD, height=5, bd=0, background=style.lookup("TLabel", "background")
         )
-        instructions_text.insert(tk.END, _("1. Describe all vehicle component properties in the window below\n"))
-        instructions_text.insert(tk.END, _("2. Scroll all the way down and make sure to edit all properties\n"))
-        instructions_text.insert(tk.END, _("3. Do not be lazy, collect the required information and enter it\n"))
-        instructions_text.insert(tk.END, _("4. Press the "))
+        instructions_text.insert(tk.END, _("1. Describe the properties of the vehicle components in the window below.\n"))
+        instructions_text.insert(tk.END, _("2. Each field has mouse-over tooltips for additional guidance.\n"))
+        instructions_text.insert(tk.END, _("3. Optional fields are marked with gray text and can be left blank.\n"))
+        instructions_text.insert(tk.END, _("4. Scroll to the bottom of the window to ensure all properties are edited.\n"))
+        instructions_text.insert(tk.END, _("5. Press the "))
         instructions_text.insert(tk.END, _("Save data and start configuration"), "italic")
-        instructions_text.insert(tk.END, _(" only after all information is correct"))
+        instructions_text.insert(tk.END, _(" button only after verifying that all information is correct.\n"))
         instructions_text.config(state=tk.DISABLED)
 
         UsagePopupWindow.display(

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -746,7 +746,7 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
             self.close_connection_and_quit()
 
     def write_changes_to_intermediate_parameter_file(self) -> None:
-        if self.parameter_editor_table.get_at_least_one_param_edited():
+        if self.parameter_editor_table.get_at_least_one_param_edited() or self.annotate_params_into_files.get():
             msg = _("Do you want to write the changes to the {self.current_file} file?")
             if messagebox.askyesno(_("One or more parameters have been edited"), msg.format(**locals())):
                 self.local_filesystem.export_to_param(

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -103,11 +103,11 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
             )
             if error_msg:
                 messagebox.showerror(_("Error in derived parameters"), error_msg)
-            else:
-                # merge derived parameter values
-                self.local_filesystem.merge_forced_or_derived_parameters(
-                    selected_file, self.local_filesystem.derived_parameters, list(fc_parameters.keys())
-                )
+            # merge derived parameter values
+            elif self.local_filesystem.merge_forced_or_derived_parameters(
+                selected_file, self.local_filesystem.derived_parameters, list(fc_parameters.keys())
+            ):
+                self.at_least_one_param_edited = True
 
             self.rename_fc_connection(selected_file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ lint.ignore = [
     "DTZ005",  # `tz=None` passed to `datetime.datetime.now()`
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition
+    "LOG015",  # `error()` call on root logger, Use own logger instead
 ]
 
 line-length = 127

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "matplotlib==3.9.4",
     "numpy==2.0.2",
     "pillow==11.1.0",
+    "pip_system_certs==4.0",
     "platformdirs==4.3.6",
     "pymavlink==2.4.43",
     "pyserial==3.5",


### PR DESCRIPTION
This pull request includes several changes to the `ardupilot_methodic_configurator` project, focusing on parameter file handling and dependency updates. The most important changes involve modifying how parameter files are exported and annotated, updating dependencies, and handling parameter edits in the frontend.

Changes to parameter file handling:

* [`ardupilot_methodic_configurator/backend_filesystem.py`](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L669-R671): Modified the `update_and_export_vehicle_params_from_fc` method to include an option for annotating documentation into parameter files.
* [`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py`](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5L749-R749): Updated the `write_changes_to_intermediate_parameter_file` method to check if parameters should be annotated into files before exporting.
* [`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py`](diffhunk://#diff-a1fc77b2f824d73d73195abb5559fad566982d510708937a5c52ba2c86de71acL106-R110): Adjusted the `repopulate` method to set a flag when derived parameters are merged, indicating that at least one parameter has been edited.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R50): Added the `pip_system_certs` dependency.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R196): Added `LOG015` to the lint ignore list to avoid errors for using the root logger.