### PR TITLE
Increase test coverage minimum threshold to 73%

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -158,7 +158,7 @@ jobs:
             echo "Pytest failed - failing coverage check"
             exit 1
           fi
-          coverage report --fail-under=55
+          coverage report --fail-under=73
 
   publish-test-results:
     if: always()
@@ -249,4 +249,4 @@ jobs:
         with:
             coverageFile: coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdAll: 0.60
+            thresholdAll: 0.73


### PR DESCRIPTION
This pull request updates the test coverage thresholds in the GitHub Actions workflow configuration to enforce stricter standards for code quality.

Updates to test coverage thresholds:

* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL161-R161): Increased the `--fail-under` threshold in the `coverage report` command from 55% to 73%.
* [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL252-R252): Updated the `thresholdAll` parameter for coverage reporting from 60% to 73%.