### PR TITLE
Support configurable FC baudrate

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -79,7 +79,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
 
 
 def connect_to_fc_and_set_vehicle_type(args: argparse.Namespace) -> tuple[FlightController, str]:
-    flight_controller = FlightController(args.reboot_time)
+    flight_controller = FlightController(reboot_time=args.reboot_time, baudrate=args.baudrate)
 
     error_str = flight_controller.connect(args.device, log_errors=False)
     if error_str:

--- a/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
@@ -285,8 +285,8 @@ def main() -> None:
     )
     # pylint: enable=duplicate-code
 
-    flight_controller = FlightController(args.reboot_time)  # Initialize your FlightController instance
-    result = flight_controller.connect(device=args.device)  # Connect to the flight controller
+    flight_controller = FlightController(reboot_time=args.reboot_time, baudrate=args.baudrate)
+    result = flight_controller.connect(device=args.device)
     if result:
         logging_warning(result)
         window = ConnectionSelectionWindow(flight_controller, result)

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -961,7 +961,7 @@ if __name__ == "__main__":
 
     logging_basicConfig(level=logging_getLevelName(args.loglevel), format="%(asctime)s - %(levelname)s - %(message)s")
 
-    fc = FlightController(args.reboot_time)
+    fc = FlightController(reboot_time=args.reboot_time, baudrate=args.baudrate)
     filesystem = LocalFilesystem(
         args.vehicle_dir, args.vehicle_type, "", args.allow_editing_template_files, args.save_component_to_system_templates
     )

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -52,7 +52,7 @@ class TestMainFunctions(unittest.TestCase):
         mock_fc.info.vendor = "vendor"
         mock_fc.info.firmware_type = "type"
 
-        args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5)
+        args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5, baudrate=115200)
         flight_controller, vehicle_type = connect_to_fc_and_set_vehicle_type(args)
         assert flight_controller == mock_fc
         assert vehicle_type == "quad"
@@ -115,7 +115,7 @@ class TestMainFunctions(unittest.TestCase):
         mock_fc.info.flight_sw_version_and_type = "v1.0"
 
         # Set an explicit vehicle type
-        args = argparse.Namespace(device="test_device", vehicle_type="plane", reboot_time=5)
+        args = argparse.Namespace(device="test_device", vehicle_type="plane", reboot_time=5, baudrate=115200)
         flight_controller, vehicle_type = connect_to_fc_and_set_vehicle_type(args)
 
         assert flight_controller == mock_fc
@@ -131,7 +131,7 @@ class TestMainFunctions(unittest.TestCase):
             mock_window_instance = MagicMock()
             mock_window.return_value = mock_window_instance
 
-            args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5)
+            args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5, baudrate=115200)
             connect_to_fc_and_set_vehicle_type(args)
 
             # Verify ConnectionSelectionWindow was created with the right parameters
@@ -198,6 +198,7 @@ class TestMainFunctions(unittest.TestCase):
             # Just calling connect_to_fc_and_set_vehicle_type to get flight_controller
             args = argparse.Namespace(
                 device="test_device",
+                baudrate=115200,
                 vehicle_type="",
                 reboot_time=5,
                 n=0,

--- a/tests/test_backend_flightcontroller.py
+++ b/tests/test_backend_flightcontroller.py
@@ -17,26 +17,26 @@ from ardupilot_methodic_configurator.backend_flightcontroller import FlightContr
 
 
 def test_add_connection() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     assert fc.add_connection("test_connection") is True
     assert fc.add_connection("test_connection") is False
     assert fc.add_connection("") is False
 
 
 def test_discover_connections() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.discover_connections()
     assert len(fc.get_connection_tuples()) > 0
 
 
 def test_connect() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     result = fc.connect(device="test")
     assert result == ""
 
 
 def test_disconnect() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     fc.disconnect()
     assert fc.master is None
@@ -48,7 +48,7 @@ def test_disconnect() -> None:
     side_effect=lambda x: {"param1": Par(1, x), "param2": Par(2, x)},
 )
 def test_download_params(mock_load_param_file_into_dict, mock_file) -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     with patch("ardupilot_methodic_configurator.backend_flightcontroller.open", mock_file):
         params, _ = fc.download_params()
@@ -63,7 +63,7 @@ def test_download_params(mock_load_param_file_into_dict, mock_file) -> None:
     side_effect=lambda x: {"param1": Par(1, x), "param2": Par(2, x)},
 )
 def test_set_param(mock_load_param_file_into_dict, mock_file) -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     fc.set_param("TEST_PARAM", 1.0)
     with patch("ardupilot_methodic_configurator.backend_flightcontroller.open", mock_file):
@@ -73,14 +73,14 @@ def test_set_param(mock_load_param_file_into_dict, mock_file) -> None:
 
 
 def test_reset_and_reconnect() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     result = fc.reset_and_reconnect()
     assert result == ""
 
 
 def test_upload_file() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     result = fc.upload_file("local.txt", "remote.txt")
     # Assuming the mock environment always returns False for upload_file
@@ -88,7 +88,7 @@ def test_upload_file() -> None:
 
 
 def test_get_connection_tuples() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.add_connection("test_connection")
     connections = fc.get_connection_tuples()
     assert ("test_connection", "test_connection") in connections
@@ -100,7 +100,7 @@ def test_get_connection_tuples() -> None:
     side_effect=lambda x: {"param1": Par(1, x), "param2": Par(2, x)},
 )
 def test_set_param_and_verify(mock_load_param_file_into_dict, mock_file) -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     fc.set_param("TEST_PARAM", 1.0)
     with patch("ardupilot_methodic_configurator.backend_flightcontroller.open", mock_file):
@@ -111,7 +111,7 @@ def test_set_param_and_verify(mock_load_param_file_into_dict, mock_file) -> None
 
 
 def test_download_params_via_mavftp() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     params, default_params = fc.download_params_via_mavftp()
     assert isinstance(params, dict)
@@ -119,7 +119,7 @@ def test_download_params_via_mavftp() -> None:
 
 
 def test_auto_detect_serial() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     serial_ports = fc._FlightController__auto_detect_serial()  # pylint: disable=protected-access
     assert isinstance(serial_ports, list)
 
@@ -136,34 +136,34 @@ def test_list_network_ports() -> None:
 
 
 def test_request_banner() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     fc._FlightController__request_banner()  # pylint: disable=protected-access
     # Since we cannot verify in the mock environment, we will just ensure no exceptions are raised
 
 
 def test_receive_banner_text() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     banner_text = fc._FlightController__receive_banner_text()  # pylint: disable=protected-access
     assert isinstance(banner_text, list)
 
 
 def test_request_message() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     fc._FlightController__request_message(1)  # pylint: disable=protected-access
     # Since we cannot verify in the mock environment, we will just ensure no exceptions are raised
 
 
 def test_create_connection_with_retry() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     result = fc._FlightController__create_connection_with_retry(progress_callback=None, retries=1, timeout=1)  # pylint: disable=protected-access
     assert result == ""
 
 
 def test_process_autopilot_version() -> None:
-    fc = FlightController(reboot_time=7)
+    fc = FlightController(reboot_time=7, baudrate=115200)
     fc.connect(device="test")
     banner_msgs = ["ChibiOS: 123", "ArduPilot"]
     result = fc._FlightController__process_autopilot_version(None, banner_msgs)  # pylint: disable=protected-access


### PR DESCRIPTION
This pull request introduces support for configuring the baud rate for MAVLink serial connections to the flight controller, along with improvements to the `FlightController` class and its usage across the codebase. The changes include adding a `baudrate` parameter with a default value, updating related methods to use this parameter, and adjusting tests accordingly.

### Enhancements to `FlightController` functionality:
* [`ardupilot_methodic_configurator/backend_flightcontroller.py`](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376R63-R66): Added `DEFAULT_BAUDRATE` and `DEFAULT_REBOOT_TIME` constants. Updated the `FlightController` class to include a `baudrate` parameter with a default value, and modified the `__create_connection_with_retry` method to use this parameter when establishing connections. [[1]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376R63-R66) [[2]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376L74-R85) [[3]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376L170-R177) [[4]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376R234) [[5]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376L255-R268)

### Updates to argument parsing:
* [`ardupilot_methodic_configurator/backend_flightcontroller.py`](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376R619-R624): Enhanced the `add_argparse_arguments` method to include a `--baudrate` argument for specifying the MAVLink serial connection baud rate. Updated the default value for `--reboot_time` to use `DEFAULT_REBOOT_TIME`. [[1]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376R619-R624) [[2]](diffhunk://#diff-289e82157f271122ec2b5c50452ffe6b9f0f8226ce1ac9b8bd414dba90825376L623-R642)

### Code adjustments for `FlightController` initialization:
* `ardupilot_methodic_configurator/__main__.py`, `ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py`, `ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py`: Updated the initialization of `FlightController` instances to include the `baudrate` parameter. [[1]](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fL82-R82) [[2]](diffhunk://#diff-e8e2fdf0d2330fee8caec9b69f994f4ae055df1c4f578214ce3ef77eadabf2ddL288-R289) [[3]](diffhunk://#diff-66416537a8c3d05fc24b29ee4b158b15e4bade6fe86f9229e780081570a279b5L964-R964)

### Test updates:
* [`tests/test_backend_flightcontroller.py`](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L20-R39): Modified tests to initialize `FlightController` with the new `baudrate` parameter and verify its functionality across various methods. [[1]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L20-R39) [[2]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L51-R51) [[3]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L66-R66) [[4]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L76-R91) [[5]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L103-R103) [[6]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L114-R122) [[7]](diffhunk://#diff-35bd4b36bd97e902694e4fe943b0a6409af90f0f40fcb490b2ed1612740cac44L139-R166)