### PR TITLE
ci(update vehicle templates): only update them on the master branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,14 +20,6 @@ updates:
       - dependency-type: "all"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-
-  - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "monthly"

--- a/.github/workflows/update_vehicle_templates.yml
+++ b/.github/workflows/update_vehicle_templates.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '30 3 * * 1,3,5'  # Run at 3:30 UTC on Monday, Wednesday, and Friday
   push:
+    branches:
+      - master
     paths:
       - 'update_vehicle_templates.py'
       - 'ardupilot_methodic_configurator/vehicle_templates/**'


### PR DESCRIPTION
This pull request includes updates to the Dependabot configuration and workflow triggers to improve dependency management and workflow execution control.

### Dependabot Configuration Changes:
* Removed a redundant `github-actions` package-ecosystem entry for the root directory in `.github/dependabot.yml`. This simplifies the configuration by retaining only the relevant entry for workflows under `/.github/workflows`.

### Workflow Trigger Updates:
* Updated the `push` trigger in `.github/workflows/update_vehicle_templates.yml` to include the `master` branch, ensuring the workflow runs only for changes pushed to the `master` branch.