### PR TITLE
Renovate creates PRs, so no need to do it extra

### DIFF
--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -25,15 +25,3 @@ jobs:
           configurationFile: renovate-config.json
         env:
           LOG_LEVEL: debug
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: deps, automated-pr
-          branch: renovate/pre-commit-hooks
-          title: "chore(deps): update pre-commit hooks"
-          commit-message: "chore(deps): update pre-commit hooks"
-          body: |
-            Updates pre-commit hook versions in .pre-commit-config.yaml
-          delete-branch: true

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:recommended"],
   "enabledManagers": ["pre-commit"],
+  "repositories": ["ArduPilot/MethodicConfigurator"],
   "packageRules": [
     {
       "matchManagers": ["pre-commit"],


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/renovate_pre_commit_hooks.yml` file to remove the step that creates a pull request for updating pre-commit hooks.

Changes in `jobs:`:

* Removed the step that uses `peter-evans/create-pull-request` to create a pull request for updating pre-commit hooks. This includes the removal of the associated parameters such as `token`, `labels`, `branch`, `title`, `commit-message`, `body`, and `delete-branch`.