### PR TITLE
Clean up all spelling issues

### DIFF
--- a/.codespell-exclude-file
+++ b/.codespell-exclude-file
@@ -2,6 +2,5 @@
             "Juli Gallup",
                     "Version": "LAF"
                 "Version": "LAF"
-MOT_SPIN_MIN,0.13  # since hover thst is around 18.
              datas= [],
                ardupilot_methodic_configuratorAny.datas,

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -32,5 +32,5 @@ jobs:
           # Optional: specify a codespell configuration file
           # codespell_args: --config .codespellrc
           # Optional: specify a list of words to ignore
-          ignore_words_list: SITL,PARM,parm,NED,THST
+          ignore_words_list: SITL,PARM,parm,NED,THST,intoto
           exclude_file: .codespell-exclude-file

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -58,7 +58,7 @@ SPDX-FileCopyrightText = "2024-2025 Amilcar Lucas"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
-path = ["uv.lock"]
+path = ["uv.lock", ".codespell-exclude-file"]
 SPDX-FileCopyrightText = "2024-2025 Amilcar Lucas"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X13/15_motor.param
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X13/15_motor.param
@@ -1,4 +1,4 @@
 MOT_SPIN_ARM,0.1  # lower than spin min
 MOT_SPIN_MAX,0.9  # as per previous drone setup similar specs
-MOT_SPIN_MIN,0.13  # since hover thst is around 18.
+MOT_SPIN_MIN,0.13  # MOT_SPIN_ARM + 0.03 and smaller than MOT_THST_HOVER (0.18)
 MOT_THST_EXPO,0.75  # as per previous drone setup similar specs


### PR DESCRIPTION
This pull request introduces updates to improve spelling consistency, enhance configuration files, and refine parameter documentation. The most important changes include updates to the `.codespell-exclude-file`, `.github/workflows/codespell.yml`, and `REUSE.toml` files, as well as improvements in parameter descriptions for the ArduCopter vehicle template.

### Spelling and configuration updates:

* [`.codespell-exclude-file`](diffhunk://#diff-843bd8db7e4182a994e642ca3428785486b7082ab6e333d4e5efe830045790c9L5): Corrected a spelling issue in the excluded words list, ensuring better alignment with the codespell configuration.
* [`.github/workflows/codespell.yml`](diffhunk://#diff-ce84a1b2c9eb4ab3ea22f610cad7111cb9a2f66365c3b24679901376a2a73ab2L35-R35): Added `intoto` to the `ignore_words_list` to exclude it from codespell checks.

### Licensing and compliance:

* [`REUSE.toml`](diffhunk://#diff-74bd2d6afd7a1f967679adae374ca38fd9745fe6129dc4717a1ab0e388590b08L61-R61): Updated the `path` field to include `.codespell-exclude-file` for SPDX annotations, ensuring proper licensing compliance for the new file.

### Parameter documentation:

* [`ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X13/15_motor.param`](diffhunk://#diff-abb3a8f6dae27044854c174ea3b3495e3d566420fcafce403efe682d9a6dba20L3-R3): Improved the comment for `MOT_SPIN_MIN` to provide a clearer explanation of its relationship with `MOT_SPIN_ARM` and `MOT_THST_HOVER`.