### PR TITLE
Update the change reason tooltip when the param value changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,6 @@ updates:
       include: "scope"
     open-pull-requests-limit: 10
 
-  - package-ecosystem: "pip"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-    allow:
-      - dependency-type: "all"
-
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:

--- a/TUNING_GUIDE_ArduCopter.md
+++ b/TUNING_GUIDE_ArduCopter.md
@@ -97,7 +97,7 @@ Use Mission Planner to flash the latest stable [ArduCopter](https://firmware.ard
 
 ## 2.1 Used software summary
 
-The table bellow summarizes the software used in this guide. Download and install them as you progress in the guide.
+The table below summarizes the software used in this guide. Download and install them as you progress in the guide.
 
 | Software | Version | Description |
 |:----|:----|:----|
@@ -295,7 +295,7 @@ Propeller size has a big influence on the vehicle dynamics, this adapts controll
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `11_initial_atc.param` file
 
-When asked *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 ## 6.9 Configure "Mandatory Hardware" Parameters
 
@@ -384,8 +384,8 @@ Now do some general configuration
 
 1. Connect the flight controller to the PC
 1. Start *ArduPilot Methodic Configurator* and select the vehicle directory where you previously stored your *intermediate parameter files*.
-1. When *ArduPilot Methodic Configurator* asks you *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `Yes`
-1. Select `13_general_configuration.param` on the *Current intermediate parameter file:* Combobox.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `12_mp_setup_mandatory_hardware.param` file because you've completed the experiment.
+1. Press `Upload selected params to FC, and advance to next file` button.
 1. Read the documentation links inside the `13_general_configuration.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
@@ -620,7 +620,7 @@ The estimation will be improved after the first flight.
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `18_notch_filter_setup.param` file
 
-When asked *Should the FC values now be copied to the 19_notch_filter_results.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 # 7. Assemble propellers and perform the first flight
 
@@ -643,7 +643,7 @@ Land and disarm.
 
 > [!IMPORTANT]
 > If your vehicle is very overpowered and requires a [MOT_THST_HOVER](https://ardupilot.org/copter/docs/parameters.html#mot-thst-hover)
-> level close to or bellow 0.2 you will need to set the [MOT_HOVER_LEARN](https://ardupilot.org/copter/docs/parameters.html#mot-hover-learn)
+> level close to or below 0.2 you will need to set the [MOT_HOVER_LEARN](https://ardupilot.org/copter/docs/parameters.html#mot-hover-learn)
 > parameter to 0 (using the `Add` button on the GUI) and follow the [setting hover throttle instructions](https://ardupilot.org/copter/docs/ac_throttlemid.html)
 
 ### 7.1.1 Check for Motor Output Oscillation
@@ -722,7 +722,7 @@ These are the very minimum tuning steps required for a stable flight:
 
 Load the `.bin` log from the first flight onto the [online Ardupilot Filter Review tool](https://firmware.ardupilot.org/Tools/WebTools/FilterReview/)
 Follow the [instructions from Peter Hall on his Blog Post](https://discuss.ardupilot.org/t/new-fft-filter-setup-and-review-web-tool/102572) to configure the Harmonic Notch filter(s).
-Noise levels bellow -50dB are considered good enough.
+Noise levels below -50dB are considered good enough.
 Do not use notch filters to reduce noise bellow that level as it introduces unwanted signal lag.
 The graph below is a bode diagram of the gyro signals before and after the low-pass and Harmonic Notch filters.
 As you can see, the filters remove most of the vibration noise from the gyro sensors.
@@ -786,7 +786,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `23_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 23_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `23_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -816,8 +816,7 @@ Follow these steps before the flight:
 1. Read the documentation links inside the `24_inflight_magnetometer_fit_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the MagFit figure-eight flight and land
 
@@ -829,7 +828,7 @@ Perform the MagFit figure-eight flight and land
 1. Perform the MagFit calculations. Save the tool-generated file as `25_inflight_magnetometer_fit_results.param` in your vehicle's intermediate parameter file directory.
 1. Connect your flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_inflight_magnetometer_fit_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `No`.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -858,8 +857,7 @@ Setup the lua script using:
 1. Read the documentation links inside the `24_quicktune_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the flight and afterward:
 
@@ -867,7 +865,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `25_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -935,14 +933,14 @@ Follow the sequence below for tuning each axis as that particular order improves
 ### 9.5.1 Roll axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `30_autotune_roll_setup.param` and upload it to the FC. It will activate the roll axis Autotune.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either [`AltHold`](https://ardupilot.org/copter/docs/altholdmode.html) or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the Autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `31_autotune_roll_results.param`.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `31_autotune_roll_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 
@@ -963,14 +961,14 @@ If the battery got depleted before Autotune completion, change the initial PID p
 ### 9.5.2 Pitch axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `32_autotune_pitch_setup.param` and upload it to the FC. It will activate the pitch axis Autotune.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either `AltHold` or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC Transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `33_autotune_pitch_results.param`.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `33_autotune_pitch_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 

--- a/TUNING_GUIDE_ArduPlane.md
+++ b/TUNING_GUIDE_ArduPlane.md
@@ -97,7 +97,7 @@ Use Mission Planner to flash the latest stable [ArduCopter](https://firmware.ard
 
 ## 2.1 Used software summary
 
-The table bellow summarizes the software used in this guide. Download and install them as you progress in the guide.
+The table below summarizes the software used in this guide. Download and install them as you progress in the guide.
 
 | Software | Version | Description |
 |:----|:----|:----|
@@ -295,7 +295,7 @@ Propeller size has a big influence on the vehicle dynamics, this adapts controll
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `11_initial_atc.param` file
 
-When asked *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 ## 6.9 Configure "Mandatory Hardware" Parameters
 
@@ -384,8 +384,8 @@ Now do some general configuration
 
 1. Connect the flight controller to the PC
 1. Start *ArduPilot Methodic Configurator* and select the vehicle directory where you previously stored your *intermediate parameter files*.
-1. When *ArduPilot Methodic Configurator* asks you *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `Yes`
-1. Select `13_general_configuration.param` on the *Current intermediate parameter file:* Combobox.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `12_mp_setup_mandatory_hardware.param` file because you've completed the experiment.
+1. Press `Upload selected params to FC, and advance to next file` button.
 1. Read the documentation links inside the `13_general_configuration.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
@@ -595,7 +595,7 @@ The estimation will be improved after the first flight.
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `18_notch_filter_setup.param` file
 
-When asked *Should the FC values now be copied to the 19_notch_filter_results.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 # 7. Assemble propellers and perform the first flight
 
@@ -626,6 +626,8 @@ These are the very minimum tuning steps required for a stable flight:
 
 Load the `.bin` log from the first flight onto the [online Ardupilot Filter Review tool](https://firmware.ardupilot.org/Tools/WebTools/FilterReview/)
 Follow the [instructions from Peter Hall on his Blog Post](https://discuss.ardupilot.org/t/new-fft-filter-setup-and-review-web-tool/102572) to configure the Harmonic Notch filter(s).
+Noise levels below -50dB are considered good enough.
+Do not use notch filters to reduce noise below that level as it introduces unwanted signal lag.
 The graph below is a bode diagram of the gyro signals before and after the low-pass and Harmonic Notch filters.
 As you can see, the filters remove most of the vibration noise from the gyro sensors.
 
@@ -688,7 +690,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `23_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 23_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `23_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -718,8 +720,7 @@ Follow these steps before the flight:
 1. Read the documentation links inside the `24_inflight_magnetometer_fit_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the MagFit figure-eight flight and land
 
@@ -731,7 +732,7 @@ Perform the MagFit figure-eight flight and land
 1. Perform the MagFit calculations. Save the tool-generated file as `25_inflight_magnetometer_fit_results.param` in your vehicle's intermediate parameter file directory.
 1. Connect your flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_inflight_magnetometer_fit_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `No`.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -760,8 +761,7 @@ Setup the lua script using:
 1. Read the documentation links inside the `24_quicktune_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the flight and afterward:
 
@@ -769,7 +769,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `25_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -837,14 +837,14 @@ Follow the sequence below for tuning each axis as that particular order improves
 ### 9.5.1 Roll axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `30_autotune_roll_setup.param` and upload it to the FC. It will activate the roll axis Autotune.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either [`AltHold`](https://ardupilot.org/copter/docs/altholdmode.html) or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the Autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `31_autotune_roll_results.param`.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `31_autotune_roll_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 
@@ -865,14 +865,14 @@ If the battery got depleted before Autotune completion, change the initial PID p
 ### 9.5.2 Pitch axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `32_autotune_pitch_setup.param` and upload it to the FC. It will activate the pitch axis Autotune.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either `AltHold` or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC Transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `33_autotune_pitch_results.param`.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `33_autotune_pitch_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 

--- a/TUNING_GUIDE_Heli.md
+++ b/TUNING_GUIDE_Heli.md
@@ -96,7 +96,7 @@ Use Mission Planner to flash the latest stable [ArduCopter](https://firmware.ard
 
 ## 2.1 Used software summary
 
-The table bellow summarizes the software used in this guide. Download and install them as you progress in the guide.
+The table below summarizes the software used in this guide. Download and install them as you progress in the guide.
 
 | Software | Version | Description |
 |:----|:----|:----|
@@ -294,7 +294,7 @@ Propeller size has a big influence on the vehicle dynamics, this adapts controll
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `11_initial_atc.param` file
 
-When asked *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 ## 6.9 Configure "Mandatory Hardware" Parameters
 
@@ -339,7 +339,8 @@ There should be a more detailed setup in this area for helicopters.
 
 ### [ESC Calibration](https://ardupilot.org/copter/docs/esc-calibration.html)
 
-ESC calibration is only needed if the ESC doesn't have an internal governor.  In that case, the throttle curve would be used with the built-in rotor speed governor.
+ESC calibration is only needed if the ESC doesn't have an internal governor.
+In that case, the throttle curve would be used with the built-in rotor speed governor.
 
 ### [Flight Modes](https://ardupilot.org/copter/docs/flight-modes.html)
 
@@ -373,8 +374,8 @@ Now do some general configuration
 
 1. Connect the flight controller to the PC
 1. Start *ArduPilot Methodic Configurator* and select the vehicle directory where you previously stored your *intermediate parameter files*.
-1. When *ArduPilot Methodic Configurator* asks you *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `Yes`
-1. Select `13_general_configuration.param` on the *Current intermediate parameter file:* Combobox.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `12_mp_setup_mandatory_hardware.param` file because you've completed the experiment.
+1. Press `Upload selected params to FC, and advance to next file` button.
 1. Read the documentation links inside the `13_general_configuration.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
@@ -536,7 +537,7 @@ The estimation will be improved after the first flight.
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `18_notch_filter_setup.param` file
 
-When asked *Should the FC values now be copied to the 19_notch_filter_results.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 # 7. Install rotor blades and perform the first flight
 
@@ -566,6 +567,8 @@ These are the very minimum tuning steps required for a stable flight:
 
 Load the `.bin` log from the first flight onto the [online Ardupilot Filter Review tool](https://firmware.ardupilot.org/Tools/WebTools/FilterReview/)
 Follow the [instructions from Peter Hall on his Blog Post](https://discuss.ardupilot.org/t/new-fft-filter-setup-and-review-web-tool/102572) to configure the Harmonic Notch filter(s).
+Noise levels below -50dB are considered good enough.
+Do not use notch filters to reduce noise below that level as it introduces unwanted signal lag.
 The graph below is a bode diagram of the gyro signals before and after the low-pass and Harmonic Notch filters.
 As you can see, the filters remove most of the vibration noise from the gyro sensors.
 
@@ -628,7 +631,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `23_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 23_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `23_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -658,8 +661,7 @@ Follow these steps before the flight:
 1. Read the documentation links inside the `24_inflight_magnetometer_fit_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the MagFit figure-eight flight and land
 
@@ -671,7 +673,7 @@ Perform the MagFit figure-eight flight and land
 1. Perform the MagFit calculations. Save the tool-generated file as `25_inflight_magnetometer_fit_results.param` in your vehicle's intermediate parameter file directory.
 1. Connect your flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_inflight_magnetometer_fit_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `No`.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -700,8 +702,7 @@ Setup the lua script using:
 1. Read the documentation links inside the `24_quicktune_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the flight and afterward:
 
@@ -709,7 +710,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `25_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -777,14 +778,14 @@ Follow the sequence below for tuning each axis as that particular order improves
 ### 9.5.1 Roll axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `30_autotune_roll_setup.param` and upload it to the FC. It will activate the roll axis Autotune.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either [`AltHold`](https://ardupilot.org/copter/docs/altholdmode.html) or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the Autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `31_autotune_roll_results.param`.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `31_autotune_roll_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 
@@ -805,14 +806,14 @@ If the battery got depleted before Autotune completion, change the initial PID p
 ### 9.5.2 Pitch axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `32_autotune_pitch_setup.param` and upload it to the FC. It will activate the pitch axis Autotune.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either `AltHold` or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC Transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `33_autotune_pitch_results.param`.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `33_autotune_pitch_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 

--- a/TUNING_GUIDE_Rover.md
+++ b/TUNING_GUIDE_Rover.md
@@ -97,7 +97,7 @@ Use Mission Planner to flash the latest stable [ArduCopter](https://firmware.ard
 
 ## 2.1 Used software summary
 
-The table bellow summarizes the software used in this guide. Download and install them as you progress in the guide.
+The table below summarizes the software used in this guide. Download and install them as you progress in the guide.
 
 | Software | Version | Description |
 |:----|:----|:----|
@@ -295,7 +295,7 @@ Propeller size has a big influence on the vehicle dynamics, this adapts controll
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `11_initial_atc.param` file
 
-When asked *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 ## 6.9 Configure "Mandatory Hardware" Parameters
 
@@ -380,8 +380,8 @@ Now do some general configuration
 
 1. Connect the flight controller to the PC
 1. Start *ArduPilot Methodic Configurator* and select the vehicle directory where you previously stored your *intermediate parameter files*.
-1. When *ArduPilot Methodic Configurator* asks you *Should the FC values now be copied to the 12_mp_setup_mandatory_hardware.param file?* select `Yes`
-1. Select `13_general_configuration.param` on the *Current intermediate parameter file:* Combobox.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `12_mp_setup_mandatory_hardware.param` file because you've completed the experiment.
+1. Press `Upload selected params to FC, and advance to next file` button.
 1. Read the documentation links inside the `13_general_configuration.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
@@ -591,7 +591,7 @@ The estimation will be improved after the first flight.
 
 Repeat the steps from [Section 6.1.1](#611-use-ardupilot-methodic-configurator-to-edit-the-parameter-file-and-upload-it-to-the-flight-controller) to edit and upload the `18_notch_filter_setup.param` file
 
-When asked *Should the FC values now be copied to the 19_notch_filter_results.param file?* select `No` and close the *ArduPilot Methodic Configurator* software.
+When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 # 7. Assemble propellers and perform the first flight
 
@@ -621,6 +621,8 @@ These are the very minimum tuning steps required for a stable flight:
 
 Load the `.bin` log from the first flight onto the [online Ardupilot Filter Review tool](https://firmware.ardupilot.org/Tools/WebTools/FilterReview/)
 Follow the [instructions from Peter Hall on his Blog Post](https://discuss.ardupilot.org/t/new-fft-filter-setup-and-review-web-tool/102572) to configure the Harmonic Notch filter(s).
+Noise levels below -50dB are considered good enough.
+Do not use notch filters to reduce noise below that level as it introduces unwanted signal lag.
 The graph below is a bode diagram of the gyro signals before and after the low-pass and Harmonic Notch filters.
 As you can see, the filters remove most of the vibration noise from the gyro sensors.
 
@@ -683,7 +685,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `23_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 23_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `23_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -713,8 +715,7 @@ Follow these steps before the flight:
 1. Read the documentation links inside the `24_inflight_magnetometer_fit_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the MagFit figure-eight flight and land
 
@@ -726,7 +727,7 @@ Perform the MagFit figure-eight flight and land
 1. Perform the MagFit calculations. Save the tool-generated file as `25_inflight_magnetometer_fit_results.param` in your vehicle's intermediate parameter file directory.
 1. Connect your flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_inflight_magnetometer_fit_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_inflight_magnetometer_fit_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `No`.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -755,8 +756,7 @@ Setup the lua script using:
 1. Read the documentation links inside the `24_quicktune_setup.param documentation`
 1. Edit the parameters' `New Value` and `Change Reason` to suit your requirements
 1. Press `Upload selected params to FC, and advance to next file` button.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `No`.
-1. Close *ArduPilot Methodic Configurator*
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 
 Perform the flight and afterward:
 
@@ -764,7 +764,7 @@ Perform the flight and afterward:
 
 1. Connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `25_quicktune_results.param` on the *Current intermediate parameter file:* Combobox.
-1. When asked *Should the FC values now be copied to the 25_quicktune_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `25_quicktune_results.param` file because you've completed the experiment.
 1. Press `Upload selected params to FC, and advance to next file` button.
 1. Close *ArduPilot Methodic Configurator*
 
@@ -832,14 +832,14 @@ Follow the sequence below for tuning each axis as that particular order improves
 ### 9.5.1 Roll axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `30_autotune_roll_setup.param` and upload it to the FC. It will activate the roll axis Autotune.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either [`AltHold`](https://ardupilot.org/copter/docs/altholdmode.html) or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the Autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `31_autotune_roll_results.param`.
-1. When asked *Should the FC values now be copied to the 31_autotune_roll_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `31_autotune_roll_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 
@@ -860,14 +860,14 @@ If the battery got depleted before Autotune completion, change the initial PID p
 ### 9.5.2 Pitch axis autotune
 
 1. On *ArduPilot Methodic Configurator* select `32_autotune_pitch_setup.param` and upload it to the FC. It will activate the pitch axis Autotune.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `No`.
+1. When asked *Update file with values from FC?* select `Close` to close the application and go perform the experiment.
 1. Outdoors on a non-windy day (or indoors in a big warehouse like we at IAV do) take off and fly in either `AltHold` or `Loiter` flight mode.
 1. At about 2 meters high, select `Autotune` flight mode in the RC Transmitter to engage Autotune.
 1. Use the RC transmitter sticks to correct the vehicle position if it gets too high, too low or too close to obstacles.
 1. Once the autotune is completed, land and disarm the vehicle without changing the flight mode.
 1. connect the flight controller to the PC
 1. On *ArduPilot Methodic Configurator* select `33_autotune_pitch_results.param`.
-1. When asked *Should the FC values now be copied to the 33_autotune_pitch_results.param file?* select `Yes`.
+1. When asked *Update file with values from FC?* select `Yes` to copy current FC values to the `33_autotune_pitch_results.param` file because you've completed the experiment.
 
 The autotune might have found a poor solution, here are some indicators of a poor tune:
 

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -379,7 +379,7 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         )
 
         # Function to show the appropriate error message
-        def show_parameter_error(_event: tk.Event) -> None:  # pylint: disable=unused-argument
+        def show_parameter_error(_event: tk.Event) -> None:
             if present_as_forced:
                 messagebox.showerror(_("Forced Parameter"), forced_error_msg)
             elif present_as_derived:
@@ -690,6 +690,30 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
             # Revert to the previous (valid) value
             p = old_value
         self.__update_new_value_entry_text(event.widget, p, self.local_filesystem.param_default_dict.get(param_name, None))
+        self.__update_change_reason_entry_tooltip(param_name, p)
+
+    def __update_change_reason_entry_tooltip(self, param_name: str, param_value: float) -> None:
+        """Update the tooltip on the change reason entry with the current parameter value."""
+        value_str = format(param_value, ".6f").rstrip("0").rstrip(".")
+
+        # Find the change reason entry widget for this parameter
+        for widget in self.view_port.winfo_children():
+            if isinstance(widget, ttk.Entry) and widget.grid_info().get("column", 0) == 6:
+                # Get the parameter label in the same row
+                row = widget.grid_info().get("row")
+                for param_widget in self.view_port.winfo_children():
+                    if (
+                        isinstance(param_widget, ttk.Label)
+                        and param_widget.grid_info().get("column", 0) == 1
+                        and param_widget.grid_info().get("row") == row
+                        and param_widget.cget("text").strip() == param_name
+                    ):
+                        # Found the matching change reason entry, update its tooltip
+                        msg = _("Reason why {param_name} should change to {value_str}")
+                        show_tooltip(widget, msg.format(**locals()))
+                        return
+
+        logging_debug(_("Could not find change reason entry widget for parameter %s (%s)"), param_name, value_str)
 
     def __on_parameter_change_reason_change(self, event: tk.Event, current_file: str, param_name: str) -> None:
         # Get the new value from the Entry widget


### PR DESCRIPTION
This pull request focuses on improving the clarity and consistency of instructions in the tuning guides for ArduCopter, ArduPlane, and Heli. It also removes unnecessary configuration from `.github/dependabot.yml`. The most important changes involve standardizing user prompts and enhancing documentation details.

### Changes to Tuning Guides:

**Standardization of User Prompts:**
* Updated all instances of prompts in `TUNING_GUIDE_ArduCopter.md`, `TUNING_GUIDE_ArduPlane.md`, and `TUNING_GUIDE_Heli.md` to use consistent phrasing: "When asked *Update file with values from FC?*" instead of the previous "Should the FC values now be copied to..." phrasing. This improves clarity and aligns instructions across guides. [[1]](diffhunk://#diff-25057261d62a266a9e263de6a22afbff4c4b7d12ea12f4c4bbb4a6ff32012b4fL298-R298) [[2]](diffhunk://#diff-68a9a14ea8acf321e778d20d6af36386d7ee4a5ef4a266f0854a460d811fb46fL298-R298) [[3]](diffhunk://#diff-0ff9f16c709769114e677e9a0a668caa500392a0b24e6c8102e0de0d3759bf12L297-R297)

**Enhancements to Documentation:**
* Added a note on noise levels in `TUNING_GUIDE_ArduPlane.md` to guide users on effective notch filter usage: "Noise levels below -50dB are considered good enough. Do not use notch filters to reduce noise below that level as it introduces unwanted signal lag."

### Configuration Cleanup:

**Dependabot Configuration:**
* Removed redundant `pip` package-ecosystem configuration from `.github/dependabot.yml`, as it was not in use.