### PR TITLE
Correct ESC_HW_POLES and MAGH_USE_LOITER values

### DIFF
--- a/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
+++ b/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
@@ -103,6 +103,7 @@
                 "MOT_HOVER_LEARN": { "New Value": 2, "Change Reason": "So that it can tune the throttle controller on 20_throttle_controller.param file" }
             },
             "derived_parameters": {
+                "ESC_HW_POLES": { "New Value": "vehicle_components['Motors']['Specifications']['Poles']", "Change Reason": "Specified in component editor window" },
                 "MOT_PWM_TYPE": { "New Value": "vehicle_components['ESC']['FC Connection']['Protocol']", "Change Reason": "Specified in component editor window" },
                 "SERVO_BLH_POLES": { "New Value": "vehicle_components['Motors']['Specifications']['Poles']", "Change Reason": "Specified in component editor window" },
                 "SERVO_FTW_POLES": { "New Value": "vehicle_components['Motors']['Specifications']['Poles']", "Change Reason": "Specified in component editor window" }

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/AirCar_v1/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/AirCar_v1/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Chimera7/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Chimera7/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/FETtec-5/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/FETtec-5/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/GazeboIrisWithTargetFollow/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/GazeboIrisWithTargetFollow/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Holybro_X500_V2/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Holybro_X500_V2/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Holybro_X650_LTE/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Holybro_X650_LTE/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X11+/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X11+/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,6  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Marmotte5v2/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Marmotte5v2/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/ReadyToSkyZD550/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/ReadyToSkyZD550/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Tarot_X4/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Tarot_X4/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/X11_plus/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/X11_plus/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.3.8-params/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.3.8-params/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.4.4-params/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.4.4-params/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.5.x-params/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.5.x-params/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.6.x-params/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/diatone_taycan_mxc/4.6.x-params/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints

--- a/ardupilot_methodic_configurator/vehicle_templates/Rover/AION_R1/24_inflight_magnetometer_fit_setup.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/Rover/AION_R1/24_inflight_magnetometer_fit_setup.param
@@ -5,4 +5,4 @@ MAGH_COUNT,6  # Number of times the drone repeats the eight
 MAGH_LOG_ENABLE,1  # Activates the logging of the MAGH.Active message
 MAGH_MIN_SPEED,5  # Starting speed for the mission; slowly adjusts to the general speed in auto-missions
 MAGH_NUM_WP,18  # Number of waypoints from which the eight is built
-MAGH_USE_LOITER,0  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints
+MAGH_USE_LOITER,1  # Sets a Loiter_unlimited command at the beginning of the mission to check the generated waypoints


### PR DESCRIPTION
This pull request includes multiple changes to the ArduPilot Methodic Configurator, focusing on updating parameter values for various vehicle templates and adding a new derived parameter in the configuration steps. The most important changes are summarized below:

### Configuration Steps Update:

* Added the `ESC_HW_POLES` derived parameter in the `configuration_steps_ArduCopter.json` file to specify the number of poles for the ESC hardware.

### Vehicle Templates Parameter Updates:

* Updated the `MAGH_USE_LOITER` parameter from `0` to `1` across multiple vehicle template files to set a Loiter_unlimited command at the beginning of the mission for checking generated waypoints. This change was applied to the following files:
  - `ArduCopter/AirCar_v1/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Chimera7/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/FETtec-5/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/GazeboIrisWithTargetFollow/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Holybro_X500_V2/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Holybro_X650_LTE/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Hoverit_X11+/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Marmotte5v2/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/ReadyToSkyZD550/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/Tarot_X4/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/X11_plus/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/diatone_taycan_mxc/4.3.8-params/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/diatone_taycan_mxc/4.4.4-params/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/diatone_taycan_mxc/4.5.x-params/24_inflight_magnetometer_fit_setup.param`
  - `ArduCopter/diatone_taycan_mxc/4.6.x-params/24_inflight_magnetometer_fit_setup.param`
  - `Rover/AION_R1/24_inflight_magnetometer_fit_setup.param`