### PR TITLE
Generate GitHub Actions build provenance

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,14 +24,13 @@ jobs:
 
     permissions:
       contents: write
-      id-token: write  # Needed for keyless signing
-      actions: read    # Needed for provenance generation
+      id-token: write    # Needed for keyless signing
+      actions: read      # Needed for provenance generation
+      packages: write    # Add this permission for attestations
+      attestations: write # Add permissions for attestations
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+      # step-security/harden-runner does not (yet) run on windows, so do not use it
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,6 +81,21 @@ jobs:
           }
           Get-Content -Raw git_hash.txt
 
+      - name: Debug GitHub token and permissions
+        run: |
+          Write-Host "Checking GitHub token and permissions"
+          # Don't print the actual token, just check if it exists
+          if ([string]::IsNullOrEmpty("${{ secrets.GITHUB_TOKEN }}")) {
+            Write-Host "::warning::GITHUB_TOKEN is empty or not accessible"
+          } else {
+            Write-Host "GITHUB_TOKEN is available"
+          }
+
+          # Check if running in fork (which may have limited permissions)
+          if ("${{ github.repository }}" -ne "${{ github.repository_owner }}/${{ github.event.repository.name }}") {
+            Write-Host "::warning::Running in a fork which may have limited permissions"
+          }
+
       - name: Build installer
         run: |
           cd windows
@@ -89,6 +103,16 @@ jobs:
           curl -L -o "c:\program files (x86)\inno setup 6\Languages\ChineseSimplified.isl" https://raw.githubusercontent.com/jrsoftware/issrc/refs/heads/main/Files/Languages/Unofficial/ChineseSimplified.isl
           ISCC.exe /dMyAppVersion=$env:VERSION ardupilot_methodic_configurator.iss
           ls Output
+
+      - name: Generate GitHub Actions build provenance
+        uses: actions/attest-build-provenance@v2.3.0
+        with:
+          subject-path: windows/Output/*.exe
+          subject-name: 'ardupilot_methodic_configurator'
+          push-to-registry: false
+          # Use the built-in token instead of secrets
+          github-token: ${{ github.token }}
+          show-summary: true
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb
@@ -103,20 +127,29 @@ jobs:
             $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$($hash)  $_"))
             $encoded
           }
-          echo "hashes=$(($hashes -join ','))" >> $env:GITHUB_OUTPUT
+          $hashesJoined = $hashes -join ','
+          "hashes=$hashesJoined" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Store Executable Path
         id: exe_path
         run: |
           cd windows/Output
           $exePath = Get-ChildItem -Filter *.exe | Select-Object -First 1 -ExpandProperty FullName
-          echo "exe_path=$exePath" >> $env:GITHUB_OUTPUT
+          "exe_path=$exePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Install SLSA Verifier
         run: |
-          $version = "v2.5.1"
+          $version = "v2.7.0"
           $url = "https://github.com/slsa-framework/slsa-verifier/releases/download/$version/slsa-verifier-windows-amd64.exe"
-          Invoke-WebRequest -Uri $url -OutFile slsa-verifier.exe
+          Invoke-WebRequest -Uri $url -OutFile "slsa-verifier.exe"
+
+          # Verify the download was successful
+          if (Test-Path "slsa-verifier.exe") {
+            Write-Host "SLSA verifier downloaded successfully to $(Get-Location)\slsa-verifier.exe"
+          } else {
+            Write-Host "::error::Failed to download SLSA verifier"
+            exit 1
+          }
 
       - name: Generate SLSA provenance
         uses: slsa-framework/slsa-github-generator/actions/generator/generic/create-base64-subjects-from-file@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0


### PR DESCRIPTION
This pull request updates the Windows build workflow in `.github/workflows/windows_build.yml` to enhance security, improve debugging, and streamline the process for generating build provenance and handling outputs. Key changes include adjustments to permissions, added debugging steps, provenance generation, and improved handling of outputs and dependencies.

### Security and Permissions Updates:
* Added `packages: write` and `attestations: write` permissions to enable attestations in the build process. (`[.github/workflows/windows_build.ymlR29-R33](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eR29-R33)`)
* Removed the `step-security/harden-runner` step, as it is not supported on Windows. (`[.github/workflows/windows_build.ymlR29-R33](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eR29-R33)`)

### Debugging Enhancements:
* Introduced a new step to check the availability of the `GITHUB_TOKEN` and detect if the workflow is running in a fork with limited permissions. (`[.github/workflows/windows_build.ymlR84-R98](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eR84-R98)`)

### Build Provenance and Output Handling:
* Added a step to generate build provenance using `actions/attest-build-provenance@v2.3.0`, with configurations for subject path, name, and token usage. (`[.github/workflows/windows_build.ymlR107-R116](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eR107-R116)`)
* Updated output handling to use `Out-File` with UTF-8 encoding for appending environment variables like `hashes` and `exe_path`. (`[.github/workflows/windows_build.ymlL106-R152](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eL106-R152)`)

### Dependency Management:
* Upgraded the `slsa-verifier` version from `v2.5.1` to `v2.7.0` and added a verification step to ensure the download was successful. (`[.github/workflows/windows_build.ymlL106-R152](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eL106-R152)`)