### PR TITLE
Added missing commas to ignore files in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ source = ardupilot_methodic_configurator
 
 [report]
 include = ardupilot_methodic_configurator/*
-omit = ardupilot_methodic_configurator/backend_mavftp.py, ardupilot_methodic_configurator/mavftp_example.py ardupilot_methodic_configurator/configuration_steps_strings.py ardupilot_methodic_configurator/vehicle_components.py
+omit = ardupilot_methodic_configurator/backend_mavftp.py, ardupilot_methodic_configurator/mavftp_example.py, ardupilot_methodic_configurator/configuration_steps_strings.py, ardupilot_methodic_configurator/vehicle_components.py


### PR DESCRIPTION
This pull request includes a minor change to the `.coveragerc` file, specifically to the `omit` list. The change corrects the formatting by adding missing commas between file names.

* [`.coveragerc`](diffhunk://#diff-834e9b406d74791ffbafaeec9cc894082cea9739bc347b6ff9f72312c92ebc79L6-R6): Added missing commas between file names in the `omit` list to ensure proper formatting.