### PR TITLE
ci(permissions): restricted permisions

### DIFF
--- a/.github/workflows/dependabot-apt-update.yml
+++ b/.github/workflows/dependabot-apt-update.yml
@@ -5,9 +5,14 @@ on:
     - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   check-apt-updates:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for `dependabot-apt-update` by adding permissions to enhance security and functionality.

### Workflow configuration updates:

* [`.github/workflows/dependabot-apt-update.yml`](diffhunk://#diff-e099fd6fa1c015c032d0c543d91235b3572c3bfeb96b53300b3d41054ef122b2R8-R15): Added `permissions` at the workflow level with `contents: read` to limit access to repository contents and at the job level with `issues: write` to allow the job to create or modify issues.