### PR TITLE
Increase the test coverage threshold to 60%

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -139,7 +139,7 @@ jobs:
             echo "Pytest failed - failing coverage check"
             exit 1
           fi
-          coverage report --fail-under=51
+          coverage report --fail-under=60
 
   publish-test-results:
     if: always()
@@ -220,4 +220,4 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.55
+            thresholdAll: 0.60


### PR DESCRIPTION
This pull request includes updates to the coverage thresholds in the `pytest` workflow configuration. The changes increase the required coverage percentage for the project.

Changes to coverage thresholds:

* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL142-R142): Increased the `--fail-under` coverage threshold from 51 to 60.
* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL223-R223): Increased the `thresholdAll` coverage threshold from 0.55 to 0.60.