### PR TITLE
Updated all languages

### DIFF
--- a/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -109,11 +109,11 @@ msgstr "Die Datei %s existiert bereits. Datei %s wird nicht in %s umbenannt."
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:221
 msgid "Could not convert values to int or float for %s"
-msgstr ""
+msgstr "Werte konnten nicht in int oder float für %s konvertiert werden"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:223
 msgid "Parameter %s has invalid metadata. Please file a bug at %s"
-msgstr ""
+msgstr "Parameter %s hat ungültige Metadaten. Bitte melden Sie einen Fehler unter %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:266
 msgid "Error: %s is not a directory."
@@ -222,7 +222,7 @@ msgstr ""
 msgid ""
 "Save the vehicle component to the system templates. Only for software "
 "developers that know what they are doing. Default is %(default)s"
-msgstr ""
+msgstr "Speichern Sie die Fahrzeugkomponente in den Systemvorlagen. Nur für Softwareentwickler, die wissen, was sie tun. Standard ist %(default)s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py:65
 msgid ""
@@ -365,11 +365,11 @@ msgstr "standort_verzeichnis: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:70
 msgid "Schema file '%s' is valid."
-msgstr ""
+msgstr "Schema-Datei '%s' ist gültig."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:72
 msgid "Schema file '%s' is not a valid JSON Schema: %s"
-msgstr ""
+msgstr "Schema-Datei '%s' ist kein gültiges JSON-Schema: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:77
 msgid "Schema file '%s' not found."
@@ -381,31 +381,31 @@ msgstr "Fehler beim Dekodieren des JSON-Schemas aus Datei '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:136
 msgid "System component templates file '%s' not found."
-msgstr ""
+msgstr "Systemkomponenten-Vorlagendatei '%s' nicht gefunden."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:138
 msgid "Error decoding JSON system component templates from file '%s'."
-msgstr ""
+msgstr "Fehler beim Dekodieren der JSON-Systemkomponentenvorlagen aus Datei '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:156
 msgid "User component templates file '%s' not found."
-msgstr ""
+msgstr "Benutzerkomponenten-Vorlagendatei '%s' nicht gefunden."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:158
 msgid "Error decoding JSON user component templates from file '%s'."
-msgstr ""
+msgstr "Fehler beim Dekodieren der JSON-Benutzerkomponentenvorlagen aus Datei '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:256
 msgid "Failed to create templates directory '{}': {}"
-msgstr ""
+msgstr "Vorlagenverzeichnis '{}' konnte nicht erstellt werden: {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "File not found when writing to '{}': {}"
-msgstr ""
+msgstr "Datei nicht gefunden beim Schreiben nach '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "Path not found"
-msgstr ""
+msgstr "Pfad nicht gefunden"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:271
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:343
@@ -419,7 +419,7 @@ msgstr "Betriebssystemfehler beim Schreiben in Datei '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:277
 msgid "Unexpected error saving templates to file '{}': {}"
-msgstr ""
+msgstr "Unerwarteter Fehler beim Speichern der Vorlagen in Datei '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:290
 msgid "Could not load validation schema"
@@ -479,7 +479,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:494
 msgid "Exception occurred in get_component_property_description: {}"
-msgstr ""
+msgstr "Ausnahme aufgetreten in get_component_property_description: {}"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller.py:78
 msgid "You should uninstall ModemManager as it conflicts with ArduPilot"
@@ -768,23 +768,23 @@ msgstr "Aktualisierung über pip für Linux und macOS..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:214
 msgid "URL not provided."
-msgstr ""
+msgstr "URL nicht angegeben."
 
 #: ardupilot_methodic_configurator/backend_internet.py:217
 msgid "Verifying URL: %s"
-msgstr ""
+msgstr "Überprüfe URL: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:234
 msgid "Failed to access URL: %s. Error: %s"
-msgstr ""
+msgstr "Zugriff auf URL fehlgeschlagen: %s. Fehler: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:239
 msgid "Opening URL in browser: %s"
-msgstr ""
+msgstr "Öffne URL im Browser: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:242
 msgid "Failed to open URL in browser: %s"
-msgstr ""
+msgstr "Fehler beim Öffnen der URL im Browser: %s"
 
 #: ardupilot_methodic_configurator/common_arguments.py:23
 msgid "Logging level. Default is %(default)s."
@@ -1096,15 +1096,15 @@ msgstr "Amilcar Lucas - ArduPilot methodischer Konfigurator "
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:96
 msgid "Please configure properties of the vehicle components.\n"
-msgstr ""
+msgstr "Bitte konfigurieren Sie die Eigenschaften der Fahrzeugkomponenten.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:97
 msgid "Labels for optional properties are displayed in gray text.\n"
-msgstr ""
+msgstr "Bezeichnungen für optionale Eigenschaften werden in grauem Text angezeigt.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:98
 msgid "Scroll down to ensure that you do not overlook any properties.\n"
-msgstr ""
+msgstr "Scrollen Sie nach unten, um sicherzustellen, dass Sie keine Eigenschaften übersehen.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:107
 msgid ""
@@ -1127,33 +1127,33 @@ msgstr "Daten speichern und Konfiguration starten"
 msgid ""
 "Save component data to the vehicle_components.json file\n"
 "and start parameter value configuration and tuning."
-msgstr ""
+msgstr "Speichern Sie die Komponentendaten in der vehicle_components.json Datei\nund beginnen Sie mit der Parameterwert-Konfiguration und -Abstimmung."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:150
 msgid ""
 "1. Describe the properties of the vehicle components in the window below.\n"
-msgstr ""
+msgstr "1. Beschreiben Sie die Eigenschaften der Fahrzeugkomponenten im Fenster unten.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:151
 msgid "2. Each field has mouse-over tooltips for additional guidance.\n"
-msgstr ""
+msgstr "2. Jedes Feld hat Mauszeiger-Tooltips für zusätzliche Hinweise.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:152
 msgid "3. Optional fields are marked with gray text and can be left blank.\n"
-msgstr ""
+msgstr "3. Optionale Felder sind grau markiert und können leer gelassen werden.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:153
 msgid ""
 "4. Scroll to the bottom of the window to ensure all properties are edited.\n"
-msgstr ""
+msgstr "4. Scrollen Sie zum Ende des Fensters, um sicherzustellen, dass alle Eigenschaften bearbeitet wurden.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:154
 msgid "5. Press the "
-msgstr ""
+msgstr "5. Drücken Sie die"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:156
 msgid " button only after verifying that all information is correct.\n"
-msgstr ""
+msgstr "Schaltfläche erst, nachdem Sie überprüft haben, dass alle Informationen korrekt sind.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:162
 msgid "How to use the component editor window"
@@ -1164,7 +1164,7 @@ msgstr "Wie man das Komponenten-Editorfenster verwendet"
 msgid ""
 "\n"
 "This is optional and can be left blank"
-msgstr ""
+msgstr "\nDies ist optional und kann leer gelassen werden"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:307
 msgid ""
@@ -1212,61 +1212,61 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:61
 msgid "Template:"
-msgstr ""
+msgstr "Vorlage:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:69
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:123
 msgid "Select a template for this component"
-msgstr ""
+msgstr "Wählen Sie eine Vorlage für diese Komponente"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:77
 msgid "Save current configuration as template"
-msgstr ""
+msgstr "Aktuelle Konfiguration als Vorlage speichern"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:87
 msgid "No data for component: "
-msgstr ""
+msgstr "Keine Daten für Komponente:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Enter a name for this template:"
-msgstr ""
+msgstr "Geben Sie einen Namen für diese Vorlage ein:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Save Template"
-msgstr ""
+msgstr "Vorlage speichern"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "A template with this name already exists. Overwrite?"
-msgstr ""
+msgstr "Eine Vorlage mit diesem Namen existiert bereits. Überschreiben?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "Template exists"
-msgstr ""
+msgstr "Vorlage existiert"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 msgid "Template has been updated"
-msgstr ""
+msgstr "Vorlage wurde aktualisiert"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template Saved"
-msgstr ""
+msgstr "Vorlage gespeichert"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template has been saved"
-msgstr ""
+msgstr "Vorlage wurde gespeichert"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:150
 msgid "No component templates available"
-msgstr ""
+msgstr "Keine Komponentenvorlagen verfügbar"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "Template Applied"
-msgstr ""
+msgstr "Vorlage angewendet"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "{} has been applied to {}"
-msgstr ""
+msgstr "{} wurde auf {} angewendet"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py:63
 msgid "flight controller connection:"

--- a/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -111,11 +111,11 @@ msgstr "Il file %s esiste già. Non verrà rinominato il file %s in %s."
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:221
 msgid "Could not convert values to int or float for %s"
-msgstr ""
+msgstr "Impossibile convertire i valori in int o float per %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:223
 msgid "Parameter %s has invalid metadata. Please file a bug at %s"
-msgstr ""
+msgstr "Il parametro %s ha metadati non validi. Per favore segnala un bug su %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:266
 msgid "Error: %s is not a directory."
@@ -222,7 +222,7 @@ msgstr ""
 msgid ""
 "Save the vehicle component to the system templates. Only for software "
 "developers that know what they are doing. Default is %(default)s"
-msgstr ""
+msgstr "Salva il componente del veicolo nei modelli di sistema. Solo per sviluppatori che sanno cosa stanno facendo. Il valore predefinito è %(default)s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py:65
 msgid ""
@@ -363,11 +363,11 @@ msgstr "directory_sito: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:70
 msgid "Schema file '%s' is valid."
-msgstr ""
+msgstr "Il file schema '%s' è valido."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:72
 msgid "Schema file '%s' is not a valid JSON Schema: %s"
-msgstr ""
+msgstr "Il file schema '%s' non è un JSON Schema valido: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:77
 msgid "Schema file '%s' not found."
@@ -379,31 +379,31 @@ msgstr "Errore durante la decodifica dello schema JSON dal file '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:136
 msgid "System component templates file '%s' not found."
-msgstr ""
+msgstr "File dei modelli di componenti di sistema '%s' non trovato."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:138
 msgid "Error decoding JSON system component templates from file '%s'."
-msgstr ""
+msgstr "Errore nella decodifica dei modelli JSON dei componenti di sistema dal file '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:156
 msgid "User component templates file '%s' not found."
-msgstr ""
+msgstr "File dei modelli di componenti utente '%s' non trovato."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:158
 msgid "Error decoding JSON user component templates from file '%s'."
-msgstr ""
+msgstr "Errore nella decodifica dei modelli JSON dei componenti utente dal file '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:256
 msgid "Failed to create templates directory '{}': {}"
-msgstr ""
+msgstr "Impossibile creare la directory dei modelli '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "File not found when writing to '{}': {}"
-msgstr ""
+msgstr "File non trovato durante la scrittura su '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "Path not found"
-msgstr ""
+msgstr "Percorso non trovato"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:271
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:343
@@ -417,7 +417,7 @@ msgstr "Errore del sistema operativo durante la scrittura del file '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:277
 msgid "Unexpected error saving templates to file '{}': {}"
-msgstr ""
+msgstr "Errore imprevisto nel salvataggio dei modelli nel file '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:290
 msgid "Could not load validation schema"
@@ -477,7 +477,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:494
 msgid "Exception occurred in get_component_property_description: {}"
-msgstr ""
+msgstr "Si è verificata un'eccezione in get_component_property_description: {}"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller.py:78
 msgid "You should uninstall ModemManager as it conflicts with ArduPilot"
@@ -762,23 +762,23 @@ msgstr "Aggiornamento tramite pip per Linux e macOS..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:214
 msgid "URL not provided."
-msgstr ""
+msgstr "URL non fornito."
 
 #: ardupilot_methodic_configurator/backend_internet.py:217
 msgid "Verifying URL: %s"
-msgstr ""
+msgstr "Verifica URL: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:234
 msgid "Failed to access URL: %s. Error: %s"
-msgstr ""
+msgstr "Impossibile accedere all'URL: %s. Errore: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:239
 msgid "Opening URL in browser: %s"
-msgstr ""
+msgstr "Apertura URL nel browser: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:242
 msgid "Failed to open URL in browser: %s"
-msgstr ""
+msgstr "Impossibile aprire l'URL nel browser: %s"
 
 #: ardupilot_methodic_configurator/common_arguments.py:23
 msgid "Logging level. Default is %(default)s."
@@ -1093,15 +1093,15 @@ msgstr "Configuratore metodico ArduPilot di Amilcar Lucas "
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:96
 msgid "Please configure properties of the vehicle components.\n"
-msgstr ""
+msgstr "Per favore configura le proprietà dei componenti del veicolo.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:97
 msgid "Labels for optional properties are displayed in gray text.\n"
-msgstr ""
+msgstr "Le etichette per le proprietà opzionali sono visualizzate in grigio.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:98
 msgid "Scroll down to ensure that you do not overlook any properties.\n"
-msgstr ""
+msgstr "Scorri verso il basso per assicurarti di non tralasciare alcuna proprietà.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:107
 msgid ""
@@ -1124,33 +1124,33 @@ msgstr "Salva i dati e inizia la configurazione"
 msgid ""
 "Save component data to the vehicle_components.json file\n"
 "and start parameter value configuration and tuning."
-msgstr ""
+msgstr "Salva i dati dei componenti nel file vehicle_components.json\ne inizia la configurazione e la regolazione dei parametri."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:150
 msgid ""
 "1. Describe the properties of the vehicle components in the window below.\n"
-msgstr ""
+msgstr "1. Descrivi le proprietà dei componenti del veicolo nella finestra sottostante.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:151
 msgid "2. Each field has mouse-over tooltips for additional guidance.\n"
-msgstr ""
+msgstr "2. Ogni campo ha suggerimenti al passaggio del mouse per ulteriore assistenza.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:152
 msgid "3. Optional fields are marked with gray text and can be left blank.\n"
-msgstr ""
+msgstr "3. I campi opzionali sono contrassegnati in grigio e possono essere lasciati vuoti.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:153
 msgid ""
 "4. Scroll to the bottom of the window to ensure all properties are edited.\n"
-msgstr ""
+msgstr "4. Scorri fino in fondo alla finestra per assicurarti che tutte le proprietà siano modificate.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:154
 msgid "5. Press the "
-msgstr ""
+msgstr "5. Premi il pulsante"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:156
 msgid " button only after verifying that all information is correct.\n"
-msgstr ""
+msgstr "solo dopo aver verificato che tutte le informazioni siano corrette.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:162
 msgid "How to use the component editor window"
@@ -1161,7 +1161,7 @@ msgstr "Come utilizzare la finestra dell'editor dei componenti"
 msgid ""
 "\n"
 "This is optional and can be left blank"
-msgstr ""
+msgstr "\nQuesto è opzionale e può essere lasciato vuoto"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:307
 msgid ""
@@ -1209,61 +1209,61 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:61
 msgid "Template:"
-msgstr ""
+msgstr "Modello:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:69
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:123
 msgid "Select a template for this component"
-msgstr ""
+msgstr "Seleziona un modello per questo componente"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:77
 msgid "Save current configuration as template"
-msgstr ""
+msgstr "Salva la configurazione attuale come modello"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:87
 msgid "No data for component: "
-msgstr ""
+msgstr "Nessun dato per il componente:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Enter a name for this template:"
-msgstr ""
+msgstr "Inserisci un nome per questo modello:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Save Template"
-msgstr ""
+msgstr "Salva Modello"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "A template with this name already exists. Overwrite?"
-msgstr ""
+msgstr "Esiste già un modello con questo nome. Sovrascrivere?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "Template exists"
-msgstr ""
+msgstr "Il modello esiste"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 msgid "Template has been updated"
-msgstr ""
+msgstr "Il modello è stato aggiornato"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template Saved"
-msgstr ""
+msgstr "Modello Salvato"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template has been saved"
-msgstr ""
+msgstr "Il modello è stato salvato"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:150
 msgid "No component templates available"
-msgstr ""
+msgstr "Nessun modello di componente disponibile"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "Template Applied"
-msgstr ""
+msgstr "Modello Applicato"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "{} has been applied to {}"
-msgstr ""
+msgstr "{} è stato applicato a {}"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py:63
 msgid "flight controller connection:"

--- a/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -107,11 +107,11 @@ msgstr "ファイル%sはすでに存在します。ファイル%sを%sに名前
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:221
 msgid "Could not convert values to int or float for %s"
-msgstr ""
+msgstr "%s の値を整数または浮動小数点数に変換できませんでした"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:223
 msgid "Parameter %s has invalid metadata. Please file a bug at %s"
-msgstr ""
+msgstr "パラメータ %s に無効なメタデータがあります。%s でバグを報告してください"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:266
 msgid "Error: %s is not a directory."
@@ -219,7 +219,7 @@ msgstr ""
 msgid ""
 "Save the vehicle component to the system templates. Only for software "
 "developers that know what they are doing. Default is %(default)s"
-msgstr ""
+msgstr "車両コンポーネントをシステムテンプレートに保存します。これは何をしているか分かっている開発者のみ使用してください。デフォルトは %(default)s です"
 
 #: ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py:65
 msgid ""
@@ -356,11 +356,11 @@ msgstr "サイトディレクトリ: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:70
 msgid "Schema file '%s' is valid."
-msgstr ""
+msgstr "スキーマファイル '%s' は有効です。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:72
 msgid "Schema file '%s' is not a valid JSON Schema: %s"
-msgstr ""
+msgstr "スキーマファイル '%s' は有効なJSONスキーマではありません: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:77
 msgid "Schema file '%s' not found."
@@ -372,31 +372,31 @@ msgstr "JSONスキーマファイル '%s' のデコードエラー。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:136
 msgid "System component templates file '%s' not found."
-msgstr ""
+msgstr "システムコンポーネントテンプレートファイル '%s' が見つかりません。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:138
 msgid "Error decoding JSON system component templates from file '%s'."
-msgstr ""
+msgstr "ファイル '%s' からのJSONシステムコンポーネントテンプレートのデコードエラー。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:156
 msgid "User component templates file '%s' not found."
-msgstr ""
+msgstr "ユーザーコンポーネントテンプレートファイル '%s' が見つかりません。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:158
 msgid "Error decoding JSON user component templates from file '%s'."
-msgstr ""
+msgstr "ファイル '%s' からのJSONユーザーコンポーネントテンプレートのデコードエラー。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:256
 msgid "Failed to create templates directory '{}': {}"
-msgstr ""
+msgstr "テンプレートディレクトリ '{}' の作成に失敗しました: {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "File not found when writing to '{}': {}"
-msgstr ""
+msgstr "'{}' への書き込み時にファイルが見つかりません: {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "Path not found"
-msgstr ""
+msgstr "パスが見つかりません"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:271
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:343
@@ -410,7 +410,7 @@ msgstr "ファイル '{}' への書き込み中にOSエラーが発生しまし�
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:277
 msgid "Unexpected error saving templates to file '{}': {}"
-msgstr ""
+msgstr "テンプレートをファイル '{}' に保存中に予期せぬエラーが発生しました: {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:290
 msgid "Could not load validation schema"
@@ -470,7 +470,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:494
 msgid "Exception occurred in get_component_property_description: {}"
-msgstr ""
+msgstr "get_component_property_description で例外が発生しました: {}"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller.py:78
 msgid "You should uninstall ModemManager as it conflicts with ArduPilot"
@@ -754,23 +754,23 @@ msgstr "LinuxとmacOS用にpipを使用して更新しています..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:214
 msgid "URL not provided."
-msgstr ""
+msgstr "URLが指定されていません。"
 
 #: ardupilot_methodic_configurator/backend_internet.py:217
 msgid "Verifying URL: %s"
-msgstr ""
+msgstr "URLを確認中: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:234
 msgid "Failed to access URL: %s. Error: %s"
-msgstr ""
+msgstr "URLへのアクセスに失敗しました: %s. エラー: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:239
 msgid "Opening URL in browser: %s"
-msgstr ""
+msgstr "ブラウザでURLを開いています: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:242
 msgid "Failed to open URL in browser: %s"
-msgstr ""
+msgstr "ブラウザでURLを開くことができませんでした: %s"
 
 #: ardupilot_methodic_configurator/common_arguments.py:23
 msgid "Logging level. Default is %(default)s."
@@ -1075,15 +1075,15 @@ msgstr "Amilcar Lucasの - ArduPilot方法論的コンフィギュレータ"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:96
 msgid "Please configure properties of the vehicle components.\n"
-msgstr ""
+msgstr "車両コンポーネントのプロパティを設定してください。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:97
 msgid "Labels for optional properties are displayed in gray text.\n"
-msgstr ""
+msgstr "オプションのプロパティのラベルはグレーのテキストで表示されます。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:98
 msgid "Scroll down to ensure that you do not overlook any properties.\n"
-msgstr ""
+msgstr "すべてのプロパティを確認するため、下までスクロールしてください。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:107
 msgid ""
@@ -1106,33 +1106,33 @@ msgstr "データを保存して設定を開始"
 msgid ""
 "Save component data to the vehicle_components.json file\n"
 "and start parameter value configuration and tuning."
-msgstr ""
+msgstr "コンポーネントデータを vehicle_components.json ファイルに保存し、\nパラメータ値の設定とチューニングを開始します。"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:150
 msgid ""
 "1. Describe the properties of the vehicle components in the window below.\n"
-msgstr ""
+msgstr "1. 下のウィンドウで車両コンポーネントのプロパティを説明してください。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:151
 msgid "2. Each field has mouse-over tooltips for additional guidance.\n"
-msgstr ""
+msgstr "2. 各フィールドにはマウスオーバーで追加のガイダンスが表示されます。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:152
 msgid "3. Optional fields are marked with gray text and can be left blank.\n"
-msgstr ""
+msgstr "3. オプションフィールドはグレーのテキストでマークされており、空白のままにできます。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:153
 msgid ""
 "4. Scroll to the bottom of the window to ensure all properties are edited.\n"
-msgstr ""
+msgstr "4. すべてのプロパティが編集されていることを確認するため、ウィンドウの一番下までスクロールしてください。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:154
 msgid "5. Press the "
-msgstr ""
+msgstr "5."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:156
 msgid " button only after verifying that all information is correct.\n"
-msgstr ""
+msgstr "ボタンは、すべての情報が正しいことを確認してから押してください。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:162
 msgid "How to use the component editor window"
@@ -1143,7 +1143,7 @@ msgstr "コンポーネントエディタウィンドウの使用方法"
 msgid ""
 "\n"
 "This is optional and can be left blank"
-msgstr ""
+msgstr "\nこれはオプションで、空白のままにできます"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:307
 msgid ""
@@ -1191,61 +1191,61 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:61
 msgid "Template:"
-msgstr ""
+msgstr "テンプレート:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:69
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:123
 msgid "Select a template for this component"
-msgstr ""
+msgstr "このコンポーネントのテンプレートを選択"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:77
 msgid "Save current configuration as template"
-msgstr ""
+msgstr "現在の設定をテンプレートとして保存"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:87
 msgid "No data for component: "
-msgstr ""
+msgstr "コンポーネントにデータがありません:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Enter a name for this template:"
-msgstr ""
+msgstr "このテンプレートの名前を入力してください:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Save Template"
-msgstr ""
+msgstr "テンプレートを保存"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "A template with this name already exists. Overwrite?"
-msgstr ""
+msgstr "この名前のテンプレートは既に存在します。上書きしますか？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "Template exists"
-msgstr ""
+msgstr "テンプレートが存在します"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 msgid "Template has been updated"
-msgstr ""
+msgstr "テンプレートが更新されました"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template Saved"
-msgstr ""
+msgstr "テンプレートが保存されました"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template has been saved"
-msgstr ""
+msgstr "テンプレートが保存されました"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:150
 msgid "No component templates available"
-msgstr ""
+msgstr "利用可能なコンポーネントテンプレートがありません"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "Template Applied"
-msgstr ""
+msgstr "テンプレートが適用されました"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "{} has been applied to {}"
-msgstr ""
+msgstr "{} が {} に適用されました"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py:63
 msgid "flight controller connection:"

--- a/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -109,11 +109,11 @@ msgstr "Ficheiro % já existe. Não vai mudar o nome do ficheiro %s para %s."
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:221
 msgid "Could not convert values to int or float for %s"
-msgstr ""
+msgstr "Não foi possível converter valores para int ou float para %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:223
 msgid "Parameter %s has invalid metadata. Please file a bug at %s"
-msgstr ""
+msgstr "O parâmetro %s tem metadados inválidos. Por favor, reporte um erro em %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:266
 msgid "Error: %s is not a directory."
@@ -219,7 +219,7 @@ msgstr ""
 msgid ""
 "Save the vehicle component to the system templates. Only for software "
 "developers that know what they are doing. Default is %(default)s"
-msgstr ""
+msgstr "Guardar o componente do veículo nos modelos do sistema. Apenas para programadores que sabem o que estão a fazer. Por defeito é %(default)s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py:65
 msgid ""
@@ -360,11 +360,11 @@ msgstr "diretório base de destino: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:70
 msgid "Schema file '%s' is valid."
-msgstr ""
+msgstr "O ficheiro de esquema '%s' é válido."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:72
 msgid "Schema file '%s' is not a valid JSON Schema: %s"
-msgstr ""
+msgstr "O ficheiro de esquema '%s' não é um esquema JSON válido: %s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:77
 msgid "Schema file '%s' not found."
@@ -376,31 +376,31 @@ msgstr "Erro ao descodificar esquema JSON do ficheiro '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:136
 msgid "System component templates file '%s' not found."
-msgstr ""
+msgstr "Ficheiro de modelos de componentes do sistema '%s' não encontrado."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:138
 msgid "Error decoding JSON system component templates from file '%s'."
-msgstr ""
+msgstr "Erro ao descodificar modelos JSON de componentes do sistema do ficheiro '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:156
 msgid "User component templates file '%s' not found."
-msgstr ""
+msgstr "Ficheiro de modelos de componentes do utilizador '%s' não encontrado."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:158
 msgid "Error decoding JSON user component templates from file '%s'."
-msgstr ""
+msgstr "Erro ao descodificar modelos JSON de componentes do utilizador do ficheiro '%s'."
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:256
 msgid "Failed to create templates directory '{}': {}"
-msgstr ""
+msgstr "Falha ao criar diretório de modelos '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "File not found when writing to '{}': {}"
-msgstr ""
+msgstr "Ficheiro não encontrado ao escrever em '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "Path not found"
-msgstr ""
+msgstr "Caminho não encontrado"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:271
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:343
@@ -414,7 +414,7 @@ msgstr "Erro do sistema operativo ao escrever no ficheiro '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:277
 msgid "Unexpected error saving templates to file '{}': {}"
-msgstr ""
+msgstr "Erro inesperado ao guardar modelos no ficheiro '{}': {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:290
 msgid "Could not load validation schema"
@@ -474,7 +474,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:494
 msgid "Exception occurred in get_component_property_description: {}"
-msgstr ""
+msgstr "Ocorreu uma exceção em get_component_property_description: {}"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller.py:78
 msgid "You should uninstall ModemManager as it conflicts with ArduPilot"
@@ -758,23 +758,23 @@ msgstr "A atualizar via pip para Linux e macOS..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:214
 msgid "URL not provided."
-msgstr ""
+msgstr "URL não fornecido."
 
 #: ardupilot_methodic_configurator/backend_internet.py:217
 msgid "Verifying URL: %s"
-msgstr ""
+msgstr "A verificar URL: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:234
 msgid "Failed to access URL: %s. Error: %s"
-msgstr ""
+msgstr "Falha ao aceder ao URL: %s. Erro: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:239
 msgid "Opening URL in browser: %s"
-msgstr ""
+msgstr "A abrir URL no navegador: %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:242
 msgid "Failed to open URL in browser: %s"
-msgstr ""
+msgstr "Falha ao abrir URL no navegador: %s"
 
 #: ardupilot_methodic_configurator/common_arguments.py:23
 msgid "Logging level. Default is %(default)s."
@@ -1082,15 +1082,15 @@ msgstr "Configurador metódico do ArduPilot por Amilcar Lucas "
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:96
 msgid "Please configure properties of the vehicle components.\n"
-msgstr ""
+msgstr "Por favor, configure as propriedades dos componentes do veículo.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:97
 msgid "Labels for optional properties are displayed in gray text.\n"
-msgstr ""
+msgstr "Etiquetas para propriedades opcionais são apresentadas em texto cinzento.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:98
 msgid "Scroll down to ensure that you do not overlook any properties.\n"
-msgstr ""
+msgstr "Desloque para baixo para garantir que não ignora nenhuma propriedade.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:107
 msgid ""
@@ -1113,33 +1113,33 @@ msgstr "Salvar dados e iniciar a configuração"
 msgid ""
 "Save component data to the vehicle_components.json file\n"
 "and start parameter value configuration and tuning."
-msgstr ""
+msgstr "Guardar dados dos componentes no ficheiro vehicle_components.json\ne iniciar configuração e ajuste dos valores dos parâmetros."
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:150
 msgid ""
 "1. Describe the properties of the vehicle components in the window below.\n"
-msgstr ""
+msgstr "1. Descreva as propriedades dos componentes do veículo na janela abaixo.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:151
 msgid "2. Each field has mouse-over tooltips for additional guidance.\n"
-msgstr ""
+msgstr "2. Cada campo tem dicas ao passar o rato para orientação adicional.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:152
 msgid "3. Optional fields are marked with gray text and can be left blank.\n"
-msgstr ""
+msgstr "3. Campos opcionais estão marcados com texto cinzento e podem ficar em branco.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:153
 msgid ""
 "4. Scroll to the bottom of the window to ensure all properties are edited.\n"
-msgstr ""
+msgstr "4. Desloque até ao fundo da janela para garantir que todas as propriedades são editadas.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:154
 msgid "5. Press the "
-msgstr ""
+msgstr "5. Prima o botão"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:156
 msgid " button only after verifying that all information is correct.\n"
-msgstr ""
+msgstr "apenas depois de verificar que toda a informação está correta.\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:162
 msgid "How to use the component editor window"
@@ -1150,7 +1150,7 @@ msgstr "Como usar a janela de editor de componentes"
 msgid ""
 "\n"
 "This is optional and can be left blank"
-msgstr ""
+msgstr "\nIsto é opcional e pode ficar em branco"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:307
 msgid ""
@@ -1198,61 +1198,61 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:61
 msgid "Template:"
-msgstr ""
+msgstr "Modelo:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:69
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:123
 msgid "Select a template for this component"
-msgstr ""
+msgstr "Selecione um modelo para este componente"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:77
 msgid "Save current configuration as template"
-msgstr ""
+msgstr "Guardar configuração atual como modelo"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:87
 msgid "No data for component: "
-msgstr ""
+msgstr "Sem dados para o componente:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Enter a name for this template:"
-msgstr ""
+msgstr "Introduza um nome para este modelo:"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Save Template"
-msgstr ""
+msgstr "Guardar Modelo"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "A template with this name already exists. Overwrite?"
-msgstr ""
+msgstr "Já existe um modelo com este nome. Substituir?"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "Template exists"
-msgstr ""
+msgstr "O modelo existe"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 msgid "Template has been updated"
-msgstr ""
+msgstr "O modelo foi atualizado"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template Saved"
-msgstr ""
+msgstr "Modelo Guardado"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template has been saved"
-msgstr ""
+msgstr "O modelo foi guardado"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:150
 msgid "No component templates available"
-msgstr ""
+msgstr "Não há modelos de componentes disponíveis"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "Template Applied"
-msgstr ""
+msgstr "Modelo Aplicado"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "{} has been applied to {}"
-msgstr ""
+msgstr "{} foi aplicado a {}"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py:63
 msgid "flight controller connection:"

--- a/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -109,11 +109,11 @@ msgstr "文件 %s 已經存在。將不會將文件 %s 重命名為 %s。"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:221
 msgid "Could not convert values to int or float for %s"
-msgstr ""
+msgstr "无法将值转换为 %s 的整数或浮点数"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:223
 msgid "Parameter %s has invalid metadata. Please file a bug at %s"
-msgstr ""
+msgstr "参数 %s 具有无效的元数据。请在 %s 提交错误报告"
 
 #: ardupilot_methodic_configurator/backend_filesystem.py:266
 msgid "Error: %s is not a directory."
@@ -212,7 +212,7 @@ msgstr ""
 msgid ""
 "Save the vehicle component to the system templates. Only for software "
 "developers that know what they are doing. Default is %(default)s"
-msgstr ""
+msgstr "将车辆组件保存到系统模板中。仅供了解其操作的软件开发人员使用。默认值为 %(default)s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py:65
 msgid ""
@@ -342,11 +342,11 @@ msgstr "站點目錄：%s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:70
 msgid "Schema file '%s' is valid."
-msgstr ""
+msgstr "架构文件 '%s' 有效。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:72
 msgid "Schema file '%s' is not a valid JSON Schema: %s"
-msgstr ""
+msgstr "架构文件 '%s' 不是有效的 JSON 架构：%s"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:77
 msgid "Schema file '%s' not found."
@@ -358,31 +358,31 @@ msgstr "从文件'%s'解码JSON模式时出错。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:136
 msgid "System component templates file '%s' not found."
-msgstr ""
+msgstr "未找到系统组件模板文件 '%s'。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:138
 msgid "Error decoding JSON system component templates from file '%s'."
-msgstr ""
+msgstr "从文件 '%s' 解码 JSON 系统组件模板时出错。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:156
 msgid "User component templates file '%s' not found."
-msgstr ""
+msgstr "未找到用户组件模板文件 '%s'。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:158
 msgid "Error decoding JSON user component templates from file '%s'."
-msgstr ""
+msgstr "从文件 '%s' 解码 JSON 用户组件模板时出错。"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:256
 msgid "Failed to create templates directory '{}': {}"
-msgstr ""
+msgstr "创建模板目录 '{}' 失败：{}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "File not found when writing to '{}': {}"
-msgstr ""
+msgstr "写入 '{}' 时未找到文件：{}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:268
 msgid "Path not found"
-msgstr ""
+msgstr "未找到路径"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:271
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:343
@@ -396,7 +396,7 @@ msgstr "写入文件'{}'时发生操作系统错误: {}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:277
 msgid "Unexpected error saving templates to file '{}': {}"
-msgstr ""
+msgstr "将模板保存到文件 '{}' 时发生意外错误：{}"
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:290
 msgid "Could not load validation schema"
@@ -456,7 +456,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py:494
 msgid "Exception occurred in get_component_property_description: {}"
-msgstr ""
+msgstr "在 get_component_property_description 中发生异常：{}"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller.py:78
 msgid "You should uninstall ModemManager as it conflicts with ArduPilot"
@@ -738,23 +738,23 @@ msgstr "正在通过pip更新Linux和macOS版本..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:214
 msgid "URL not provided."
-msgstr ""
+msgstr "未提供 URL。"
 
 #: ardupilot_methodic_configurator/backend_internet.py:217
 msgid "Verifying URL: %s"
-msgstr ""
+msgstr "正在验证 URL：%s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:234
 msgid "Failed to access URL: %s. Error: %s"
-msgstr ""
+msgstr "访问 URL 失败：%s。错误：%s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:239
 msgid "Opening URL in browser: %s"
-msgstr ""
+msgstr "正在浏览器中打开 URL：%s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:242
 msgid "Failed to open URL in browser: %s"
-msgstr ""
+msgstr "在浏览器中打开 URL 失败：%s"
 
 #: ardupilot_methodic_configurator/common_arguments.py:23
 msgid "Logging level. Default is %(default)s."
@@ -1063,15 +1063,15 @@ msgstr "Amilcar Lucas 的 - ArduPilot 调参助手"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:96
 msgid "Please configure properties of the vehicle components.\n"
-msgstr ""
+msgstr "请配置车辆组件的属性。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:97
 msgid "Labels for optional properties are displayed in gray text.\n"
-msgstr ""
+msgstr "可选属性的标签以灰色文本显示。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:98
 msgid "Scroll down to ensure that you do not overlook any properties.\n"
-msgstr ""
+msgstr "向下滚动以确保不遗漏任何属性。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:107
 msgid ""
@@ -1092,33 +1092,33 @@ msgstr "保存数据并开始配置"
 msgid ""
 "Save component data to the vehicle_components.json file\n"
 "and start parameter value configuration and tuning."
-msgstr ""
+msgstr "将组件数据保存到 vehicle_components.json 文件中\n并开始参数值配置和调整。"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:150
 msgid ""
 "1. Describe the properties of the vehicle components in the window below.\n"
-msgstr ""
+msgstr "1. 在下方窗口中描述车辆组件的属性。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:151
 msgid "2. Each field has mouse-over tooltips for additional guidance.\n"
-msgstr ""
+msgstr "2. 每个字段都有鼠标悬停提示以提供额外指导。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:152
 msgid "3. Optional fields are marked with gray text and can be left blank.\n"
-msgstr ""
+msgstr "3. 可选字段以灰色文本标记，可以留空。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:153
 msgid ""
 "4. Scroll to the bottom of the window to ensure all properties are edited.\n"
-msgstr ""
+msgstr "4. 滚动到窗口底部以确保所有属性都已编辑。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:154
 msgid "5. Press the "
-msgstr ""
+msgstr "5. 请在验证所有信息正确后"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:156
 msgid " button only after verifying that all information is correct.\n"
-msgstr ""
+msgstr "再点击按钮。\n"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:162
 msgid "How to use the component editor window"
@@ -1129,7 +1129,7 @@ msgstr "如何使用組件編輯器窗口"
 msgid ""
 "\n"
 "This is optional and can be left blank"
-msgstr ""
+msgstr "\n这是可选的，可以留空"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py:307
 #, fuzzy
@@ -1176,61 +1176,61 @@ msgstr "跳过组件编辑器窗口。仅在所有组件都已配置时使用。
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:61
 msgid "Template:"
-msgstr ""
+msgstr "模板："
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:69
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:123
 msgid "Select a template for this component"
-msgstr ""
+msgstr "为此组件选择模板"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:77
 msgid "Save current configuration as template"
-msgstr ""
+msgstr "将当前配置保存为模板"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:87
 msgid "No data for component: "
-msgstr ""
+msgstr "组件无数据："
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Enter a name for this template:"
-msgstr ""
+msgstr "输入此模板的名称："
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:92
 msgid "Save Template"
-msgstr ""
+msgstr "保存模板"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "A template with this name already exists. Overwrite?"
-msgstr ""
+msgstr "已存在同名模板。是否覆盖？"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:105
 msgid "Template exists"
-msgstr ""
+msgstr "模板已存在"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 msgid "Template has been updated"
-msgstr ""
+msgstr "模板已更新"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:109
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template Saved"
-msgstr ""
+msgstr "模板已保存"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:114
 msgid "Template has been saved"
-msgstr ""
+msgstr "模板已保存"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:150
 msgid "No component templates available"
-msgstr ""
+msgstr "没有可用的组件模板"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "Template Applied"
-msgstr ""
+msgstr "模板已应用"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py:196
 msgid "{} has been applied to {}"
-msgstr ""
+msgstr "{} 已应用到 {}"
 
 #: ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py:63
 msgid "flight controller connection:"


### PR DESCRIPTION
This pull request includes updates to the German and Italian translation files for the `ardupilot_methodic_configurator` project. The changes primarily involve adding previously missing translations for various messages.

Translation updates:

* Added German translations for error messages and instructions in `ardupilot_methodic_configurator.po` [[1]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L112-R116) [[2]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L225-R225) [[3]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L368-R372) [[4]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L384-R408) [[5]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L422-R422) [[6]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L482-R482) [[7]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L771-R787) [[8]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L1099-R1107) [[9]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L1130-R1156) [[10]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L1167-R1167) [[11]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L1215-R1269).

* Added Italian translations for error messages and instructions in `ardupilot_methodic_configurator.po` [[1]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L114-R118) [[2]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L225-R225) [[3]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L366-R370) [[4]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L382-R406) [[5]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L420-R420) [[6]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L480-R480) [[7]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L765-R781) [[8]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L1096-R1104).