### PR TITLE
Updated translation strings

### DIFF
--- a/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -4592,7 +4592,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:77
 msgid "No suitable assets found for Windows installation"
-msgstr ""
+msgstr "Keine geeigneten Assets für die Windows-Installation gefunden"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:86
 msgid "Error accessing release assets: %s"
@@ -4600,11 +4600,11 @@ msgstr "Fehler beim Zugriff auf Release-Assets: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:89
 msgid "Error during Windows download: %s"
-msgstr ""
+msgstr "Fehler beim Windows-Download: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:97
 msgid "Error during pip installation: %s"
-msgstr ""
+msgstr "Fehler bei der pip-Installation: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:107
 msgid "Already running latest version."

--- a/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -4590,7 +4590,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:77
 msgid "No suitable assets found for Windows installation"
-msgstr ""
+msgstr "Nessun asset adatto trovato per l'installazione di Windows"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:86
 msgid "Error accessing release assets: %s"
@@ -4598,11 +4598,11 @@ msgstr "Errore nell'accesso agli asset della release: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:89
 msgid "Error during Windows download: %s"
-msgstr ""
+msgstr "Errore durante il download di Windows: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:97
 msgid "Error during pip installation: %s"
-msgstr ""
+msgstr "Errore durante l'installazione di pip: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:107
 msgid "Already running latest version."

--- a/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -4403,7 +4403,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:77
 msgid "No suitable assets found for Windows installation"
-msgstr ""
+msgstr "Windows インストール用の適切なアセットが見つかりません"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:86
 msgid "Error accessing release assets: %s"
@@ -4411,11 +4411,11 @@ msgstr "リリースアセットへのアクセス中にエラーが発生しま
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:89
 msgid "Error during Windows download: %s"
-msgstr ""
+msgstr "Windows ダウンロード中にエラーが発生しました: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:97
 msgid "Error during pip installation: %s"
-msgstr ""
+msgstr "pip インストール中にエラーが発生しました: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:107
 msgid "Already running latest version."

--- a/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -4534,7 +4534,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:77
 msgid "No suitable assets found for Windows installation"
-msgstr ""
+msgstr "Não foram encontrados recursos adequados para a instalação do Windows"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:86
 msgid "Error accessing release assets: %s"
@@ -4542,11 +4542,11 @@ msgstr "Erro ao aceder aos recursos da versão: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:89
 msgid "Error during Windows download: %s"
-msgstr ""
+msgstr "Erro durante o download do Windows: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:97
 msgid "Error during pip installation: %s"
-msgstr ""
+msgstr "Erro durante a instalação do pip: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:107
 msgid "Already running latest version."

--- a/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -4232,7 +4232,7 @@ msgstr ""
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:77
 msgid "No suitable assets found for Windows installation"
-msgstr ""
+msgstr "未找到适用于Windows安装的合适资源"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:86
 msgid "Error accessing release assets: %s"
@@ -4240,11 +4240,11 @@ msgstr "访问发布资源时出错：%s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:89
 msgid "Error during Windows download: %s"
-msgstr ""
+msgstr "Windows下载过程中出错: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:97
 msgid "Error during pip installation: %s"
-msgstr ""
+msgstr "pip安装过程中出错: %s"
 
 #: ardupilot_methodic_configurator/middleware_software_updates.py:107
 msgid "Already running latest version."


### PR DESCRIPTION
This pull request updates translations for error messages in the `ardupilot_methodic_configurator` project across multiple languages. The changes provide localized strings for untranslated messages related to software updates, improving user experience for non-English speakers.

### Translation Updates:

* **German (`de`)**:
  - Added translations for messages related to Windows installation, download errors, and pip installation.

* **Italian (`it`)**:
  - Added translations for similar messages, including errors during Windows download and pip installation.

* **Japanese (`ja`)**:
  - Provided translations for error messages concerning Windows installation, download, and pip installation.

* **Portuguese (`pt`)**:
  - Localized error messages regarding Windows installation, download, and pip installation.

* **Simplified Chinese (`zh_CN`)**:
  - Added translations for error messages related to Windows installation, download, and pip installation.