### PR TITLE
Add initial test code

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -21,7 +21,7 @@ from logging import getLevelName as logging_getLevelName
 from logging import info as logging_info
 from logging import warning as logging_warning
 from tkinter import filedialog, messagebox, ttk
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 # from logging import critical as logging_critical
 from webbrowser import open as webbrowser_open  # to open the blog post documentation
@@ -448,6 +448,10 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
                         raise
                     self.parameter_editor_table.set_at_least_one_param_edited(True)  # force writing doc annotations to file
 
+    def __handle_dialog_choice(self, result: list, dialog: tk.Toplevel, choice: Optional[bool]) -> None:
+        result.append(choice)
+        dialog.destroy()
+
     def __should_copy_fc_values_to_file(self, selected_file: str) -> None:  # pylint: disable=too-many-locals
         auto_changed_by = self.local_filesystem.auto_changed_by(selected_file)
         if auto_changed_by and self.flight_controller.fc_parameters:
@@ -484,24 +488,27 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
 
             # Close button (default)
             close_button = tk.Button(
-                button_frame, text=_("Close"), width=10, command=lambda: [result.append(None), dialog.destroy()]
+                button_frame,
+                text=_("Close"),
+                width=10,
+                command=lambda: self.__handle_dialog_choice(result, dialog, choice=None),
             )
             close_button.pack(side=tk.LEFT, padx=5)
 
             # Yes button
             yes_button = tk.Button(
-                button_frame, text=_("Yes"), width=10, command=lambda: [result.append(True), dialog.destroy()]
+                button_frame, text=_("Yes"), width=10, command=lambda: self.__handle_dialog_choice(result, dialog, choice=True)
             )
             yes_button.pack(side=tk.LEFT, padx=5)
 
             # No button
             no_button = tk.Button(
-                button_frame, text=_("No"), width=10, command=lambda: [result.append(False), dialog.destroy()]
+                button_frame, text=_("No"), width=10, command=lambda: self.__handle_dialog_choice(result, dialog, choice=False)
             )
             no_button.pack(side=tk.LEFT, padx=5)
 
             close_button.focus_set()  # Give the Close button focus
-            dialog.bind("<Return>", lambda _event: [result.append(None), dialog.destroy()])
+            dialog.bind("<Return>", lambda _event: self.__handle_dialog_choice(result, dialog, None))
 
             # Center the dialog on the parent window
             dialog.update_idletasks()

--- a/tests/test_frontend_tkinter_parameter_editor.py
+++ b/tests/test_frontend_tkinter_parameter_editor.py
@@ -1,0 +1,197 @@
+#!/usr/bin/python3
+
+"""
+Tests for the ParameterEditorWindow class.
+
+This file is part of Ardupilot methodic configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2025 Amilcar Lucas
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import tkinter as tk
+import unittest
+from tkinter import ttk
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.annotate_params import Par
+from ardupilot_methodic_configurator.frontend_tkinter_parameter_editor import ParameterEditorWindow
+
+
+class TestParameterEditorWindow(unittest.TestCase):  # pylint: disable=too-many-instance-attributes
+    """Test cases for the ParameterEditorWindow class."""
+
+    def setUp(self) -> None:
+        # Create mock objects for dependencies
+        self.root = tk.Tk()
+        self.root.withdraw()  # Hide the main window during tests
+
+        self.mock_flight_controller = MagicMock()
+        self.mock_flight_controller.fc_parameters = {"PARAM1": 1.0, "PARAM2": 2.0}
+
+        self.mock_local_filesystem = MagicMock()
+        self.mock_local_filesystem.file_parameters = {"test_file.param": {"PARAM1": Par(1.0), "PARAM2": Par(2.0)}}
+
+        # Patch necessary methods and classes
+        self.toplevel_patcher = patch("tkinter.Toplevel")
+        self.mock_toplevel = self.toplevel_patcher.start()
+        # Setup the mock toplevel to better simulate dialog behavior
+        self.mock_dialog = MagicMock()
+        self.mock_toplevel.return_value = self.mock_dialog
+        self.mock_dialog.result = [None]  # Initialize result list
+
+        self.label_patcher = patch("tkinter.Label")
+        self.mock_label = self.label_patcher.start()
+
+        self.frame_patcher = patch("tkinter.Frame")
+        self.mock_frame = self.frame_patcher.start()
+
+        self.button_patcher = patch("tkinter.Button")
+        self.mock_button = self.button_patcher.start()
+
+        # Better than patching __init__, just create the object directly
+        # and set its attributes manually
+        self.parameter_editor = ParameterEditorWindow.__new__(ParameterEditorWindow)
+
+        # Create a mock for parameter_editor_table
+        self.mock_parameter_editor_table = MagicMock()
+
+        # Manually set required attributes for tests
+        self.parameter_editor.root = self.root
+        self.parameter_editor.main_frame = ttk.Frame(self.root)
+        self.parameter_editor.current_file = "test_file.param"
+        self.parameter_editor.flight_controller = self.mock_flight_controller
+        self.parameter_editor.local_filesystem = self.mock_local_filesystem
+        self.parameter_editor.at_least_one_changed_parameter_written = False
+        self.parameter_editor.parameter_editor_table = self.mock_parameter_editor_table
+
+    def tearDown(self) -> None:
+        self.toplevel_patcher.stop()
+        self.label_patcher.stop()
+        self.frame_patcher.stop()
+        self.button_patcher.stop()
+        self.root.destroy()
+
+    @patch("sys.exit")
+    def test_should_copy_fc_values_to_file_no_auto_change(self, mock_exit: MagicMock) -> None:
+        """Test that nothing happens when there is no auto_changed_by value."""
+        self.mock_local_filesystem.auto_changed_by.return_value = None
+
+        self.parameter_editor._ParameterEditorWindow__should_copy_fc_values_to_file("test_file.param")  # pylint: disable=protected-access
+
+        self.mock_local_filesystem.auto_changed_by.assert_called_once_with("test_file.param")
+        self.mock_local_filesystem.copy_fc_values_to_file.assert_not_called()
+        mock_exit.assert_not_called()
+
+    @patch("sys.exit")
+    def test_should_copy_fc_values_to_file_yes_response(self, mock_exit: MagicMock) -> None:
+        """Test handling 'Yes' response in the dialog."""
+        self.mock_local_filesystem.auto_changed_by.return_value = "External Tool"
+
+        # Create a fake dialog response mechanism - simulate "Yes" button click
+        def side_effect(*args, **kwargs) -> None:  # noqa: ARG001 # pylint: disable=unused-argument
+            # Find the "Yes" button callback and execute it
+            for call in self.mock_button.call_args_list:
+                _call_args, call_kwargs = call
+                if "text" in call_kwargs and call_kwargs["text"] == _("Yes"):
+                    # This is the "Yes" button - execute its command
+                    call_kwargs["command"]()
+                    break
+
+        # Set up the dialog behavior when wait_window is called
+        self.root.wait_window = MagicMock(side_effect=side_effect)
+
+        # Ensure the toplevel dialog has a result list that can be modified by the command
+        self.mock_dialog.result = [None]
+
+        self.parameter_editor._ParameterEditorWindow__should_copy_fc_values_to_file("test_file.param")  # pylint: disable=protected-access
+
+        self.mock_local_filesystem.auto_changed_by.assert_called_once_with("test_file.param")
+        self.mock_local_filesystem.copy_fc_values_to_file.assert_called_once()
+        mock_exit.assert_not_called()
+
+    @patch("sys.exit")
+    def test_should_copy_fc_values_to_file_no_response(self, mock_exit: MagicMock) -> None:
+        """Test handling 'No' response in the dialog."""
+        self.mock_local_filesystem.auto_changed_by.return_value = "External Tool"
+
+        # Create a fake dialog response mechanism - simulate "No" button click
+        def side_effect(*args, **kwargs) -> None:  # noqa: ARG001 # pylint: disable=unused-argument
+            # Find the "No" button callback and execute it
+            for call in self.mock_button.call_args_list:
+                _call_args, call_kwargs = call
+                if "text" in call_kwargs and call_kwargs["text"] == _("No"):
+                    # This is the "No" button - execute its command
+                    call_kwargs["command"]()
+                    break
+
+        # Set up the dialog behavior when wait_window is called
+        self.root.wait_window = MagicMock(side_effect=side_effect)
+
+        # Ensure the toplevel dialog has a result list that can be modified by the command
+        self.mock_dialog.result = [None]
+
+        self.parameter_editor._ParameterEditorWindow__should_copy_fc_values_to_file("test_file.param")  # pylint: disable=protected-access
+
+        self.mock_local_filesystem.auto_changed_by.assert_called_once_with("test_file.param")
+        self.mock_local_filesystem.copy_fc_values_to_file.assert_not_called()
+        mock_exit.assert_not_called()
+
+    @patch("sys.exit")
+    def test_should_copy_fc_values_to_file_close_response(self, mock_exit: MagicMock) -> None:
+        """Test handling 'Close' response in the dialog."""
+        self.mock_local_filesystem.auto_changed_by.return_value = "External Tool"
+
+        # Create a fake dialog response mechanism - simulate "Close" button click
+        def side_effect(*args, **kwargs) -> None:  # noqa: ARG001 # pylint: disable=unused-argument
+            # Find the "Close" button callback and execute it
+            for call in self.mock_button.call_args_list:
+                _call_args, call_kwargs = call
+                if "text" in call_kwargs and call_kwargs["text"] == _("Close"):
+                    # This is the "Close" button - execute its command
+                    call_kwargs["command"]()
+                    break
+
+        # Set up the dialog behavior when wait_window is called
+        self.root.wait_window = MagicMock(side_effect=side_effect)
+
+        # Ensure the toplevel dialog has a result list that can be modified by the command
+        self.mock_dialog.result = [None]
+
+        self.parameter_editor._ParameterEditorWindow__should_copy_fc_values_to_file("test_file.param")  # pylint: disable=protected-access
+
+        self.mock_local_filesystem.auto_changed_by.assert_called_once_with("test_file.param")
+        self.mock_local_filesystem.copy_fc_values_to_file.assert_not_called()
+        mock_exit.assert_called_once_with(0)
+
+    @patch("tkinter.Button")
+    def test_dialog_creation(self, mock_button: MagicMock) -> None:  # pylint: disable=unused-argument
+        """Test the creation of the dialog with its components."""
+        self.mock_local_filesystem.auto_changed_by.return_value = "External Tool"
+
+        # Don't let the test exit
+        with patch("sys.exit"):
+            # Replace wait_window with a mock that doesn't block
+            def fake_wait_window(*args: Any, **kwargs: Any) -> None:  # noqa: ANN401 # pylint: disable=unused-argument
+                pass
+
+            self.root.wait_window = MagicMock(side_effect=fake_wait_window)
+
+            # Ensure the toplevel dialog has a result list
+            self.mock_dialog.result = [None]
+
+            self.parameter_editor._ParameterEditorWindow__should_copy_fc_values_to_file("test_file.param")  # pylint: disable=protected-access
+
+        # Verify dialog creation
+        self.mock_toplevel.assert_called_once()
+
+        # Check for label, buttons, and frame creation
+        self.mock_label.assert_called_once()
+        self.mock_frame.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request includes several changes to the `ardupilot_methodic_configurator` project, focusing on improving the tkinter parameter editor and adding unit tests for better coverage. The most important changes include adding a new method to handle dialog choices, refactoring button command handling, and introducing comprehensive unit tests for the `ParameterEditorWindow` class.

Refactoring and improvements:

* [`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py`](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5R451-R454): Added the `__handle_dialog_choice` method to centralize dialog choice handling and refactored button commands to use this new method. [[1]](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5R451-R454) [[2]](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5L487-R508)

Testing enhancements:

* [`tests/test_frontend_tkinter_parameter_editor.py`](diffhunk://#diff-904878e910689c68c27caa359992da1808412e8c5986be0e37bb307a1ae4e2d3R1-R197): Added a new test file with unit tests for the `ParameterEditorWindow` class, including setup and teardown methods, and tests for different dialog responses (`Yes`, `No`, `Close`).

Type hinting:

* [`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py`](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5L24-R24): Updated import statements to include `Optional` from the `typing` module.Also fix some linting issues