### PR TITLE
Renovate permissions fixes

### DIFF
--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write      # Job-specific permission for creating branches
       pull-requests: write # Job-specific permission for creating PRs
+      issues: write        # for creating dashboard issues
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -12,5 +12,8 @@
   ],
   "pin": {
     "enabled": true
-  }
+  },
+  "platform": "github",
+  "includePaths": ["**/.pre-commit-config.yaml"],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/renovate_pre_commit_hooks.yml` and `renovate-config.json` files to enhance permissions and configuration settings for the Renovate bot.

Improvements to permissions and configuration:

* [`.github/workflows/renovate_pre_commit_hooks.yml`](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R17): Added `issues: write` permission to allow the creation of dashboard issues.
* [`renovate-config.json`](diffhunk://#diff-26dbe544619f8f0e948aabd7f14bb061b657807812430c7b5f0b1ae8972550bdL15-R18): Added `"platform": "github"`, `"includePaths": ["**/.pre-commit-config.yaml"]`, and set `"dependencyDashboard"` to `false` to refine the Renovate configuration.