### PR TITLE
Add a codeowners file to automate reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @username will be requested for review when someone opens a pull request.
+* @amilcarlucas
+
+# You can also specify multiple owners
+# *.js @username1 @username2
+
+# And you can specify owners for specific directories
+# /docs/ @username


### PR DESCRIPTION
This pull request includes a change to the `.github/CODEOWNERS` file. The change assigns a default owner for the entire repository and provides examples for specifying multiple owners and owners for specific directories.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R10): Added default owner `@amilcarlucas` for the entire repository and included examples for specifying multiple owners and owners for specific directories.