### PR TITLE
Check that a file exists before zipping it

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -439,7 +439,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         with ZipFile(zip_file_path, "w") as zipf:
             # Add all intermediate parameter files
             for file_name in self.file_parameters:
-                zipf.write(os_path.join(self.vehicle_dir, file_name), arcname=file_name)
+                self.add_configuration_file_to_zip(zipf, file_name)
                 # Add step-specific documentation metadata files
                 pdef_xml_file = file_name.replace(".param", ".pdef.xml")
                 self.add_configuration_file_to_zip(zipf, pdef_xml_file)


### PR DESCRIPTION
This pull request includes a change to the `zip_files` method in the `ardupilot_methodic_configurator/backend_filesystem.py` file. The change refactors the method to use a helper function for adding files to the zip archive.

Refactoring of `zip_files` method:

* [`ardupilot_methodic_configurator/backend_filesystem.py`](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716L442-R442): Modified the `zip_files` method to use the `add_configuration_file_to_zip` helper function for adding files to the zip archive.