### PR TITLE
Automate updates of packages used in CI jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
       prefix: "build"
       include: "scope"
 
+  - package-ecosystem: "pip"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to add a new update configuration for the `pip` package ecosystem. This new configuration schedules weekly updates for dependencies located in the `.github/workflows` directory.

* Added a new `pip` package-ecosystem configuration for weekly updates in the `.github/workflows` directory.