### PR TITLE
Generate GitHub Actions build provenance

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -36,16 +36,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # https://docs.astral.sh/uv/guides/integration/github/
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
-          python-version: ${{ matrix.python-version }}
+            python-version: ${{ matrix.python-version }}
+            activate-environment: true
 
       - name: Install dependencies
         run: |
-          python -m pip install -U wheel pip
-          python -m pip install -U pywin32
-          python -m pip install -U pyinstaller packaging
+          uv pip install .[win_dist]
 
       - name: Download Inno Setup installer
         run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.3.3.exe
@@ -53,9 +53,8 @@ jobs:
       - name: Install Inno Setup
         run: ./installer.exe /verysilent /allusers /dir=inst
 
-      - name: Build ardupilot_methodic_configurator
+      - name: List installed software versions
         run: |
-          python -m pip install . --user
           python -m pip list
 
       - name: Prepare installer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,14 @@ scripts = [
     "bs4",
 ]
 
+win_dist = [
+    "wheel==0.45.1",
+    "pip==25.1.1",
+    "pywin32==310",
+    "pyinstaller==6.13.0",
+    "packaging==25.0",
+]
+
 [project.scripts]
 ardupilot_methodic_configurator = "ardupilot_methodic_configurator.__main__:main"
 extract_param_defaults = "ardupilot_methodic_configurator.extract_param_defaults:main"


### PR DESCRIPTION
This pull request updates the build process for Windows and adds a new dependency group for Windows-specific distributions. The most important changes involve switching to the `astral-sh/setup-uv` action in the GitHub workflow and defining a `win_dist` dependency group in `pyproject.toml`.

### Updates to the build process:

* [`.github/workflows/windows_build.yml`](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eL39-L58): Replaced the `actions/setup-python` action with `astral-sh/setup-uv` to manage Python setup and environment activation. Simplified dependency installation by using the `win_dist` group from `pyproject.toml`.

### Dependency management:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R82-R89): Added a new `win_dist` dependency group containing Windows-specific dependencies such as `wheel`, `pip`, `pywin32`, `pyinstaller`, and `packaging`.