### PR TITLE
More version pinning and automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
     directory: "/.github/workflows"
@@ -15,9 +16,19 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    allow:
+      - dependency-type: "all"
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
     schedule:
       interval: "monthly"
     commit-message:

--- a/.github/workflows/dependabot-apt-update.yml
+++ b/.github/workflows/dependabot-apt-update.yml
@@ -1,0 +1,82 @@
+name: Check apt dependencies for updates
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  check-apt-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Check for apt package updates
+        run: |
+          # Create a list of all pinned apt packages from github workflow files
+          grep -r "apt-get install" .github/workflows/ | grep -o "[a-zA-Z0-9\-\._+~:]*=[a-zA-Z0-9\.\-+~:]*" > pinned_apt_packages.txt
+          
+          # Create report file header
+          echo "# Apt Package Update Report" > apt_update_report.md
+          echo "Generated on $(date)" >> apt_update_report.md
+          echo "" >> apt_update_report.md
+          
+          if [ -s pinned_apt_packages.txt ]; then
+            echo "Checking these pinned apt packages for updates:"
+            cat pinned_apt_packages.txt
+            
+            echo "## Pinned Packages" >> apt_update_report.md
+            echo "" >> apt_update_report.md
+            echo "| Package | Current Version | Latest Version | Update Available |" >> apt_update_report.md
+            echo "|---------|----------------|---------------|-----------------|" >> apt_update_report.md
+            
+            # Update apt database
+            sudo apt-get update
+            
+            updates_available=false
+            
+            # Check each package for available updates
+            while read package; do
+              pkg_name=${package%=*}
+              current_version=${package#*=}
+              available_version=$(apt-cache policy $pkg_name | grep Candidate | awk '{print $2}')
+              
+              echo "Package: $pkg_name"
+              echo "  Current pinned version: $current_version"
+              echo "  Latest available version: $available_version"
+              echo ""
+              
+              if [ "$current_version" != "$available_version" ]; then
+                update_status="Yes"
+                updates_available=true
+              else
+                update_status="No"
+              fi
+              
+              echo "| $pkg_name | $current_version | $available_version | $update_status |" >> apt_update_report.md
+            done < pinned_apt_packages.txt
+            
+            echo "" >> apt_update_report.md
+            if [ "$updates_available" = true ]; then
+              echo "## Action Required" >> apt_update_report.md
+              echo "Please update the pinned versions in the workflow files to the latest available versions." >> apt_update_report.md
+            else
+              echo "## No Action Required" >> apt_update_report.md
+              echo "All pinned packages are up to date." >> apt_update_report.md
+            fi
+            
+            echo "Check complete. Manual update required for any outdated packages."
+          else
+            echo "No pinned apt packages found in workflow files." 
+            echo "## No Pinned Packages Found" >> apt_update_report.md
+            echo "No pinned apt packages were found in the workflow files." >> apt_update_report.md
+          fi
+      
+      - name: Create issue for outdated packages
+        if: ${{ success() }}
+        uses: peter-evans/create-issue-from-file@v5.0.1 # v5.0.1
+        with:
+          title: Outdated apt packages in workflows
+          content-filepath: ./apt_update_report.md
+          labels: dependencies, apt

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install apt gettext package
         run: |
           sudo apt-get update
-          sudo apt-get install -y gettext
+          sudo apt-get install -y gettext=0.21-14ubuntu2
 
       - name: Install python-gettext requirement
         run: |

--- a/.github/workflows/update_mo_files.yml
+++ b/.github/workflows/update_mo_files.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y gettext
+          sudo apt-get install -y gettext=0.21-14ubuntu2
 
       - name: Compile translation .mo files from the .po files
         run: python create_mo_files.py


### PR DESCRIPTION
This pull request introduces updates to the Dependabot configuration, adds a new workflow for tracking apt package updates, and pins specific versions of the `gettext` package in existing workflows. These changes aim to improve dependency management and ensure consistency in the development environment.

### Dependabot Configuration Updates:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10): Added a limit of 10 open pull requests for Dependabot and allowed updates for all dependency types. Introduced a new monthly update schedule for `github-actions` dependencies in the `.github/workflows` directory. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R19-R20) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R29-R36)

### New Workflow for Apt Package Updates:
* [`.github/workflows/dependabot-apt-update.yml`](diffhunk://#diff-e099fd6fa1c015c032d0c543d91235b3572c3bfeb96b53300b3d41054ef122b2R1-R82): Added a new workflow to check for updates to apt packages used in GitHub workflows. The workflow runs weekly and generates a report on outdated packages, optionally creating an issue if updates are required.

### Pinned Versions for `gettext`:
* [`.github/workflows/i18n-extract.yml`](diffhunk://#diff-2d579475fad26e1d128dc2d45de56003325cc16a838bd385822f9179d1254b6eL42-R42): Pinned the `gettext` package to version `0.21-14ubuntu2` to ensure consistency across environments.
* [`.github/workflows/update_mo_files.yml`](diffhunk://#diff-079456a054c5d473e34523ec3c59b6eee56654682a5e4a0bdefcacfdd7809c61L38-R38): Similarly, pinned the `gettext` package to version `0.21-14ubuntu2` in the workflow for updating `.mo` translation files.