### PR TITLE
More unit tests

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
@@ -455,15 +455,16 @@ class VehicleComponents:
             elif isinstance(value, list):
                 # If it's a list, preserve it but empty it
                 data[key] = []
-            elif isinstance(value, (int, float)):
-                # For numerical values, set to 0
-                data[key] = 0 if isinstance(value, int) else 0.0
             elif isinstance(value, bool):
-                # For boolean values, set to False
                 data[key] = False
+            elif isinstance(value, int):
+                data[key] = 0
+            elif isinstance(value, float):
+                data[key] = 0.0
+            elif isinstance(value, str):
+                data[key] = ""
             else:
-                # For strings and other types, set to empty string or None
-                data[key] = "" if isinstance(value, str) else None
+                data[key] = None
 
     def get_component_property_description(self, path: tuple[str, ...]) -> tuple[str, bool]:
         """


### PR DESCRIPTION
This pull request includes several changes to the `ardupilot_methodic_configurator` project, focusing on enhancing the `ConfigurationSteps` and `VehicleComponents` functionalities and improving test coverage. The most important changes include refactoring the `_recursively_clear_dict` method, adding new test cases, and importing necessary modules.

Refactoring and bug fixes:

* [`ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py`](diffhunk://#diff-4d082af14c1239b3a9772b04b19d0ba7bc6a11c6675c8dae7d127dcb65ab7d92L458-R467): Refactored the `_recursively_clear_dict` method to handle different data types more explicitly, ensuring numerical values are set to 0 or 0.0, and strings are set to an empty string.

Test coverage improvements:

* [`tests/test_backend_filesystem_configuration_steps.py`](diffhunk://#diff-7b0552b94b71e24191618c017a961224b98a67b3f84a022229a73088db121f52R117-R464): Added multiple new test cases to cover various scenarios such as handling file not found errors, JSON decode errors, computing parameters with different types of values, and validating parameters.
* [`tests/test_backend_filesystem_vehicle_components.py`](diffhunk://#diff-8c424135c193ff93090364a9e2f78626833099dc0230a31ceebcfe880cf0875aR15): Imported `JSONDecodeError` from `json.decoder` to handle JSON decode errors in tests.

Module imports:

* [`tests/test_backend_filesystem_configuration_steps.py`](diffhunk://#diff-7b0552b94b71e24191618c017a961224b98a67b3f84a022229a73088db121f52R14-R20): Added import for `JSONDecodeError` and included a `# ruff: noqa: SIM117` comment to suppress specific linting warnings.