### PR TITLE
Use newer SW versions in ci

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install 'mypy==1.15.0' 'types-requests==2.32.0.20241016'
+          python -m pip install 'mypy==1.15.0' 'types-requests==2.32.0.20250328'
 
       - name: Lint the code with mypy
         uses: sasanquaneuf/mypy-github-action@a3f3a66f97792cac0cfd11d3e5c87088e5c8f6a9 # releases/v1.3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install 'pip==25.0.1' 'coverage==7.6.12'
+          python -m pip install 'pip==25.0.1' 'coverage==7.8.0'
 
       - name: Check coverage
         run: |
@@ -139,7 +139,7 @@ jobs:
             echo "Pytest failed - failing coverage check"
             exit 1
           fi
-          coverage report --fail-under=60
+          coverage report --fail-under=55
 
   publish-test-results:
     if: always()

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -30,7 +30,7 @@ jobs:
       # Ruff does not need a specific python version installed
       - name: Install dependencies
         run: |
-          python -m pip install 'ruff==0.9.6'
+          python -m pip install 'ruff==0.11.2'
 
       - name: Lint with Ruff
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,6 @@ indent-width = 4
 "ardupilot_methodic_configurator/backend_mavftp.py" = ["PGH004", "N801", "ANN001"]
 "ardupilot_methodic_configurator/backend_mavftp_example.py" = ["ANN001"]
 "ardupilot_methodic_configurator/tempcal_imu.py" = ["ANN001"]
-"ardupilot_methodic_configurator/middleware_fc_ids.py" = ["E501"]
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
This pull request includes several updates to dependencies and configuration files across multiple workflows. The most important changes include updating dependencies in the `mypy`, `pytest`, and `ruff` workflows, adjusting the coverage threshold in the `pytest` workflow, and removing a configuration entry in `pyproject.toml`.

Dependency updates:

* [`.github/workflows/mypy.yml`](diffhunk://#diff-07730f31c368f5e0af82cb7d820dc37ae6a752a0a226f7aee9ebac72dfe41459L26-R26): Updated `types-requests` dependency to version `2.32.0.20250328`.
* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL133-R133): Updated `coverage` dependency to version `7.8.0`.
* [`.github/workflows/ruff.yml`](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L33-R33): Updated `ruff` dependency to version `0.11.2`.

Configuration changes:

* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL142-R142): Lowered the coverage report fail threshold from 60 to 55.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L204): Removed the configuration entry for `"ardupilot_methodic_configurator/middleware_fc_ids.py"`.