### PR TITLE
Remove outdated and misleading screenshot.

### DIFF
--- a/TUNING_GUIDE_ArduCopter.md
+++ b/TUNING_GUIDE_ArduCopter.md
@@ -409,8 +409,6 @@ If it doesn't, go back and perform the missing calibration(s).
 
 ## 6.12 Configure Logging
 
-![MP LOG_BITMASK parameter](images/blog/mp_logging_bitmask.png)
-
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `14_Logging.param` file
 
 For vehicles with weak F4 processors, small propellers, low-speed microSDcards, **or** simply not capable of gyro raw logging,

--- a/USECASES.md
+++ b/USECASES.md
@@ -18,6 +18,16 @@ But there are other use cases as well:
 
 ## Use the *ArduPilot Methodic Configurator* software for the first time
 
+It is recommended to start with default parameter values on your flight controller as it guarantees that all parameters have sane values and
+provides a clean baseline for the configuration process.
+This is especially important for new vehicles or when you've made significant changes to your setup.
+
+If your vehicle is already operating correctly and you're just making minor adjustments, you do not need to reset the parameters to their default values
+as this would require reconfiguring everything from scratch.
+
+The ArduPilot documentation explains [how to reset all parameters to their default value](https://ardupilot.org/copter/docs/common-parameter-reset.html)
+if you decide this is the best approach for your situation.
+
 1. Close all other GCS software (MissionPlanner, QGroundControl, MAVProxy, DroneKit-Python, APM Planner 2.0, UgCS, LOGOS, Tower, AndroPilot, etc)
 the *ArduPilot Methodic Configurator* needs connection exclusivity.
 1. Connect the flight controller to the computer using a USB cable.


### PR DESCRIPTION
This pull request includes updates to documentation files to improve clarity and provide additional guidance for users. The most important changes include removing an unused image reference in the tuning guide and adding detailed recommendations for parameter management in the use cases guide.

### Documentation improvements:

* [`TUNING_GUIDE_ArduCopter.md`](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL412-L413): Removed a reference to an unused image (`mp_logging_bitmask.png`) to streamline the tuning guide.
* [`USECASES.md`](diffhunk://#diff-4e820b515938539a318b7a796ae98a44f3f4968e82ea5be4ca8f7552b4dfa340R21-R30): Added recommendations for starting with default parameter values and provided a link to ArduPilot documentation on resetting parameters, offering clearer guidance for new or significantly modified vehicles.