### PR TITLE
Add PEP 723 header to scripts/crawl_ardupilot_wiki.py

### DIFF
--- a/scripts/crawl_ardupilot_wiki.py
+++ b/scripts/crawl_ardupilot_wiki.py
@@ -1,4 +1,12 @@
-#!/usr/bin/python3
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "beautifulsoup4",
+#     "requests",
+# ]
+# ///
 
 """
 Outputs URLs of ArduPilot documentation pages.
@@ -69,7 +77,7 @@ def get_env_proxies() -> Union[dict[str, str], None]:
     # Remove None values
     proxies_dict: dict[str, str] = {k: v for k, v in proxies_env.items() if v is not None}
     # define as None if no proxies are defined in the OS environment variables
-    proxies = proxies_dict if proxies_dict else None
+    proxies = proxies_dict or None
     if proxies:
         logging.info("Proxies: %s", proxies)
     else:


### PR DESCRIPTION
OPTIONAL!!!  This is an approach that I have found useful for scripts with PyPI dependencies.

https://peps.python.org/pep-0723 enables Python files to have a header like:
```python
# /// script
# requires-python = ">=3.9"
# dependencies = [
#     "requests",
# ]
# ///
```
which enables:
`pipx run scripts/crawl_ardupilot_wiki.py` or
`uv run --script scripts/crawl_ardupilot_wiki.py`.

When this command is run, `pipx` or `uv` will import the dependencies from PyPI, put them in an isolated `venv`, and then run the script in that `venv`.

https://thisdavej.com/share-python-scripts-like-a-pro-uv-and-pep-723-for-easy-deployment