### PR TITLE
Automatically open all available documentation links when in simple mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,6 +85,9 @@ the following system design requirements were derived:
     - In the parameter editor:
       - hiding the "Upload" column, "Current intermediate parameter file" combobox, "See only changed parameters" checkbox, and "Annotate docs into .param files" checkbox;
       - automatically selecting all parameters for upload
+    - In the documentation frame:
+      - automatically opening all available documentation links (wiki, external tools, blog posts) in the browser
+        when the current intermediate parameter file changes, providing immediate access to relevant documentation for beginners
   - When set to "normal", all interface elements are displayed for advanced users
   - Users should be able to switch between complexity levels using a dropdown combobox in the component editor
 

--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -164,7 +164,7 @@ def component_editor(
         sys_exit(1)
 
 
-def main() -> None:
+def main() -> None:  # pylint: disable=too-many-locals
     args = create_argument_parser().parse_args()
 
     logging_basicConfig(level=logging_getLevelName(args.loglevel), format="%(asctime)s - %(levelname)s - %(message)s")
@@ -209,7 +209,9 @@ def main() -> None:
 
     vehicle_dir_window = None
     if not files:
-        vehicle_dir_window = VehicleDirectorySelectionWindow(local_filesystem, len(flight_controller.fc_parameters) > 0)
+        fc_connected = len(flight_controller.fc_parameters) > 0
+        connected_fc_vehicle_type = flight_controller.info.vehicle_type if fc_connected else ""
+        vehicle_dir_window = VehicleDirectorySelectionWindow(local_filesystem, fc_connected, connected_fc_vehicle_type)
         vehicle_dir_window.root.mainloop()
 
     component_editor(args, flight_controller, local_filesystem.vehicle_type, local_filesystem, vehicle_dir_window)

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -205,8 +205,14 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
 
         # Create a new frame inside the config_subframe for the intermediate parameter file directory selection labels
         # and directory selection button
+        connected_vehicle_type = self.flight_controller.info.vehicle_type if self.flight_controller.info.vehicle_type else ""
         directory_selection_frame = VehicleDirectorySelectionWidgets(
-            self, config_subframe, self.local_filesystem, self.local_filesystem.vehicle_dir, destroy_parent_on_open=False
+            self,
+            config_subframe,
+            self.local_filesystem,
+            self.local_filesystem.vehicle_dir,
+            destroy_parent_on_open=False,
+            connected_fc_vehicle_type=connected_vehicle_type,
         )
         if self.gui_complexity != "simple":
             directory_selection_frame.container_frame.pack(side=tk.LEFT, fill="x", expand=False, padx=(4, 6))

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_documentation_frame.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_documentation_frame.py
@@ -134,7 +134,7 @@ class DocumentationFrame:
         mandatory_text, _mandatory_url = self.local_filesystem.get_documentation_text_and_url(current_file, "mandatory")
         self._refresh_mandatory_level(current_file, mandatory_text)
 
-        if self.auto_open_var.get():
+        if self.auto_open_var.get() or ProgramSettings.get_setting("gui_complexity") == "simple":
             if wiki_url:
                 webbrowser_open(url=wiki_url, new=0, autoraise=False)
             if external_tool_url:

--- a/tests/test_frontend_tkinter_component_editor_base.py
+++ b/tests/test_frontend_tkinter_component_editor_base.py
@@ -22,7 +22,7 @@ from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
 from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
 from ardupilot_methodic_configurator.data_model_vehicle_components import ComponentDataModel
 from ardupilot_methodic_configurator.frontend_tkinter_component_editor_base import (
-    VEICLE_IMAGE_WIDTH_PIX,
+    VEHICLE_IMAGE_WIDTH_PIX,
     WINDOW_WIDTH_PIX,
     ComponentEditorWindowBase,
     EntryWidget,
@@ -666,10 +666,10 @@ class TestModuleConstants:
     def test_window_dimensions_are_reasonable(self) -> None:
         """Test that window dimensions are reasonable values."""
         assert WINDOW_WIDTH_PIX == 880
-        assert VEICLE_IMAGE_WIDTH_PIX == 100
-        assert WINDOW_WIDTH_PIX > VEICLE_IMAGE_WIDTH_PIX
+        assert VEHICLE_IMAGE_WIDTH_PIX == 100
+        assert WINDOW_WIDTH_PIX > VEHICLE_IMAGE_WIDTH_PIX
         assert WINDOW_WIDTH_PIX > 500  # Minimum reasonable width
-        assert VEICLE_IMAGE_WIDTH_PIX > 50  # Minimum reasonable image width
+        assert VEHICLE_IMAGE_WIDTH_PIX > 50  # Minimum reasonable image width
 
     def test_entry_widget_type_alias_definition(self) -> None:
         """Test that EntryWidget type alias is correctly defined."""

--- a/tests/test_frontend_tkinter_directory_selection.py
+++ b/tests/test_frontend_tkinter_directory_selection.py
@@ -151,6 +151,7 @@ def directory_selection_widgets(root: tk.Tk, base_parent: MagicMock) -> Generato
             dir_tooltip="Test directory tooltip",
             button_tooltip="Select directory button tooltip",
             is_template_selection=False,
+            connected_fc_vehicle_type="",
         )
         yield widget
 
@@ -214,6 +215,7 @@ def test_directory_selection_widgets_template_selection(base_parent, root) -> No
                     dir_tooltip="Template directory tooltip",
                     button_tooltip="Select template button tooltip",
                     is_template_selection=True,
+                    connected_fc_vehicle_type="ArduCopter",
                 )
 
                 # Call the method to select a template
@@ -250,6 +252,7 @@ def test_directory_selection_widgets_autoresize_width(base_parent, root) -> None
             dir_tooltip="Tooltip",
             button_tooltip="Button tooltip",
             is_template_selection=False,
+            connected_fc_vehicle_type="ArduCopter",
         )
 
         # Test with autoresize_width=False
@@ -262,6 +265,7 @@ def test_directory_selection_widgets_autoresize_width(base_parent, root) -> None
             dir_tooltip="Another tooltip",
             button_tooltip="Another button tooltip",
             is_template_selection=False,
+            connected_fc_vehicle_type="ArduCopter",
         )
 
         # Verify the difference in behavior when selecting a directory
@@ -297,6 +301,7 @@ def test_directory_selection_widgets_extremely_long_path(base_parent, root) -> N
             dir_tooltip="Test tooltip",
             button_tooltip="Button tooltip",
             is_template_selection=False,
+            connected_fc_vehicle_type="ArduCopter",
         )
 
         # Create an extremely long path
@@ -335,6 +340,7 @@ def test_directory_selection_widgets_special_characters(base_parent, root) -> No
             dir_tooltip="Test tooltip",
             button_tooltip="Button tooltip",
             is_template_selection=False,
+            connected_fc_vehicle_type="ArduCopter",
         )
 
         # Test with paths containing special characters
@@ -1165,11 +1171,19 @@ def test_create_option1_widgets(root, photo_patcher, icon_patcher, mock_local_fi
                                 with patch.object(window, "create_option1_widgets", mock_create_option1):
                                     # Call the method via the patched object
                                     window.create_option1_widgets(
-                                        "/template/dir", "/base/dir", "vehicle_name", fc_connected=True
+                                        "/template/dir",
+                                        "/base/dir",
+                                        "vehicle_name",
+                                        fc_connected=True,
+                                        connected_fc_vehicle_type="ArduCopter",
                                     )
                                     # Verify it was called with the correct arguments
                                     mock_create_option1.assert_called_once_with(
-                                        "/template/dir", "/base/dir", "vehicle_name", fc_connected=True
+                                        "/template/dir",
+                                        "/base/dir",
+                                        "vehicle_name",
+                                        fc_connected=True,
+                                        connected_fc_vehicle_type="ArduCopter",
                                     )
 
 
@@ -1203,6 +1217,7 @@ def test_ui_interaction_directory_selection_widgets() -> None:
                     dir_tooltip="Test tooltip",
                     button_tooltip="Select directory",
                     is_template_selection=True,
+                    connected_fc_vehicle_type="ArduCopter",
                 )
 
                 # Verify initial state

--- a/tests/test_frontend_tkinter_directory_selection_integration.py
+++ b/tests/test_frontend_tkinter_directory_selection_integration.py
@@ -345,6 +345,7 @@ def test_directory_selection_widgets_interaction(root: tk.Tk, monkeypatch: pytes
                     dir_tooltip="Test tooltip",
                     button_tooltip="Select directory",
                     is_template_selection=False,
+                    connected_fc_vehicle_type="ArduCopter",
                 )
 
                 # Update UI
@@ -383,6 +384,7 @@ def test_keyboard_navigation(root: tk.Tk, monkeypatch: pytest.MonkeyPatch) -> No
                 dir_tooltip="Test tooltip",
                 button_tooltip="Test button tooltip",
                 is_template_selection=False,
+                connected_fc_vehicle_type="ArduCopter",
             )
 
             # Ensure widgets are created and displayed


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the codebase, focusing on improved user experience, better handling of connected flight controller data, and minor bug fixes. The key changes include adding support for filtering templates based on the connected flight controller's vehicle type, modifying the GUI to automatically open documentation links in simplified mode, and fixing a typo in a constant name.

### Enhancements to GUI and functionality:

* [`ARCHITECTURE.md`](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR88-R90): Updated documentation to specify that all available documentation links (wiki, external tools, blog posts) will now automatically open in the browser when the intermediate parameter file changes, improving accessibility for beginners.
* [`ardupilot_methodic_configurator/__main__.py`](diffhunk://#diff-07c8aae629798ce99b3a341b36fe9273c6afcf8de3d503dfbc9e720055f5630fL212-R214): Modified the `VehicleDirectorySelectionWindow` initialization to include the connected flight controller's vehicle type, enabling context-aware directory selection.

### Support for connected flight controller data:

* [`ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py`](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8R52-R59): Added a `connected_fc_vehicle_type` parameter to various classes and methods, allowing filtering and context-specific behavior based on the flight controller's vehicle type. This includes updates to the `DirectorySelectionWidgets` and `VehicleDirectorySelectionWindow` classes, as well as the `create_option1_widgets` and `create_option2_widgets` methods. [[1]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8R52-R59) [[2]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L234-R243) [[3]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L272-R285) [[4]](diffhunk://#diff-a905b22cef87c69aa1b10b35af17721b5aa0ad2a995994a4360e3353e4266de8L407-R426)
* [`ardupilot_methodic_configurator/frontend_tkinter_template_overview.py`](diffhunk://#diff-478c6b619593c0326b286fd054ee544e8b621ed92993649a869c3bf83223a319R89): Updated the `TemplateOverviewWindow` class to filter templates in the tree view based on the connected flight controller's vehicle type. [[1]](diffhunk://#diff-478c6b619593c0326b286fd054ee544e8b621ed92993649a869c3bf83223a319R89) [[2]](diffhunk://#diff-478c6b619593c0326b286fd054ee544e8b621ed92993649a869c3bf83223a319L216-R230)

### Improvements to documentation and simplified mode:

* [`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_documentation_frame.py`](diffhunk://#diff-8d1b8cc33fffc4f73bbcb80f054ba5131926a8bb4ef5b152561f0523c2130e61L137-R137): Enhanced the `refresh_documentation_labels` method to automatically open documentation links in the browser when the GUI complexity is set to "simple".

### Bug fixes and code quality:

* [`tests/test_frontend_tkinter_component_editor_base.py`](diffhunk://#diff-9266c56e86ddb9645dabb33740afddfdd16727aa4dbe47781bce9f8812f96e47L25-R25): Fixed a typo in the constant name `VEICLE_IMAGE_WIDTH_PIX`, correcting it to `VEHICLE_IMAGE_WIDTH_PIX`. Updated related test cases accordingly. [[1]](diffhunk://#diff-9266c56e86ddb9645dabb33740afddfdd16727aa4dbe47781bce9f8812f96e47L25-R25) [[2]](diffhunk://#diff-9266c56e86ddb9645dabb33740afddfdd16727aa4dbe47781bce9f8812f96e47L669-R672)
* [`tests/test_frontend_tkinter_directory_selection.py`](diffhunk://#diff-1d43a252b208270f18a3807dc47e9a996e8c70f13f8c287e23f84c68f87ad475R154): Updated test cases to include the `connected_fc_vehicle_type` parameter for better coverage of new functionality. [[1]](diffhunk://#diff-1d43a252b208270f18a3807dc47e9a996e8c70f13f8c287e23f84c68f87ad475R154) [[2]](diffhunk://#diff-1d43a252b208270f18a3807dc47e9a996e8c70f13f8c287e23f84c68f87ad475R218)