### PR TITLE
Disable renovate dashboard, we only have one application in one repo

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -13,7 +13,7 @@
   ],
   "pin": {"enabled": true},
   "platform": "github",
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
This pull request includes a small change to the `renovate-config.json` file. The change disables the `dependencyDashboard` feature.

* [`renovate-config.json`](diffhunk://#diff-26dbe544619f8f0e948aabd7f14bb061b657807812430c7b5f0b1ae8972550bdL16-R16): Changed the `dependencyDashboard` setting from `true` to `false`.