### PR TITLE
feat(ruff,mypy): Update ruff and mypy versions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install 'mypy==1.15.0' 'types-requests==2.32.0.20250328'
+          python -m pip install 'mypy==1.16.0' 'types-requests==2.32.0.20250602'
 
       - name: Lint the code with mypy
         uses: sasanquaneuf/mypy-github-action@a3f3a66f97792cac0cfd11d3e5c87088e5c8f6a9 # releases/v1.3

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -35,7 +35,7 @@ jobs:
       # Ruff does not need a specific python version installed
       - name: Install dependencies
         run: |
-          python -m pip install 'ruff==0.11.4'
+          python -m pip install 'ruff==0.11.13'
 
       - name: Lint with Ruff
         run: |


### PR DESCRIPTION
This pull request updates the versions of dependencies used in GitHub Actions workflows for linting with `mypy` and `ruff`.

Dependency updates:

* [`.github/workflows/mypy.yml`](diffhunk://#diff-07730f31c368f5e0af82cb7d820dc37ae6a752a0a226f7aee9ebac72dfe41459L31-R31): Updated `mypy` to version `1.16.0` and `types-requests` to version `2.32.0.20250602`.
* [`.github/workflows/ruff.yml`](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L38-R38): Updated `ruff` to version `0.11.13`.