### PR TITLE
Code simplification and pyright linter fixes

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -182,12 +182,10 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         try:
             for i, (param_name, param) in enumerate(params.items(), 1):
                 current_param_name = param_name
-                param_metadata = self.local_filesystem.doc_dict.get(param_name, None)
+                param_metadata = self.local_filesystem.doc_dict.get(param_name, {})
                 param_default = self.local_filesystem.param_default_dict.get(param_name, None)
-                doc_tooltip = (
-                    param_metadata.get("doc_tooltip")
-                    if param_metadata
-                    else _("No documentation available in apm.pdef.xml for this parameter")
+                doc_tooltip = param_metadata.get(
+                    "doc_tooltip", _("No documentation available in apm.pdef.xml for this parameter")
                 )
 
                 column: list[tk.Widget] = []
@@ -240,8 +238,8 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         return delete_button
 
     def __create_parameter_name(self, param_name: str, param_metadata: dict[str, Any], doc_tooltip: str) -> ttk.Label:
-        is_calibration = param_metadata.get("Calibration", False) if param_metadata else False
-        is_readonly = param_metadata.get("ReadOnly", False) if param_metadata else False
+        is_calibration = param_metadata.get("Calibration", False)
+        is_readonly = param_metadata.get("ReadOnly", False)
         parameter_label = ttk.Label(
             self.view_port,
             text=param_name + (" " * (16 - len(param_name))),
@@ -472,11 +470,9 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         window.wait_window()  # Wait for the window to be closed
 
     def __create_unit_label(self, param_metadata: dict[str, Union[float, str]]) -> ttk.Label:
-        unit_label = ttk.Label(self.view_port, text=param_metadata.get("unit", "") if param_metadata else "")
+        unit_label = ttk.Label(self.view_port, text=param_metadata.get("unit", ""))
         unit_tooltip = str(
-            param_metadata.get("unit_tooltip")
-            if param_metadata
-            else _("No documentation available in apm.pdef.xml for this parameter")
+            param_metadata.get("unit_tooltip", _("No documentation available in apm.pdef.xml for this parameter"))
         )
         if unit_tooltip:
             show_tooltip(unit_label, unit_tooltip)

--- a/tests/test_frontend_tkinter_template_overview.py
+++ b/tests/test_frontend_tkinter_template_overview.py
@@ -22,7 +22,9 @@ from ardupilot_methodic_configurator.backend_filesystem_program_settings import 
 from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
 from ardupilot_methodic_configurator.frontend_tkinter_template_overview import TemplateOverviewWindow, argument_parser, main
 
-# pylint: disable=unused-argument,protected-access
+# pylint: disable=useless-suppression
+# pylint: disable=unused-argument,protected-access,invalid-name
+# pylint: enable=useless-suppression
 # ruff: noqa: ARG001
 
 
@@ -401,8 +403,8 @@ class TestTemplateOverviewWindow(unittest.TestCase):
             window.tree = MagicMock()
 
             # Create mocks for the private methods using the correct name mangling format
-            window._TemplateOverviewWindow__on_row_selection_change = MagicMock()  # pylint: disable=invalid-name
-            window._TemplateOverviewWindow__on_row_double_click = MagicMock()  # pylint: disable=invalid-name
+            window._TemplateOverviewWindow__on_row_selection_change = MagicMock()
+            window._TemplateOverviewWindow__on_row_double_click = MagicMock()
 
             # Manually call the binding code
             window.tree.bind("<ButtonRelease-1>", window._TemplateOverviewWindow__on_row_selection_change)
@@ -434,7 +436,7 @@ def test_column_heading_command(mock_vehicle_components, mock_toplevel) -> None:
         window.tree["columns"] = ["col1", "col2"]
 
         # Create a mock for __sort_by_column that we can track
-        window._TemplateOverviewWindow__sort_by_column = MagicMock()  # pylint: disable=invalid-name
+        window._TemplateOverviewWindow__sort_by_column = MagicMock()
 
         # Directly call heading for each column instead of using a loop
         window.tree.heading(
@@ -797,7 +799,7 @@ def test_on_row_selection_change_with_logging(
         window.root.after.side_effect = safe_after
 
         # Create a mock update_selection that raises an exception
-        window._TemplateOverviewWindow__update_selection = MagicMock(side_effect=Exception("Test exception"))  # pylint: disable=invalid-name
+        window._TemplateOverviewWindow__update_selection = MagicMock(side_effect=Exception("Test exception"))
 
         # Call the method
         window._TemplateOverviewWindow__on_row_selection_change(mock_event)


### PR DESCRIPTION
This pull request focuses on improving code readability and simplifying logic in the `ardupilot_methodic_configurator` module, as well as cleaning up test files by removing redundant pylint suppressions. The key changes include replacing unnecessary conditional checks, streamlining tooltip logic, and refining test code.

### Code readability and logic simplification:
* Simplified the retrieval of `doc_tooltip` in `__update_table` by using a default value directly in the `get` method, removing redundant conditional checks (`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py`, [ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.pyL185-R188](diffhunk://#diff-a1fc77b2f824d73d73195abb5559fad566982d510708937a5c52ba2c86de71acL185-R188)).
* Removed unnecessary conditional checks for `param_metadata` in `__create_parameter_name` and `__create_unit_label`, directly using default values in the `get` method (`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py`, [[1]](diffhunk://#diff-a1fc77b2f824d73d73195abb5559fad566982d510708937a5c52ba2c86de71acL243-R242) [[2]](diffhunk://#diff-a1fc77b2f824d73d73195abb5559fad566982d510708937a5c52ba2c86de71acL475-R475).

### Test file cleanup:
* Removed redundant pylint suppression comments, such as `invalid-name`, where they were no longer necessary (`tests/test_frontend_tkinter_template_overview.py`, [tests/test_frontend_tkinter_template_overview.pyL25-R27](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L25-R27)).
* Cleaned up test methods by removing pylint suppressions from mock private method assignments, improving consistency across the test suite (`tests/test_frontend_tkinter_template_overview.py`, [[1]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L404-R407) [[2]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L437-R439) [[3]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L800-R802).