### PR TITLE
Ignore ap periph

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -26,7 +26,7 @@ SPDX-FileCopyrightText = "2024-2025 Amilcar Lucas"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
-path = ["24_inflight_magnetometer_fit_setup.pdef.xml", "REUSE.toml", "SECURITY.md", "SetupDeveloperPC.bat", "SetupDeveloperPC.sh", "renovate-config.json"]
+path = ["24_inflight_magnetometer_fit_setup.pdef.xml", "REUSE.toml", "SECURITY.md", "SetupDeveloperPC.bat", "SetupDeveloperPC.sh", "renovate-config.json", "renovate.json"]
 SPDX-FileCopyrightText = "2024-2025 Amilcar Lucas"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 

--- a/update_flight_controller_ids.py
+++ b/update_flight_controller_ids.py
@@ -32,7 +32,10 @@ NON_FC_SUFIXES = (
     "-Periph",
     "-SimOnHardWare",
 )
-
+NON_FC_PREFIXES = (
+    "iomcu",
+    "TBS-L431",
+)
 HwdefDict = dict[str, tuple[int, int, int, str, str, str]]
 
 logging.basicConfig(level="INFO", format="%(asctime)s - %(levelname)s - %(message)s")
@@ -160,7 +163,7 @@ def create_dicts(  # pylint: disable=too-many-locals
 
     for dirname, (numeric_board_id, vid, pid, vid_name, pid_namef, mcu_series) in hwdef_data.items():
         if (
-            dirname.startswith("iomcu")
+            dirname.startswith(NON_FC_PREFIXES)
             or dirname.endswith(NON_FC_SUFIXES)
             or mcu_series.lower().startswith(("stm32f1", "stm32f3"))
             or (numeric_board_id == 1062 and dirname != "MatekL431")  # these AP_Periph are not an FC


### PR DESCRIPTION
This pull request includes changes to improve file annotations and update the logic for handling flight controller IDs. The most important changes include adding a new file to the `REUSE.toml` annotations and updating the `update_flight_controller_ids.py` script to use a new prefix list for non-flight controller directories.

File annotations:

* [`REUSE.toml`](diffhunk://#diff-74bd2d6afd7a1f967679adae374ca38fd9745fe6129dc4717a1ab0e388590b08L29-R29): Added `renovate.json` to the list of annotated files.

Flight controller ID updates:

* [`update_flight_controller_ids.py`](diffhunk://#diff-32745db632a2e925795d3266eba628b4d2bfaf006ac6f0facec845d0eda61cb8L35-R38): Introduced a new tuple `NON_FC_PREFIXES` to store prefixes for non-flight controller directories.
* [`update_flight_controller_ids.py`](diffhunk://#diff-32745db632a2e925795d3266eba628b4d2bfaf006ac6f0facec845d0eda61cb8L163-R166): Updated the `create_dicts` function to use `NON_FC_PREFIXES` instead of hardcoding the prefix "iomcu".