### PR TITLE
Automate the generation of version-dependent apm.pdef.xml files

### DIFF
--- a/.github/workflows/generate_apm.pdef.xml.yml
+++ b/.github/workflows/generate_apm.pdef.xml.yml
@@ -1,0 +1,48 @@
+name: Generate apm.pdef.xml metadata
+
+# Whenever a tag is pushed, create the corresponding parameter metadata documentation
+# apm.pdef.xml file on the https://autotest.ardupilot.org/Parameters/versioned/ URL
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #  - cron: '30 3 * * 4'  # Every Thursday at 3:30 AM
+
+permissions:
+  contents: read
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      with:
+        egress-policy: audit
+
+    - name: Checkout MethodicConfigurator
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Checkout ArduPilot
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: ArduPilot/ardupilot
+        path: ardupilot
+
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.x'
+
+    - name: Install rsync
+      run: |
+        sudo apt-get update && sudo apt-get install -y rsync
+        python -m pip install lxml
+        mv ardupilot ..
+
+    - name: Run generate_pdef.xml_metadata.py
+      env:
+        RSYNC_USERNAME: ${{ vars.RSYNC_USERNAME }}
+        RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
+      run: python scripts/generate_pdef.xml_metadata.py

--- a/scripts/generate_pdef.xml_metadata.py
+++ b/scripts/generate_pdef.xml_metadata.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+"""
+Rsync apm.pdef.xml files for different versions of the ArduPilot firmware.
+
+For each version, it checks out the corresponding tag, generates parameter metadata,
+and finally rsyncs the updated parameter metadata pdef.xml files.
+
+SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import datetime
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+
+VEHICLE_TYPES = [
+    "Copter",
+    "Plane",
+    "Rover",
+    "ArduSub",
+    "Tracker",
+]  # Add future vehicle types here
+
+# Error messages
+ERR_USERNAME_NOT_SET = "RSYNC_USERNAME environment variable not set"
+ERR_PASSWORD_NOT_SET = "RSYNC_PASSWORD environment variable not set"  # noqa: S105
+
+RSYNC_USERNAME = os.environ.get("RSYNC_USERNAME")
+if not RSYNC_USERNAME:
+    raise ValueError(ERR_USERNAME_NOT_SET)
+
+RSYNC_PASSWORD = os.environ.get("RSYNC_PASSWORD")
+if not RSYNC_PASSWORD:
+    raise ValueError(ERR_PASSWORD_NOT_SET)
+
+# Store the current working directory
+old_cwd = os.getcwd()
+
+
+def ensure_dependencies() -> None:
+    """Check for and install required dependencies if they're missing."""
+    required_packages = ["lxml"]
+
+    for package in required_packages:
+        if importlib.util.find_spec(package) is None:
+            print(f"Installing required dependency: {package}")  # noqa: T201
+            # This is safe as we're only installing known packages defined in the code
+            subprocess.check_call([sys.executable, "-m", "pip", "install", package])  # noqa: S603
+            print(f"Successfully installed {package}")  # noqa: T201
+
+
+def get_vehicle_tags(vehicle_type: str) -> list[str]:
+    """
+    Lists all tags in the ArduPilot repository that start with the given vehicle type followed by '-'.
+
+    Returns a list of tag names.
+    """
+    try:
+        # Change to the ArduPilot directory
+        os.chdir("../ardupilot/")
+        # Using git with a known pattern is safe in this context
+        tags_output = subprocess.check_output(  # noqa: S603
+            ["git", "tag", "--list", f"{vehicle_type}-[0-9]\\.[0-9]\\.[0-9]"],  # noqa: S607
+            text=True,
+        )
+        # Return to the original directory
+        os.chdir(old_cwd)
+        return tags_output.splitlines()
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error getting {vehicle_type} tags: {e}")  # noqa: T201
+        # Ensure we return to the original directory in case of error
+        os.chdir(old_cwd)
+        return []
+
+
+def generate_vehicle_versions() -> dict[str, list[str]]:
+    """Generates arrays for each vehicle type based on the tags fetched from the ArduPilot repository."""
+    vehicle_versions: dict[str, list[str]] = {}
+
+    for vehicle_type in VEHICLE_TYPES:
+        tags = get_vehicle_tags(vehicle_type)
+        if tags:
+            vehicle_versions[vehicle_type] = [tag.split("-")[1] for tag in tags]
+
+    return vehicle_versions
+
+
+def create_one_pdef_xml_file(vehicle_type: str, dst_dir: str, git_tag: str) -> None:
+    """Create a single pdef XML file for a specific vehicle type and version."""
+    # Check if the file already exists
+    dst_file = f"{dst_dir}/apm.pdef.xml"
+    full_dst_path = f"{old_cwd}/{dst_dir}"
+    full_dst_file = f"{old_cwd}/{dst_file}"
+
+    if os.path.exists(full_dst_file):
+        print(f"File {dst_file} already exists, skipping generation...")  # noqa: T201
+        return
+
+    try:
+        os.chdir("../ardupilot")
+        # These subprocess calls are safe as they use fixed commands
+        subprocess.run(["git", "checkout", git_tag], check=True)  # noqa: S603, S607
+        # subprocess.run(['git', 'pull'], check=True)
+        subprocess.run(  # noqa: S603
+            [
+                os.path.abspath("Tools/autotest/param_metadata/param_parse.py"),
+                "--vehicle",
+                vehicle_type,
+                "--format",
+                "xml",
+            ],
+            check=True,
+        )
+
+        # Create the destination directory with parents if it doesn't exist
+        if not os.path.exists(full_dst_path):
+            os.makedirs(full_dst_path, exist_ok=True)
+
+        with open("apm.pdef.xml", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        # Insert an XML comment on line 3 in the apm.pdef.xml file
+        # with the tag used to generate the file and the current date
+        lines.insert(
+            2,
+            f"<!-- Generated from git tag {git_tag} on {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} -->\n",
+        )
+        with open("apm.pdef.xml", "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        shutil.copy("apm.pdef.xml", full_dst_file)
+        print(f"Created {dst_file}")  # noqa: T201
+    finally:
+        # Return to the old working directory, even if an exception occurs
+        os.chdir(old_cwd)
+
+
+# Function to sync files using rsync
+def sync_to_remote(vehicle_dir: str) -> None:
+    """Sync files to the remote server using rsync."""
+    src_dir = f"{vehicle_dir}/"
+    dst_host = "firmware.ardupilot.org"
+    dst_path = f"param_versioned/{vehicle_dir}/"
+
+    # Construct the rsync command with rsync:// URL format
+    rsync_cmd = [
+        "rsync",
+        "-avz",
+        "--progress",
+        src_dir,
+        f"rsync://{RSYNC_USERNAME}@{dst_host}/{dst_path}",
+    ]
+
+    print(f"Synchronizing {src_dir} to {dst_path}...")  # noqa: T201
+    # RSYNC_PASSWORD environment variable will be automatically used by rsync
+    print(rsync_cmd)  # noqa: T201
+    subprocess.run(rsync_cmd, check=True)  # noqa: S603
+
+
+def main() -> None:
+    """Main function to generate and sync parameter definition XML files."""
+    # Ensure required dependencies are installed
+    ensure_dependencies()
+
+    vehicle_versions = generate_vehicle_versions()
+
+    # Iterate over the vehicle_versions list
+    for vehicle_type, versions in vehicle_versions.items():
+        vehicle_dir = vehicle_type
+        if vehicle_type == "ArduSub":
+            vehicle_dir = "Sub"
+
+        for version in versions:
+            if version[0] == "3" and vehicle_type != "AP_Periph":
+                continue  # Skip ArduPilot 3.x versions, as param_parse.py does not support them out of the box
+            if version[0] == "4" and version[2] == "0" and vehicle_type != "ArduSub":
+                continue  # Skip ArduPilot 4.0.x versions, as param_parse.py does not support them out of the box
+            create_one_pdef_xml_file(
+                vehicle_type,
+                f"{vehicle_dir}/stable-{version}",
+                f"{vehicle_type}-{version}",
+            )
+
+        sync_to_remote(vehicle_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_frontend_tkinter_show.py
+++ b/tests/test_frontend_tkinter_show.py
@@ -15,9 +15,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# pylint: disable=redefined-outer-name
-
-
 from ardupilot_methodic_configurator.frontend_tkinter_show import (
     Tooltip,
     show_error_message,
@@ -25,6 +22,8 @@ from ardupilot_methodic_configurator.frontend_tkinter_show import (
     show_no_param_files_error,
     show_tooltip,
 )
+
+# pylint: disable=redefined-outer-name
 
 
 # Fixtures


### PR DESCRIPTION
…
This pull request introduces a new workflow and script to automate the generation and synchronization of `apm.pdef.xml` metadata files for various ArduPilot vehicle types. The workflow triggers the script, which generates parameter metadata for specific firmware versions and syncs the results to a remote server. Below are the key changes:

### New GitHub Actions Workflow
* Added `.github/workflows/generate_apm.pdef.xml.yml` to define a workflow for generating `apm.pdef.xml` metadata files. The workflow supports manual triggers (`workflow_dispatch`) and includes steps for setting up the environment, checking out repositories, and running the metadata generation script.

### New Python Script for Metadata Generation
* Introduced `scripts/generate_pdef.xml_metadata.py`, a Python script that:
  - Generates `apm.pdef.xml` files for different ArduPilot vehicle types and firmware versions.
  - Validates required environment variables (`RSYNC_USERNAME` and `RSYNC_PASSWORD`).
  - Ensures necessary dependencies (`lxml`) are installed.
  - Uses `git` to fetch tags and `param_parse.py` to generate metadata files.
  - Adds metadata comments to the generated XML files, including the git tag and generation timestamp.
  - Syncs the generated files to a remote server using `rsync`.