### PR TITLE
One more renovate fix

### DIFF
--- a/.github/workflows/renovate_pre_commit_hooks.yml
+++ b/.github/workflows/renovate_pre_commit_hooks.yml
@@ -16,10 +16,13 @@ jobs:
       pull-requests: write # Job-specific permission for creating PRs
       issues: write        # for creating dashboard issues
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@cf5954a2aac7999882d3de4e462499adde159d04 # v41.0.17
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN }}
           configurationFile: renovate-config.json
         env:
           LOG_LEVEL: debug

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,6 +2,7 @@
   "extends": ["config:recommended"],
   "enabledManagers": ["pre-commit"],
   "repositories": ["ArduPilot/MethodicConfigurator"],
+  "includePaths": [".pre-commit-config.yaml"],
   "packageRules": [
     {
       "matchManagers": ["pre-commit"],
@@ -13,5 +14,13 @@
   "pin": {
     "enabled": true
   },
-  "platform": "github"
+  "platform": "github",
+  "dependencyDashboard": true,
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.pre-commit-config\\.yaml$"],
+      "matchStrings": ["- repo: (?<depName>.*?)\n\\s+rev: (?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "github-tags"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request includes changes to the `renovate` configuration and workflow files to improve dependency management and token usage. The most important changes are as follows:

### Workflow Improvements:

* [`.github/workflows/renovate_pre_commit_hooks.yml`](diffhunk://#diff-a91cb70ee674209a9822a445114d191b6de7b703216a452d61a1b92a20ea32f9R19-R25): Added a `Checkout` step using `actions/checkout@v4.2.2` and updated the token from `GITHUB_TOKEN` to `RENOVATE_TOKEN` for the `Self-hosted Renovate` step.

### Renovate Configuration Enhancements:

* [`renovate-config.json`](diffhunk://#diff-26dbe544619f8f0e948aabd7f14bb061b657807812430c7b5f0b1ae8972550bdR5): Added the `includePaths` configuration to include `.pre-commit-config.yaml` in the managed paths.
* [`renovate-config.json`](diffhunk://#diff-26dbe544619f8f0e948aabd7f14bb061b657807812430c7b5f0b1ae8972550bdL16-R25): Enabled the `dependencyDashboard` and added `regexManagers` to manage dependencies in `.pre-commit-config.yaml` using regex patterns.