### PR TITLE
Add two new strings

### DIFF
--- a/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -760,7 +760,7 @@ msgstr "Neue Version für Windows wird heruntergeladen und installiert..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:185
 msgid "Failed to download installer from %s"
-msgstr ""
+msgstr "Fehler beim Herunterladen des Installers von %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:189
 #: ardupilot_methodic_configurator/backend_internet.py:239
@@ -769,7 +769,7 @@ msgstr "Installation wird gestartet..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:215
 msgid "Installation ready. Application will restart now."
-msgstr ""
+msgstr "Installation bereit. Die Anwendung wird jetzt neu gestartet."
 
 #: ardupilot_methodic_configurator/backend_internet.py:229
 msgid "Installation failed: {}"

--- a/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -756,7 +756,7 @@ msgstr "Download e installazione della nuova versione per Windows..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:185
 msgid "Failed to download installer from %s"
-msgstr ""
+msgstr "Impossibile scaricare il programma di installazione da %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:189
 #: ardupilot_methodic_configurator/backend_internet.py:239
@@ -765,7 +765,7 @@ msgstr "Avvio installazione..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:215
 msgid "Installation ready. Application will restart now."
-msgstr ""
+msgstr "Installazione pronta. L'applicazione verrà riavviata ora."
 
 #: ardupilot_methodic_configurator/backend_internet.py:229
 msgid "Installation failed: {}"

--- a/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -746,7 +746,7 @@ msgstr "Windows用の新バージョンをダウンロードしてインスト�
 
 #: ardupilot_methodic_configurator/backend_internet.py:185
 msgid "Failed to download installer from %s"
-msgstr ""
+msgstr "%s からインストーラーのダウンロードに失敗しました"
 
 #: ardupilot_methodic_configurator/backend_internet.py:189
 #: ardupilot_methodic_configurator/backend_internet.py:239
@@ -755,7 +755,7 @@ msgstr "インストールを開始しています..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:215
 msgid "Installation ready. Application will restart now."
-msgstr ""
+msgstr "インストールの準備ができました。アプリケーションは今再起動します。"
 
 #: ardupilot_methodic_configurator/backend_internet.py:229
 msgid "Installation failed: {}"

--- a/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -751,7 +751,7 @@ msgstr "A transferir e instalar nova versão para Windows..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:185
 msgid "Failed to download installer from %s"
-msgstr ""
+msgstr "Falha ao transferir o instalador de %s"
 
 #: ardupilot_methodic_configurator/backend_internet.py:189
 #: ardupilot_methodic_configurator/backend_internet.py:239
@@ -760,7 +760,7 @@ msgstr "A iniciar instalação..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:215
 msgid "Installation ready. Application will restart now."
-msgstr ""
+msgstr "Instalação pronta. A aplicação irá reiniciar agora."
 
 #: ardupilot_methodic_configurator/backend_internet.py:229
 msgid "Installation failed: {}"

--- a/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -727,7 +727,7 @@ msgstr "正在下载并安装Windows新版本..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:185
 msgid "Failed to download installer from %s"
-msgstr ""
+msgstr "无法从 %s 下载安装程序"
 
 #: ardupilot_methodic_configurator/backend_internet.py:189
 #: ardupilot_methodic_configurator/backend_internet.py:239
@@ -736,7 +736,7 @@ msgstr "开始安装..."
 
 #: ardupilot_methodic_configurator/backend_internet.py:215
 msgid "Installation ready. Application will restart now."
-msgstr ""
+msgstr "安装准备就绪。应用程序将立即重启。"
 
 #: ardupilot_methodic_configurator/backend_internet.py:229
 msgid "Installation failed: {}"


### PR DESCRIPTION
This pull request includes updates to the localization files for several languages in the `ardupilot_methodic_configurator` project. These changes add missing translations for specific messages related to the download and installation process.

Localization updates:

* [`ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po`](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L763-R763): Added missing German translations for messages related to downloading and installing the application. [[1]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L763-R763) [[2]](diffhunk://#diff-e5a670f01a48bd932948f31f1faa9864eec8b91a4e773129f71cccffc577df99L772-R772)
* [`ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po`](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L759-R759): Added missing Italian translations for messages related to downloading and installing the application. [[1]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L759-R759) [[2]](diffhunk://#diff-4b7f7da744af354609e0294bba567cb343ffc8899a10107ca6ba4ae38c826554L768-R768)
* [`ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po`](diffhunk://#diff-c90d1ba3c3da44e6988d72a0e2dd5fc16faa6362b9ac2dc1f83058182a82b5edL749-R749): Added missing Japanese translations for messages related to downloading and installing the application. [[1]](diffhunk://#diff-c90d1ba3c3da44e6988d72a0e2dd5fc16faa6362b9ac2dc1f83058182a82b5edL749-R749) [[2]](diffhunk://#diff-c90d1ba3c3da44e6988d72a0e2dd5fc16faa6362b9ac2dc1f83058182a82b5edL758-R758)
* [`ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po`](diffhunk://#diff-ece30c69aff1420c53cdec7048f5ecc23f3859ad26f1414e6b17b98eb9b1d240L754-R754): Added missing Portuguese translations for messages related to downloading and installing the application. [[1]](diffhunk://#diff-ece30c69aff1420c53cdec7048f5ecc23f3859ad26f1414e6b17b98eb9b1d240L754-R754) [[2]](diffhunk://#diff-ece30c69aff1420c53cdec7048f5ecc23f3859ad26f1414e6b17b98eb9b1d240L763-R763)
* [`ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po`](diffhunk://#diff-fa8481cdc2ad5f04dc4237fea04cf3f648fb46f822cd970f5db8e32ed97e8ffaL730-R730): Added missing Chinese translations for messages related to downloading and installing the application. [[1]](diffhunk://#diff-fa8481cdc2ad5f04dc4237fea04cf3f648fb46f822cd970f5db8e32ed97e8ffaL730-R730) [[2]](diffhunk://#diff-fa8481cdc2ad5f04dc4237fea04cf3f648fb46f822cd970f5db8e32ed97e8ffaL739-R739)