### PR TITLE
Do not checkout the files.

### DIFF
--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -16,9 +16,6 @@ jobs:
       pull-requests: write # Job-specific permission for creating PRs
       issues: write        # for creating dashboard issues
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@cf5954a2aac7999882d3de4e462499adde159d04 # v41.0.17
         with:

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -13,7 +13,5 @@
   "pin": {
     "enabled": true
   },
-  "platform": "github",
-  "includePaths": ["**/.pre-commit-config.yaml"],
-  "dependencyDashboard": false
+  "platform": "github"
 }


### PR DESCRIPTION
This pull request includes changes to the Renovate configuration and workflow files to streamline the process and remove unnecessary steps.

Changes to `.github/workflows/renovate_pre_commit_hooks.yml`:

* Removed the checkout step from the workflow file, simplifying the job steps.

Changes to `renovate-config.json`:

* Removed the `includePaths` and `dependencyDashboard` settings from the configuration file, focusing the configuration on essential settings only.