### PR TITLE
Refactored the file for testability and added many behaviour-tests

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -45,6 +45,19 @@ from ardupilot_methodic_configurator.frontend_tkinter_show import show_error_mes
 from ardupilot_methodic_configurator.middleware_software_updates import UpdateManager, check_for_software_updates
 
 
+class ApplicationState:  # pylint: disable=too-few-public-methods
+    """Data class to hold application state throughout the startup process."""
+
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.flight_controller: FlightController = None  # type: ignore[assignment]
+        self.vehicle_type: str = ""
+        self.param_default_values: dict = {}
+        self.local_filesystem: LocalFilesystem = None  # type: ignore[assignment]
+        self.vehicle_dir_window: Union[VehicleDirectorySelectionWindow, None] = None
+        self.param_default_values_dirty: bool = False
+
+
 def create_argument_parser() -> argparse.ArgumentParser:
     """
     Argument parser to handle the command-line arguments for the script.
@@ -78,6 +91,35 @@ def create_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def setup_logging_and_check_updates(state: ApplicationState) -> bool:
+    """
+    Set up logging and check for software updates.
+
+    Args:
+        state: Application state containing parsed arguments
+
+    Returns:
+        True if the application should exit due to updates, False otherwise
+
+    """
+    logging_basicConfig(level=logging_getLevelName(state.args.loglevel), format="%(asctime)s - %(levelname)s - %(message)s")
+
+    if not state.args.skip_check_for_updates and check_for_software_updates():
+        logging_info(_("Will now exit the old software version."))
+        return True
+    return False
+
+
+def display_first_use_documentation() -> None:
+    """Open documentation in browser if enabled in settings."""
+    if bool(ProgramSettings.get_setting("auto_open_doc_in_browser")):
+        url = (
+            "https://ardupilot.github.io/MethodicConfigurator/USECASES.html"
+            "#use-the-ardupilot-methodic-configurator-software-for-the-first-time"
+        )
+        webbrowser_open(url=url, new=0, autoraise=True)
+
+
 def connect_to_fc_and_set_vehicle_type(args: argparse.Namespace) -> tuple[FlightController, str]:
     flight_controller = FlightController(reboot_time=args.reboot_time, baudrate=args.baudrate)
 
@@ -99,153 +141,342 @@ def connect_to_fc_and_set_vehicle_type(args: argparse.Namespace) -> tuple[Flight
     return flight_controller, vehicle_type
 
 
-def component_editor(
-    args: argparse.Namespace,
+def initialize_flight_controller_and_filesystem(state: ApplicationState) -> None:
+    """
+    Initialize flight controller connection and local filesystem.
+
+    Args:
+        state: Application state to populate with initialized objects
+
+    Raises:
+        SystemExit: If there's a fatal error reading parameter files
+
+    """
+    # Connect to the flight controller and read the parameters
+    state.flight_controller, state.vehicle_type = connect_to_fc_and_set_vehicle_type(state.args)
+
+    # Get default parameter values from flight controller
+    if state.flight_controller.master is not None or state.args.device == "test":
+        fciw = FlightControllerInfoWindow(state.flight_controller)
+        state.param_default_values = fciw.get_param_default_values()
+
+    # Initialize local filesystem
+    try:
+        state.local_filesystem = LocalFilesystem(
+            state.args.vehicle_dir,
+            state.vehicle_type,
+            state.flight_controller.info.flight_sw_version,
+            state.args.allow_editing_template_files,
+            state.args.save_component_to_system_templates,
+        )
+    except SystemExit as exp:
+        show_error_message(_("Fatal error reading parameter files"), f"{exp}")
+        raise
+
+    # Write parameter default values if available
+    if state.param_default_values:
+        state.param_default_values_dirty = state.local_filesystem.write_param_default_values(state.param_default_values)
+
+
+def vehicle_directory_selection(state: ApplicationState) -> Union[VehicleDirectorySelectionWindow, None]:
+    """
+    Handle vehicle directory selection if no parameter files are found.
+
+    Args:
+        state: Application state containing filesystem and flight controller info
+
+    Returns:
+        VehicleDirectorySelectionWindow if selection was needed, None otherwise
+
+    """
+    # Get the list of intermediate parameter files that will be processed sequentially
+    files = list(state.local_filesystem.file_parameters.keys()) if state.local_filesystem.file_parameters else []
+
+    if not files:
+        fc_connected = len(state.flight_controller.fc_parameters) > 0
+        if not state.vehicle_type:
+            logging_debug(
+                _(
+                    "Will present all vehicle templates for all vehicle types since no "
+                    "FC connected and no explicit vehicle type set on the command line"
+                )
+            )
+        state.vehicle_dir_window = VehicleDirectorySelectionWindow(state.local_filesystem, fc_connected, state.vehicle_type)
+        state.vehicle_dir_window.root.mainloop()
+        return state.vehicle_dir_window
+    return None
+
+
+def create_and_configure_component_editor(
+    version: str,
+    local_filesystem: LocalFilesystem,
     flight_controller: FlightController,
     vehicle_type: str,
-    local_filesystem: LocalFilesystem,
     vehicle_dir_window: Union[None, VehicleDirectorySelectionWindow],
-) -> None:
-    component_editor_window = ComponentEditorWindow(__version__, local_filesystem)
+) -> ComponentEditorWindow:
+    """
+    Create and configure the component editor window.
+
+    Args:
+        version: Application version
+        local_filesystem: Local filesystem instance
+        flight_controller: Flight controller instance
+        vehicle_type: Vehicle type string
+        vehicle_dir_window: Vehicle directory selection window if any
+
+    Returns:
+        Configured ComponentEditorWindow instance
+
+    """
+    component_editor_window = ComponentEditorWindow(version, local_filesystem)
+
+    # Infer component specifications from FC parameters if requested
     if (
         vehicle_dir_window
         and vehicle_dir_window.configuration_template
         and vehicle_dir_window.infer_comp_specs_and_conn_from_fc_params.get()
         and flight_controller.fc_parameters
     ):
-        # Infer vehicle component specifications and connections from FC parameters
         component_editor_window.set_values_from_fc_parameters(flight_controller.fc_parameters, local_filesystem.doc_dict)
+
+    # Configure basic window properties
     component_editor_window.populate_frames()
     component_editor_window.set_vehicle_type_and_version(vehicle_type, flight_controller.info.flight_sw_version_and_type)
     component_editor_window.set_fc_manufacturer(flight_controller.info.vendor)
     component_editor_window.set_fc_model(flight_controller.info.firmware_type)
     component_editor_window.set_mcu_series(flight_controller.info.mcu_series)
+
+    # Set configuration template if available
     if vehicle_dir_window and vehicle_dir_window.configuration_template:
         component_editor_window.set_vehicle_configuration_template(vehicle_dir_window.configuration_template)
-    if args.skip_component_editor:
-        component_editor_window.root.after(10, component_editor_window.root.destroy)
-    elif (
+
+    return component_editor_window
+
+
+def should_open_firmware_documentation(flight_controller: FlightController) -> bool:
+    """
+    Determine if firmware documentation should be opened automatically.
+
+    Args:
+        flight_controller: Flight controller instance
+
+    Returns:
+        True if documentation should be opened, False otherwise
+
+    """
+    return (
         bool(ProgramSettings.get_setting("auto_open_doc_in_browser"))
         and flight_controller.info.firmware_type != _("Unknown")
         and flight_controller.info.firmware_type != ""
-    ):
-        firmware_type = flight_controller.info.firmware_type
-        url = f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{firmware_type}/README.md"
-        url_found = verify_and_open_url(url)
-        if not url_found and firmware_type.endswith("-bdshot"):
-            firmware_type = firmware_type[:-7]
-            url = (
-                f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{firmware_type}/README.md"
-            )
-            url_found = verify_and_open_url(url)
+    )
 
+
+def open_firmware_documentation(firmware_type: str) -> bool:
+    """
+    Open firmware-specific documentation in browser.
+
+    Args:
+        firmware_type: Firmware type identifier
+
+    Returns:
+        True if documentation was found and opened, False otherwise
+
+    """
+    url = f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{firmware_type}/README.md"
+    url_found = verify_and_open_url(url)
+
+    if not url_found and firmware_type.endswith("-bdshot"):
+        # Try without the bdshot suffix
+        base_firmware_type = firmware_type[:-7]
+        fallback_url = (
+            f"https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/{base_firmware_type}/README.md"
+        )
+        url_found = verify_and_open_url(fallback_url)
+
+    return url_found
+
+
+def component_editor(state: ApplicationState) -> None:
+    """
+    Run the component editor workflow.
+
+    Args:
+        state: Application state containing all necessary objects
+
+    Raises:
+        SystemExit: If there's an error in derived parameters
+
+    """
+    # Create and configure the component editor window
+    component_editor_window = create_and_configure_component_editor(
+        __version__,
+        state.local_filesystem,
+        state.flight_controller,
+        state.local_filesystem.vehicle_type,
+        state.vehicle_dir_window,
+    )
+
+    # Handle skip component editor option
+    if state.args.skip_component_editor:
+        component_editor_window.root.after(10, component_editor_window.root.destroy)
+    elif should_open_firmware_documentation(state.flight_controller):
+        open_firmware_documentation(state.flight_controller.info.firmware_type)
+
+    # Run the GUI
     component_editor_window.root.mainloop()
 
-    source_param_values: Union[dict[str, float], None] = (
-        flight_controller.fc_parameters
-        if vehicle_dir_window and vehicle_dir_window.configuration_template and vehicle_dir_window.use_fc_params.get()
-        else None
-    )
-    existing_fc_params: list[str] = (
-        list(flight_controller.fc_parameters.keys())
-        if flight_controller.fc_parameters
-        else list(local_filesystem.param_default_dict.keys())
-        if local_filesystem.param_default_dict
-        else []
-    )
-    # if source_param_values is None, the template parameter values are used
-    # if source_param_values contains the connected FC parameters, then they are used
+
+def process_component_editor_results(
+    flight_controller: FlightController,
+    local_filesystem: LocalFilesystem,
+    vehicle_dir_window: Union[None, VehicleDirectorySelectionWindow],
+) -> None:
+    """
+    Process the results after component editor completion.
+
+    Args:
+        flight_controller: Flight controller instance
+        local_filesystem: Local filesystem instance
+        vehicle_dir_window: Vehicle directory selection window if any
+
+    Raises:
+        SystemExit: If there's an error in derived parameters
+
+    """
+    # Determine parameter source
+    source_param_values: Union[dict[str, float], None] = None
+    if vehicle_dir_window and vehicle_dir_window.configuration_template and vehicle_dir_window.use_fc_params.get():
+        source_param_values = flight_controller.fc_parameters
+
+    # Get existing FC parameters for reference
+    existing_fc_params: list[str] = []
+    if flight_controller.fc_parameters:
+        existing_fc_params = list(flight_controller.fc_parameters.keys())
+    elif local_filesystem.param_default_dict:
+        existing_fc_params = list(local_filesystem.param_default_dict.keys())
+
+    # Update and export vehicle parameters
     error_message = local_filesystem.update_and_export_vehicle_params_from_fc(
         source_param_values=source_param_values, existing_fc_params=existing_fc_params
     )
+
     if error_message:
         logging_error(error_message)
         show_error_message(_("Error in derived parameters"), error_message)
         sys_exit(1)
 
 
-def main() -> None:  # pylint: disable=too-many-locals
-    args = create_argument_parser().parse_args()
+def write_parameter_defaults_if_dirty(state: ApplicationState) -> None:
+    """
+    Write parameter default values to file if they have been modified.
 
-    logging_basicConfig(level=logging_getLevelName(args.loglevel), format="%(asctime)s - %(levelname)s - %(message)s")
+    Args:
+        state: Application state containing filesystem, parameters, and dirty flag
 
-    if not args.skip_check_for_updates and check_for_software_updates():
-        logging_info(_("Will now exit the old software version."))
-        sys_exit(0)
+    """
+    if state.param_default_values_dirty:
+        state.local_filesystem.write_param_default_values_to_file(state.param_default_values)
 
-    if bool(ProgramSettings.get_setting("auto_open_doc_in_browser")):
-        url = (
-            "https://ardupilot.github.io/MethodicConfigurator/USECASES.html"
-            "#use-the-ardupilot-methodic-configurator-software-for-the-first-time"
-        )
-        webbrowser_open(url=url, new=0, autoraise=True)
 
-    # Connect to the flight controller and read the parameters
-    flight_controller, vehicle_type = connect_to_fc_and_set_vehicle_type(args)
+def backup_fc_parameters(state: ApplicationState) -> None:
+    """
+    Create backup files of current flight controller parameters.
 
-    param_default_values = {}
-    if flight_controller.master is not None or args.device == "test":
-        fciw = FlightControllerInfoWindow(flight_controller)
-        param_default_values = fciw.get_param_default_values()
+    Args:
+        state: Application state containing flight controller and filesystem
 
-    try:
-        local_filesystem = LocalFilesystem(
-            args.vehicle_dir,
-            vehicle_type,
-            flight_controller.info.flight_sw_version,
-            args.allow_editing_template_files,
-            args.save_component_to_system_templates,
-        )
-    except SystemExit as exp:
-        show_error_message(_("Fatal error reading parameter files"), f"{exp}")
-        raise
+    """
+    if state.flight_controller.fc_parameters:
+        try:
+            # Create initial backup
+            state.local_filesystem.backup_fc_parameters_to_file(
+                state.flight_controller.fc_parameters,
+                "autobackup_00_before_ardupilot_methodic_configurator.param",
+                overwrite_existing_file=False,
+                even_if_last_uploaded_filename_exists=False,
+            )
 
-    param_default_values_dirty = False
-    if param_default_values:
-        param_default_values_dirty = local_filesystem.write_param_default_values(param_default_values)
+            # Create incremental backup file
+            backup_num = state.local_filesystem.find_lowest_available_backup_number()
+            state.local_filesystem.backup_fc_parameters_to_file(
+                state.flight_controller.fc_parameters,
+                f"autobackup_{backup_num:02d}.param",
+                overwrite_existing_file=True,
+                even_if_last_uploaded_filename_exists=True,
+            )
+            logging_info(_("Created backup file autobackup_%02d.param"), backup_num)
+        except PermissionError as e:
+            logging_error(_("Permission denied when creating backup files: %s"), str(e))
+            logging_error(_("Please check file permissions and ensure you have write access to the vehicle directory"))
+        except OSError as e:
+            if "No space left on device" in str(e) or "28" in str(e):
+                logging_error(_("Insufficient disk space to create backup files: %s"), str(e))
+                logging_error(_("Please free up disk space and try again"))
+            else:
+                logging_error(_("Failed to create backup files: %s"), str(e))
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging_error(_("Unexpected error creating backup files: %s"), str(e))
 
-    # Get the list of intermediate parameter files files that will be processed sequentially
-    files = list(local_filesystem.file_parameters.keys()) if local_filesystem.file_parameters else []
 
-    vehicle_dir_window = None
-    if not files:
-        fc_connected = len(flight_controller.fc_parameters) > 0
-        connected_fc_vehicle_type = flight_controller.info.vehicle_type if fc_connected else ""
-        vehicle_dir_window = VehicleDirectorySelectionWindow(local_filesystem, fc_connected, connected_fc_vehicle_type)
-        vehicle_dir_window.root.mainloop()
+def parameter_editor_and_uploader(state: ApplicationState) -> None:
+    """
+    Start the parameter editor with the appropriate starting file.
 
-    component_editor(args, flight_controller, local_filesystem.vehicle_type, local_filesystem, vehicle_dir_window)
+    Args:
+        state: Application state containing all necessary objects
 
-    # now that we are sure that the vehicle directory is set, we can write the default values to the file
-    if param_default_values_dirty:
-        local_filesystem.write_param_default_values_to_file(param_default_values)
-
-    imu_tcal_available = "INS_TCAL1_ENABLE" in flight_controller.fc_parameters or not flight_controller.fc_parameters
+    """
+    imu_tcal_available = (
+        "INS_TCAL1_ENABLE" in state.flight_controller.fc_parameters or not state.flight_controller.fc_parameters
+    )
     simple_gui: bool = ProgramSettings.get_setting("gui_complexity") == "simple"
-    start_file = local_filesystem.get_start_file(args.n, imu_tcal_available and not simple_gui)
-
-    if flight_controller.fc_parameters:
-        local_filesystem.backup_fc_parameters_to_file(
-            flight_controller.fc_parameters,
-            "autobackup_00_before_ardupilot_methodic_configurator.param",
-            overwrite_existing_file=False,
-            even_if_last_uploaded_filename_exists=False,
-        )
-        # Create incremental backup file
-        backup_num = local_filesystem.find_lowest_available_backup_number()
-        local_filesystem.backup_fc_parameters_to_file(
-            flight_controller.fc_parameters,
-            f"autobackup_{backup_num:02d}.param",
-            overwrite_existing_file=True,
-            even_if_last_uploaded_filename_exists=True,
-        )
-        logging_info(_("Created backup file autobackup_%02d.param"), backup_num)
+    start_file = state.local_filesystem.get_start_file(state.args.n, imu_tcal_available and not simple_gui)
 
     # Call the GUI function with the starting intermediate parameter file
-    ParameterEditorWindow(start_file, flight_controller, local_filesystem)
+    ParameterEditorWindow(start_file, state.flight_controller, state.local_filesystem)
 
-    # Close the connection to the flight controller
-    flight_controller.disconnect()
+
+def main() -> None:
+    """
+    Main application entry point.
+
+    Orchestrates the entire application startup process by calling specialized functions
+    for each major step.
+    """
+    # Parse arguments and create application state
+    args = create_argument_parser().parse_args()
+    state = ApplicationState(args)
+
+    # Set up logging and check for updates
+    if setup_logging_and_check_updates(state):
+        sys_exit(0)
+
+    # Handle auto-opening documentation
+    display_first_use_documentation()
+
+    # Initialize flight controller and filesystem
+    initialize_flight_controller_and_filesystem(state)
+
+    # Handle vehicle directory selection if needed
+    vehicle_directory_selection(state)
+
+    # Run component editor workflow
+    component_editor(state)
+
+    # Process results after component editor GUI closes
+    process_component_editor_results(state.flight_controller, state.local_filesystem, state.vehicle_dir_window)
+
+    # Write parameter default values to file if dirty
+    write_parameter_defaults_if_dirty(state)
+
+    # Create parameter backups
+    backup_fc_parameters(state)
+
+    # Start parameter editor
+    parameter_editor_and_uploader(state)
+
+    # Clean up and exit
+    state.flight_controller.disconnect()
     sys_exit(0)
 
 

--- a/ardupilot_methodic_configurator/frontend_tkinter_template_overview.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_template_overview.py
@@ -226,7 +226,7 @@ class TemplateOverviewWindow(BaseWindow):
         for key, template_overview in self.vehicle_components_provider.get_vehicle_components_overviews().items():
             attribute_names = template_overview.attributes()
             values = (key, *(getattr(template_overview, attr, "") for attr in attribute_names))
-            if connected_fc_vehicle_type and connected_fc_vehicle_type not in key:
+            if connected_fc_vehicle_type and not key.startswith(connected_fc_vehicle_type):
                 continue
             self.tree.insert("", "end", text=key, values=values)
 

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 """
-Tests for the __main__.py file.
+Behavior-driven tests for the __main__.py file.
+
+Following pytest_testing_instructions.md guidelines for testability and maintainability.
 
 This file is part of Ardupilot methodic configurator. https://github.com/ArduPilot/MethodicConfigurator
 
@@ -11,275 +13,1196 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import argparse
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ardupilot_methodic_configurator.__main__ import (
+    ApplicationState,
+    backup_fc_parameters,
     component_editor,
     connect_to_fc_and_set_vehicle_type,
+    create_and_configure_component_editor,
     create_argument_parser,
+    display_first_use_documentation,
+    initialize_flight_controller_and_filesystem,
+    open_firmware_documentation,
+    parameter_editor_and_uploader,
+    process_component_editor_results,
+    setup_logging_and_check_updates,
+    should_open_firmware_documentation,
+    vehicle_directory_selection,
+    write_parameter_defaults_if_dirty,
 )
+
+# pylint: disable=,too-many-lines,redefined-outer-name,too-few-public-methods
+
+# ====== Fixtures following pytest_testing_instructions.md ======
 
 
 @pytest.fixture
-def _mock_args(mocker) -> None:
-    mocker.patch(
-        "argparse.ArgumentParser.parse_args", return_value=argparse.Namespace(conn="tcp:127.0.0.1:5760", params="params_dir")
-    )
+def mock_args() -> MagicMock:
+    """Fixture providing realistic mock arguments for application startup."""
+    args = MagicMock(spec=argparse.Namespace)
+    args.loglevel = "INFO"
+    args.skip_check_for_updates = False
+    args.vehicle_dir = "/test/vehicle/dir"
+    args.device = "test"
+    args.vehicle_type = "ArduCopter"
+    args.allow_editing_template_files = False
+    args.save_component_to_system_templates = False
+    args.reboot_time = 10.0
+    args.baudrate = 115200
+    args.skip_component_editor = False
+    args.n = 0
+    return args
 
 
-class TestArgumentParser(unittest.TestCase):
-    """Test the argument_parser function."""
-
-    @pytest.mark.usefixtures("_mock_args")
-    def test_argument_parser(self) -> None:
-        args = create_argument_parser().parse_args()
-        assert args.conn == "tcp:127.0.0.1:5760"
-        assert args.params == "params_dir"
+@pytest.fixture
+def application_state(mock_args: MagicMock) -> ApplicationState:
+    """Fixture providing a configured ApplicationState for behavior testing."""
+    return ApplicationState(mock_args)
 
 
-class TestMainFunctions(unittest.TestCase):
-    """Test the main functions of the __main__.py file."""
+@pytest.fixture
+def mock_flight_controller() -> MagicMock:
+    """Fixture providing a realistic mock flight controller with proper structure."""
+    fc = MagicMock()
+    fc.master = MagicMock()
+    fc.fc_parameters = {"PARAM1": 1.0, "PARAM2": 2.0, "INS_TCAL1_ENABLE": 1}
 
-    @patch("ardupilot_methodic_configurator.__main__.FlightController")
-    def test_connect_to_fc_and_read_parameters(self, mock_flight_controller) -> None:
-        mock_fc = mock_flight_controller.return_value
-        mock_fc.connect.return_value = ""
-        mock_fc.info.vehicle_type = "quad"
-        mock_fc.info.flight_sw_version_and_type = "v1.0"
-        mock_fc.info.vendor = "vendor"
-        mock_fc.info.firmware_type = "type"
+    # Configure flight controller info with realistic data
+    fc.info.vehicle_type = "ArduCopter"
+    fc.info.flight_sw_version = "4.5.0"
+    fc.info.flight_sw_version_and_type = "ArduCopter V4.5.0"
+    fc.info.vendor = "Pixhawk"
+    fc.info.firmware_type = "CubeOrange"
+    fc.info.mcu_series = "STM32H7xx"
 
-        args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5, baudrate=115200)
-        flight_controller, vehicle_type = connect_to_fc_and_set_vehicle_type(args)
-        assert flight_controller == mock_fc
-        assert vehicle_type == "quad"
+    fc.connect.return_value = ""  # No error
+    fc.disconnect.return_value = None
+    return fc
 
-    @patch("ardupilot_methodic_configurator.__main__.ComponentEditorWindow")
-    @patch("ardupilot_methodic_configurator.__main__.LocalFilesystem")
-    @patch("ardupilot_methodic_configurator.__main__.ProgramSettings")
-    @patch("ardupilot_methodic_configurator.__main__.sys_exit")
-    @patch("ardupilot_methodic_configurator.__main__.show_error_message")
-    def test_component_editor(  # pylint: disable=too-many-arguments, too-many-positional-arguments
-        self, mock_show_error, mock_sys_exit, mock_program_settings, mock_local_filesystem, mock_component_editor_window
-    ) -> None:
-        # Setup mock ComponentEditorWindow
-        mock_editor = MagicMock()
-        mock_component_editor_window.return_value = mock_editor
 
-        # Setup mock ProgramSettings
-        mock_program_settings.get_setting.return_value = False
+@pytest.fixture
+def mock_local_filesystem() -> MagicMock:
+    """Fixture providing a realistic mock local filesystem."""
+    fs = MagicMock()
+    fs.vehicle_type = "ArduCopter"
+    fs.file_parameters = {"01_basic.param": {}, "02_advanced.param": {}}
+    fs.param_default_dict = {"PARAM1": 1.0, "PARAM2": 2.0}
+    fs.doc_dict = {"PARAM1": "Parameter 1 documentation"}
 
-        # Setup mock LocalFilesystem
-        mock_local_fs = mock_local_filesystem
-        mock_local_fs.doc_dict = {}
-        mock_local_fs.update_and_export_vehicle_params_from_fc.return_value = ""  # Return success
+    # Configure realistic return values
+    fs.write_param_default_values.return_value = False
+    fs.update_and_export_vehicle_params_from_fc.return_value = None
+    fs.get_start_file.return_value = "01_basic.param"
+    fs.find_lowest_available_backup_number.return_value = 1
 
-        # Setup mock FlightController
-        mock_fc = MagicMock()
-        mock_fc.fc_parameters = {"param1": "value1"}
-        mock_fc.info.flight_sw_version_and_type = "v1.0"
-        mock_fc.info.vendor = "vendor"
-        mock_fc.info.firmware_type = "type"
-        mock_fc.info.mcu_series = "series"
+    return fs
 
-        # Test successful execution
-        args = argparse.Namespace(skip_component_editor=True)  # Skip to avoid mainloop blocking
-        component_editor(args, mock_fc, "quad", mock_local_fs, None)
 
-        # Verify correct method calls
-        mock_component_editor_window.assert_called_once()
-        mock_editor.populate_frames.assert_called_once()
-        mock_editor.set_vehicle_type_and_version.assert_called_once_with("quad", "v1.0")
-        mock_local_fs.update_and_export_vehicle_params_from_fc.assert_called_once_with(
-            source_param_values=None, existing_fc_params=list(mock_fc.fc_parameters.keys())
-        )
-        mock_sys_exit.assert_not_called()
+@pytest.fixture
+def configured_application_state(
+    application_state: ApplicationState, mock_flight_controller: MagicMock, mock_local_filesystem: MagicMock
+) -> ApplicationState:
+    """Fixture providing a fully configured ApplicationState for integration testing."""
+    application_state.flight_controller = mock_flight_controller
+    application_state.local_filesystem = mock_local_filesystem
+    application_state.vehicle_type = "ArduCopter"
+    application_state.param_default_values = {"PARAM1": 1.0, "PARAM2": 2.0}
+    application_state.param_default_values_dirty = False
+    application_state.vehicle_dir_window = None
+    return application_state
 
-        # Test error case
-        mock_local_fs.update_and_export_vehicle_params_from_fc.return_value = "Error message"
-        component_editor(args, mock_fc, "quad", mock_local_fs, None)
 
-        # Verify error handling
-        mock_show_error.assert_called_once()
-        mock_sys_exit.assert_called_once_with(1)
+@pytest.fixture
+def mock_vehicle_directory_window() -> MagicMock:
+    """Fixture providing a realistic mock vehicle directory selection window."""
+    window = MagicMock()
+    window.configuration_template = "QuadCopter_X"
+    window.infer_comp_specs_and_conn_from_fc_params.get.return_value = True
+    window.use_fc_params.get.return_value = True
+    window.root.mainloop.return_value = None
+    return window
 
-    @patch("ardupilot_methodic_configurator.__main__.FlightController")
-    def test_connect_to_fc_with_explicit_vehicle_type(self, mock_flight_controller) -> None:
-        """Test connecting to FC with explicitly set vehicle type."""
-        mock_fc = mock_flight_controller.return_value
-        mock_fc.connect.return_value = ""
-        mock_fc.info.vehicle_type = "quad"
-        mock_fc.info.flight_sw_version_and_type = "v1.0"
 
-        # Set an explicit vehicle type
-        args = argparse.Namespace(device="test_device", vehicle_type="plane", reboot_time=5, baudrate=115200)
-        flight_controller, vehicle_type = connect_to_fc_and_set_vehicle_type(args)
+# ====== Application State Tests ======
 
-        assert flight_controller == mock_fc
-        assert vehicle_type == "plane"  # Should use explicitly provided type
 
-    @patch("ardupilot_methodic_configurator.__main__.FlightController")
-    def test_connect_to_fc_with_connection_error(self, mock_flight_controller) -> None:
-        """Test handling of connection errors."""
-        mock_fc = mock_flight_controller.return_value
-        mock_fc.connect.return_value = "Connection error"
+class TestApplicationStartup:
+    """Test application startup behavior from user perspective."""
 
-        with patch("ardupilot_methodic_configurator.__main__.ConnectionSelectionWindow") as mock_window:
-            mock_window_instance = MagicMock()
-            mock_window.return_value = mock_window_instance
+    def test_user_can_start_application_with_updates_disabled(self, application_state: ApplicationState) -> None:
+        """
+        User can start application smoothly when update checking is disabled.
 
-            args = argparse.Namespace(device="test_device", vehicle_type="", reboot_time=5, baudrate=115200)
-            connect_to_fc_and_set_vehicle_type(args)
+        GIVEN: A user wants to start the application without checking for updates
+        WHEN: They launch with --skip-check-for-updates flag
+        THEN: Application should proceed immediately to main functionality
+        """
+        # Arrange: User disables update checking
+        application_state.args.skip_check_for_updates = True
 
-            # Verify ConnectionSelectionWindow was created with the right parameters
-            mock_window.assert_called_once_with(mock_fc, "Connection error")
-            mock_window_instance.root.mainloop.assert_called_once()
-
-    @patch("ardupilot_methodic_configurator.__main__.FlightController")
-    def test_flight_controller_info_attributes(self, mock_flight_controller) -> None:
-        """Test that FlightController info attributes are correctly used."""
-        mock_fc = mock_flight_controller.return_value
-        mock_fc.connect.return_value = ""
-        mock_fc.info.vehicle_type = "quad"
-        mock_fc.info.flight_sw_version_and_type = "v1.0"
-        mock_fc.info.vendor = "ArduPilot"
-        mock_fc.info.firmware_type = "CubeOrange"
-        mock_fc.info.mcu_series = "STM32F7"
-        mock_fc.info.flight_sw_version = "4.3.0"
-
-        # Test that info attributes are used in component editor
-        with patch("ardupilot_methodic_configurator.__main__.ComponentEditorWindow") as mock_editor_window:
-            mock_editor = MagicMock()
-            mock_editor_window.return_value = mock_editor
-
-            with patch("ardupilot_methodic_configurator.__main__.LocalFilesystem") as mock_filesystem:
-                mock_fs = MagicMock()
-                mock_filesystem.return_value = mock_fs
-                mock_fs.update_and_export_vehicle_params_from_fc.return_value = ""
-
-                with patch("ardupilot_methodic_configurator.__main__.ProgramSettings"):
-                    args = argparse.Namespace(skip_component_editor=True)
-                    component_editor(args, mock_fc, "quad", mock_fs, None)
-
-                    # Verify that info attributes are correctly passed to component editor
-                    mock_editor.set_vehicle_type_and_version.assert_called_once_with("quad", "v1.0")
-                    mock_editor.set_fc_manufacturer.assert_called_once_with("ArduPilot")
-                    mock_editor.set_fc_model.assert_called_once_with("CubeOrange")
-                    mock_editor.set_mcu_series.assert_called_once_with("STM32F7")
-
-    @patch("ardupilot_methodic_configurator.__main__.FlightController")
-    @patch("ardupilot_methodic_configurator.__main__.LocalFilesystem")
-    @patch("ardupilot_methodic_configurator.__main__.ParameterEditorWindow")
-    def test_backup_fc_parameters(self, mock_param_editor, mock_local_filesystem, mock_flight_controller) -> None:  # pylint: disable=unused-argument
-        """Test that FC parameters are backed up correctly."""
-        # Setup mocks
-        mock_fc = MagicMock()
-        mock_flight_controller.return_value = mock_fc
-        mock_fc.connect.return_value = ""
-        mock_fc.info.vehicle_type = "quad"
-        mock_fc.fc_parameters = {"PARAM1": 1.0, "PARAM2": 2.0}
-
-        mock_fs = MagicMock()
-        mock_local_filesystem.return_value = mock_fs
-        mock_fs.vehicle_type = "quad"
-        mock_fs.find_lowest_available_backup_number.return_value = 5
-        mock_fs.get_start_file.return_value = "start_file.param"
-
-        # Patch the main function to avoid running the entire flow
         with (
-            patch("ardupilot_methodic_configurator.__main__.main"),
-            patch("ardupilot_methodic_configurator.__main__.component_editor"),
+            patch("ardupilot_methodic_configurator.__main__.logging_basicConfig") as mock_logging,
+            patch("ardupilot_methodic_configurator.__main__.check_for_software_updates") as mock_check,
         ):
-            # Import and call main to trigger the backup functionality
+            # Act: User starts application
+            should_exit = setup_logging_and_check_updates(application_state)
 
-            # Just calling connect_to_fc_and_set_vehicle_type to get flight_controller
-            args = argparse.Namespace(
-                device="test_device",
-                baudrate=115200,
-                vehicle_type="",
-                reboot_time=5,
-                n=0,
-                skip_check_for_updates=True,
-                loglevel="INFO",
-                skip_component_editor=True,
-                allow_editing_template_files=False,
-                save_component_to_system_templates=False,
-                vehicle_dir="",
-            )
+            # Assert: Application continues normally
+            assert should_exit is False
+            mock_logging.assert_called_once()
+            mock_check.assert_not_called()
 
-            # Create a custom version of main that only tests the backup functionality
-            def test_backup_only() -> None:
-                flight_controller, _vehicle_type = connect_to_fc_and_set_vehicle_type(args)
+    def test_user_receives_update_notification_when_new_version_available(self, application_state: ApplicationState) -> None:
+        """
+        User is notified when a software update is available and application exits gracefully.
 
-                # This is the portion we want to test
-                if flight_controller.fc_parameters:
-                    mock_fs.backup_fc_parameters_to_file(
-                        flight_controller.fc_parameters,
-                        "autobackup_00_before_ardupilot_methodic_configurator.param",
-                        overwrite_existing_file=False,
-                        even_if_last_uploaded_filename_exists=False,
-                    )
-                    # Create incremental backup file
-                    backup_num = mock_fs.find_lowest_available_backup_number()
-                    mock_fs.backup_fc_parameters_to_file(
-                        flight_controller.fc_parameters,
-                        f"autobackup_{backup_num:02d}.param",
-                        overwrite_existing_file=True,
-                        even_if_last_uploaded_filename_exists=True,
-                    )
+        GIVEN: A user starts an outdated version of the application
+        WHEN: The application checks for updates
+        THEN: User should be informed and application should exit for update
+        """
+        # Arrange: Updates are available
+        application_state.args.skip_check_for_updates = False
 
-            # Call our custom test function
-            test_backup_only()
+        with (
+            patch("ardupilot_methodic_configurator.__main__.logging_basicConfig"),
+            patch("ardupilot_methodic_configurator.__main__.check_for_software_updates", return_value=True),
+            patch("ardupilot_methodic_configurator.__main__.logging_info") as mock_log,
+        ):
+            # Act: User starts outdated application
+            should_exit = setup_logging_and_check_updates(application_state)
 
-            # Verify backup files were created
-            mock_fs.backup_fc_parameters_to_file.assert_any_call(
-                mock_fc.fc_parameters,
-                "autobackup_00_before_ardupilot_methodic_configurator.param",
-                overwrite_existing_file=False,
-                even_if_last_uploaded_filename_exists=False,
-            )
-            mock_fs.backup_fc_parameters_to_file.assert_any_call(
-                mock_fc.fc_parameters,
-                "autobackup_05.param",
-                overwrite_existing_file=True,
-                even_if_last_uploaded_filename_exists=True,
-            )
-            assert mock_fs.backup_fc_parameters_to_file.call_count == 2
+            # Assert: User informed and application exits
+            assert should_exit is True
+            mock_log.assert_called_once()
 
-    @patch("ardupilot_methodic_configurator.__main__.LocalFilesystem")
-    def test_no_backup_without_fc_parameters(self, mock_local_filesystem) -> None:
-        """Test that backup is not created when there are no FC parameters."""
-        # Setup mocks
-        mock_fs = MagicMock()
-        mock_local_filesystem.return_value = mock_fs
+    def test_user_proceeds_normally_when_application_is_current(self, application_state: ApplicationState) -> None:
+        """
+        User can proceed with application when no updates are needed.
 
-        # Create a mock flight controller with empty parameters
+        GIVEN: A user starts the current version of the application
+        WHEN: The application checks for updates
+        THEN: Application should continue with normal startup
+        """
+        # Arrange: No updates needed
+        application_state.args.skip_check_for_updates = False
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.logging_basicConfig"),
+            patch("ardupilot_methodic_configurator.__main__.check_for_software_updates", return_value=False),
+        ):
+            # Act: User starts current application
+            should_exit = setup_logging_and_check_updates(application_state)
+
+            # Assert: Application continues normally
+            assert should_exit is False
+
+
+class TestDocumentationBehavior:
+    """Test automatic documentation opening behavior."""
+
+    def test_user_sees_help_documentation_when_auto_open_enabled(self) -> None:
+        """
+        User automatically receives helpful documentation when feature is enabled.
+
+        GIVEN: A user has enabled automatic documentation opening in settings
+        WHEN: The application starts
+        THEN: Relevant help documentation should open in their default browser
+        """
+        # Arrange: Auto-open documentation enabled
+        with (
+            patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=True),
+            patch("ardupilot_methodic_configurator.__main__.webbrowser_open") as mock_browser,
+        ):
+            # Act: User starts application
+            display_first_use_documentation()
+
+            # Assert: Documentation opens correctly for user
+            mock_browser.assert_called_once()
+            call_args = mock_browser.call_args
+            # User should see the use cases documentation
+            assert "USECASES.html" in call_args[1]["url"]
+            # Browser should open in existing window/tab for user convenience
+            assert call_args[1]["new"] == 0
+            assert call_args[1]["autoraise"] is True
+
+    def test_user_startup_not_interrupted_when_auto_documentation_disabled(self) -> None:
+        """
+        User experiences uninterrupted startup when auto-documentation is disabled.
+
+        GIVEN: A user has disabled automatic documentation opening
+        WHEN: The application starts
+        THEN: No browser windows should open and startup should be clean
+        """
+        # Arrange: Auto-open documentation disabled
+        with (
+            patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=False),
+            patch("ardupilot_methodic_configurator.__main__.webbrowser_open") as mock_browser,
+        ):
+            # Act: User starts application
+            display_first_use_documentation()
+
+            # Assert: No browser interruption
+            mock_browser.assert_not_called()
+
+
+class TestFlightControllerConnection:
+    """Test flight controller connection and initialization behavior."""
+
+    def test_user_can_initialize_with_connected_hardware(
+        self, application_state: ApplicationState, mock_flight_controller: MagicMock, mock_local_filesystem: MagicMock
+    ) -> None:
+        """
+        User can successfully initialize when flight controller hardware is connected.
+
+        GIVEN: A user has connected flight controller hardware
+        WHEN: The application initializes flight controller connection
+        THEN: All parameters should be read and filesystem should be configured
+        """
+        # Arrange: Configure realistic hardware connection scenario
+        mock_flight_controller.master = MagicMock()  # Hardware connected
+        default_params = {"TEST_PARAM": 1.0, "BATT_MONITOR": 4}
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.__main__.connect_to_fc_and_set_vehicle_type",
+                return_value=(mock_flight_controller, "ArduCopter"),
+            ),
+            patch("ardupilot_methodic_configurator.__main__.FlightControllerInfoWindow") as mock_fc_window,
+            patch("ardupilot_methodic_configurator.__main__.LocalFilesystem", return_value=mock_local_filesystem),
+        ):
+            # Configure parameter retrieval
+            mock_fc_info = MagicMock()
+            mock_fc_info.get_param_default_values.return_value = default_params
+            mock_fc_window.return_value = mock_fc_info
+            mock_local_filesystem.write_param_default_values.return_value = True
+
+            # Act: User initializes with connected hardware
+            initialize_flight_controller_and_filesystem(application_state)
+
+            # Assert: Successful hardware initialization
+            assert application_state.flight_controller is mock_flight_controller
+            assert application_state.vehicle_type == "ArduCopter"
+            assert application_state.local_filesystem is mock_local_filesystem
+            assert application_state.param_default_values == default_params
+            assert application_state.param_default_values_dirty is True
+
+    def test_user_can_work_in_simulation_mode(self, application_state: ApplicationState) -> None:
+        """
+        User can use application in simulation mode without physical hardware.
+
+        GIVEN: A user wants to test or configure without hardware
+        WHEN: The application runs in test/simulation mode
+        THEN: Application should work with simulated data
+        """
+        # Arrange: Simulation mode setup
+        application_state.args.device = "test"
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.connect_to_fc_and_set_vehicle_type") as mock_connect,
+            patch("ardupilot_methodic_configurator.__main__.FlightControllerInfoWindow") as mock_fc_window,
+            patch("ardupilot_methodic_configurator.__main__.LocalFilesystem") as mock_fs_class,
+        ):
+            # Configure simulation mode
+            mock_fc = MagicMock()
+            mock_fc.master = None  # Simulation mode
+            mock_connect.return_value = (mock_fc, "ArduCopter")
+
+            mock_fc_info = MagicMock()
+            mock_fc_info.get_param_default_values.return_value = {}
+            mock_fc_window.return_value = mock_fc_info
+
+            mock_fs_class.return_value = MagicMock()
+
+            # Act: User initializes in simulation mode
+            initialize_flight_controller_and_filesystem(application_state)
+
+            # Assert: Simulation mode works
+            assert application_state.flight_controller is mock_fc
+            assert application_state.vehicle_type == "ArduCopter"
+            mock_fc_window.assert_called_once_with(mock_fc)
+
+    def test_user_receives_clear_error_when_configuration_invalid(self, application_state: ApplicationState) -> None:
+        """
+        User receives clear error message when configuration is invalid.
+
+        GIVEN: A user has invalid configuration or corrupted files
+        WHEN: Filesystem initialization fails
+        THEN: A clear, actionable error message should be displayed
+        """
+        # Arrange: Mock configuration failure
         mock_fc = MagicMock()
-        mock_fc.fc_parameters = {}
+        with (
+            patch(
+                "ardupilot_methodic_configurator.__main__.connect_to_fc_and_set_vehicle_type",
+                return_value=(mock_fc, "ArduCopter"),
+            ),
+            patch("ardupilot_methodic_configurator.__main__.FlightControllerInfoWindow"),
+            patch(
+                "ardupilot_methodic_configurator.__main__.LocalFilesystem",
+                side_effect=SystemExit("Configuration error"),
+            ),
+            patch("ardupilot_methodic_configurator.__main__.show_error_message") as mock_error,
+        ):
+            # Act & Assert: Configuration error should be handled gracefully
+            with pytest.raises(SystemExit):
+                initialize_flight_controller_and_filesystem(application_state)
 
-        # Directly test the functionality
-        if mock_fc.fc_parameters:
-            mock_fs.backup_fc_parameters_to_file(
-                mock_fc.fc_parameters,
-                "autobackup_00_before_ardupilot_methodic_configurator.param",
-                overwrite_existing_file=False,
-                even_if_last_uploaded_filename_exists=False,
+            # Assert: Clear error message displayed
+            mock_error.assert_called_once()
+            error_args = mock_error.call_args[0]
+            assert "Fatal error reading parameter files" in error_args[0]
+            assert "Configuration error" in error_args[1]
+
+
+class TestVehicleDirectoryWorkflow:
+    """Test vehicle directory selection workflow."""
+
+    def test_user_proceeds_directly_when_configuration_ready(self, application_state: ApplicationState) -> None:
+        """
+        User proceeds directly to main functionality when configuration is ready.
+
+        GIVEN: A user has valid parameter files in their vehicle directory
+        WHEN: The application checks for vehicle directory selection
+        THEN: User should proceed directly without interruption
+        """
+        # Arrange: Ready configuration
+        mock_fs = MagicMock()
+        mock_fs.file_parameters = {"00_default.param": {}, "01_test.param": {}}
+        application_state.local_filesystem = mock_fs
+        application_state.flight_controller = MagicMock()
+
+        # Act: Check if directory selection needed
+        result = vehicle_directory_selection(application_state)
+
+        # Assert: No directory selection needed
+        assert result is None
+
+    def test_user_can_select_vehicle_configuration_when_needed(self, application_state: ApplicationState) -> None:
+        """
+        User can select appropriate vehicle configuration when none exists.
+
+        GIVEN: A user starts with empty or new vehicle directory
+        WHEN: The application needs vehicle configuration
+        THEN: User should see intuitive vehicle directory selection interface
+        """
+        # Arrange: No existing configuration
+        mock_fs = MagicMock()
+        mock_fs.file_parameters = {}  # No files
+        application_state.local_filesystem = mock_fs
+
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"PARAM1": 1.0}  # Connected FC
+        mock_fc.info.vehicle_type = "ArduCopter"
+        application_state.flight_controller = mock_fc
+        application_state.vehicle_type = "ArduCopter"  # This is what actually gets used
+
+        with patch("ardupilot_methodic_configurator.__main__.VehicleDirectorySelectionWindow") as mock_window_class:
+            mock_window = MagicMock()
+            mock_window.root.mainloop = MagicMock()
+            mock_window_class.return_value = mock_window
+
+            # Act: User selects vehicle configuration
+            result = vehicle_directory_selection(application_state)
+
+            # Assert: Directory selection interface shown
+            expected_fc_connected = True
+            expected_vehicle_type = "ArduCopter"
+            mock_window_class.assert_called_once_with(mock_fs, expected_fc_connected, expected_vehicle_type)
+            mock_window.root.mainloop.assert_called_once()
+            assert result is mock_window
+
+    def test_user_can_configure_without_connected_hardware(self, application_state: ApplicationState) -> None:
+        """
+        User can configure vehicle directory even without connected flight controller.
+
+        GIVEN: A user works without connected flight controller hardware
+        WHEN: Vehicle directory selection is needed
+        THEN: User should still be able to select and configure vehicle directory
+        """
+        # Arrange: No connected hardware
+        mock_fs = MagicMock()
+        mock_fs.file_parameters = None  # No configuration
+        application_state.local_filesystem = mock_fs
+
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {}  # No connection
+        mock_fc.info.vehicle_type = None
+        application_state.flight_controller = mock_fc
+
+        with patch("ardupilot_methodic_configurator.__main__.VehicleDirectorySelectionWindow") as mock_window_class:
+            mock_window = MagicMock()
+            mock_window_class.return_value = mock_window
+
+            # Act: User configures without hardware
+            vehicle_directory_selection(application_state)
+
+            # Assert: Configuration possible without hardware
+            expected_fc_connected = False
+            expected_vehicle_type = ""
+            mock_window_class.assert_called_once_with(mock_fs, expected_fc_connected, expected_vehicle_type)
+
+
+class TestApplicationIntegration:
+    """Test complete application workflows and integration scenarios."""
+
+    def test_user_can_complete_standard_startup_workflow(self, mock_args: MagicMock) -> None:
+        """
+        User can complete the standard application startup workflow end-to-end.
+
+        GIVEN: A user starts the application with typical configuration
+        WHEN: They go through the complete startup sequence
+        THEN: All components should initialize properly and be ready for use
+        """
+        # Arrange: Standard user configuration
+        mock_args.skip_check_for_updates = True  # Skip for test efficiency
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.logging_basicConfig"),
+            patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=False),
+            patch("ardupilot_methodic_configurator.__main__.connect_to_fc_and_set_vehicle_type") as mock_connect,
+            patch("ardupilot_methodic_configurator.__main__.FlightControllerInfoWindow"),
+            patch("ardupilot_methodic_configurator.__main__.LocalFilesystem") as mock_fs_class,
+        ):
+            # Configure successful workflow
+            mock_fc = MagicMock()
+            mock_fc.master = MagicMock()
+            mock_connect.return_value = (mock_fc, "ArduCopter")
+
+            mock_fs = MagicMock()
+            mock_fs.file_parameters = {"00_default.param": {}}
+            mock_fs_class.return_value = mock_fs
+
+            # Act: Execute complete startup workflow
+            state = ApplicationState(mock_args)
+
+            should_exit = setup_logging_and_check_updates(state)
+            assert should_exit is False
+
+            display_first_use_documentation()  # Should complete without issues
+
+            initialize_flight_controller_and_filesystem(state)
+
+            result = vehicle_directory_selection(state)
+
+            # Assert: Complete successful workflow
+            assert state.flight_controller is mock_fc
+            assert state.vehicle_type == "ArduCopter"
+            assert state.local_filesystem is mock_fs
+            assert result is None  # No directory selection needed
+
+
+class TestArgumentParser:
+    """Test argument parser creation and configuration."""
+
+    def test_argument_parser_creates_all_required_options(self) -> None:
+        """
+        User can access all necessary command-line options for configuration.
+
+        GIVEN: A user needs to configure the application via command line
+        WHEN: They check available options
+        THEN: All necessary configuration options should be available
+        """
+        # Act: Create argument parser
+        parser = create_argument_parser()
+
+        # Assert: Parser is created and has expected structure
+        assert parser is not None
+        assert hasattr(parser, "parse_args")
+
+        # Test with minimal arguments to ensure it works
+        test_args = parser.parse_args(["--skip-check-for-updates"])
+        assert test_args.skip_check_for_updates is True
+
+
+class TestFlightControllerConnectionLogic:
+    """Test flight controller connection logic in detail."""
+
+    def test_flight_controller_connection_with_explicit_vehicle_type(self) -> None:
+        """
+        User can explicitly set vehicle type to override auto-detection.
+
+        GIVEN: A user knows their vehicle type and wants to set it explicitly
+        WHEN: They provide --vehicle-type argument
+        THEN: Application should use the explicitly set type
+        """
+        # Arrange: Mock arguments with explicit vehicle type
+        mock_args = MagicMock()
+        mock_args.vehicle_type = "ArduPlane"
+        mock_args.device = "test"
+        mock_args.reboot_time = 10.0
+        mock_args.baudrate = 115200
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.FlightController") as mock_fc_class,
+            patch("ardupilot_methodic_configurator.__main__.ConnectionSelectionWindow"),
+            patch("ardupilot_methodic_configurator.__main__.logging_info") as mock_log,
+        ):
+            mock_fc = MagicMock()
+            mock_fc.connect.return_value = ""  # No error
+            mock_fc.info.vehicle_type = "ArduCopter"  # Different from explicit
+            mock_fc_class.return_value = mock_fc
+
+            # Act: Connect with explicit vehicle type
+            _fc, vehicle_type = connect_to_fc_and_set_vehicle_type(mock_args)
+
+            # Assert: User's explicit type choice is respected
+            assert vehicle_type == "ArduPlane"
+            # User gets informed about configuration choice
+            mock_log.assert_called_once()
+            log_message = mock_log.call_args[0][0]
+            # User should understand that type was specified rather than auto-detected
+            assert "explicitly set" in log_message or "specified" in log_message
+
+    def test_flight_controller_auto_detection_when_type_not_specified(self) -> None:
+        """
+        User benefits from automatic vehicle type detection when not specified.
+
+        GIVEN: A user doesn't specify vehicle type
+        WHEN: A flight controller with known type is connected
+        THEN: Application should auto-detect and use the FC's vehicle type
+        """
+        # Arrange: Mock arguments without vehicle type
+        mock_args = MagicMock()
+        mock_args.vehicle_type = ""  # Not specified
+        mock_args.device = "test"
+        mock_args.reboot_time = 10.0
+        mock_args.baudrate = 115200
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.FlightController") as mock_fc_class,
+            patch("ardupilot_methodic_configurator.__main__.ConnectionSelectionWindow"),
+            patch("ardupilot_methodic_configurator.__main__.logging_debug") as mock_log,
+        ):
+            mock_fc = MagicMock()
+            mock_fc.connect.return_value = ""
+            mock_fc.info.vehicle_type = "ArduCopter"
+            mock_fc_class.return_value = mock_fc
+
+            # Act: Connect with auto-detection
+            _fc, vehicle_type = connect_to_fc_and_set_vehicle_type(mock_args)
+
+            # Assert: Auto-detected type used
+            assert vehicle_type == "ArduCopter"
+            mock_log.assert_called_once()
+            assert "auto-detected" in mock_log.call_args[0][0]
+
+
+class TestParameterBackupWorkflow:
+    """Test parameter backup functionality."""
+
+    def test_user_gets_automatic_parameter_backup_when_fc_connected(
+        self, configured_application_state: ApplicationState
+    ) -> None:
+        """
+        User automatically gets parameter backup for safety when FC is connected.
+
+        GIVEN: A user has connected flight controller with parameters
+        WHEN: The backup process runs
+        THEN: Multiple backup files should be created for safety
+        """
+        # Arrange: Configure FC with realistic parameters
+        configured_application_state.flight_controller.fc_parameters = {"BATT_MONITOR": 4, "COMPASS_USE": 1, "GPS_TYPE": 1}
+        configured_application_state.local_filesystem.find_lowest_available_backup_number.return_value = 5
+
+        with patch("ardupilot_methodic_configurator.__main__.logging_info") as mock_log:
+            # Act: User triggers automatic parameter backup
+            backup_fc_parameters(configured_application_state)
+
+            # Assert: User gets comprehensive backup protection
+            fs = configured_application_state.local_filesystem
+            # Verify both safety backup types are created for user protection
+            assert fs.backup_fc_parameters_to_file.called
+
+            # Check that both initial and incremental backups were created
+            calls = fs.backup_fc_parameters_to_file.call_args_list
+            assert len(calls) == 2, "User should get both safety backup types"
+
+            # Verify initial backup preserves existing files for safety
+            first_call = calls[0]
+            assert "autobackup_00_before" in first_call[0][1]
+            assert first_call[1]["overwrite_existing_file"] is False
+
+            # Verify incremental backup uses available number
+            second_call = calls[1]
+            assert "autobackup_05.param" in second_call[0][1]
+            assert second_call[1]["overwrite_existing_file"] is True
+
+            # Verify user gets feedback about backup creation
+            mock_log.assert_called_once()
+            # Focus on behavior: user should be informed that backup was created
+            log_message = str(mock_log.call_args)
+            assert "backup file" in log_message or "Created" in log_message
+
+    def test_user_workflow_continues_smoothly_when_no_fc_connected(self, application_state: ApplicationState) -> None:
+        """
+        User workflow continues without issues when no FC is connected.
+
+        GIVEN: A user works without connected flight controller
+        WHEN: Backup process runs
+        THEN: No backup attempts should be made and workflow should continue
+        """
+        # Arrange: No connected FC
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {}  # Empty - no connection
+        application_state.flight_controller = mock_fc
+
+        mock_fs = MagicMock()
+        application_state.local_filesystem = mock_fs
+
+        # Act: Attempt backup without connection
+        backup_fc_parameters(application_state)
+
+        # Assert: No backup operations attempted
+        mock_fs.backup_fc_parameters_to_file.assert_not_called()
+        mock_fs.find_lowest_available_backup_number.assert_not_called()
+
+    def test_user_gets_clear_feedback_when_backup_directory_unavailable(
+        self, configured_application_state: ApplicationState
+    ) -> None:
+        """
+        User receives clear feedback when backup directory is not available.
+
+        GIVEN: A user has connected flight controller but backup directory is unavailable
+        WHEN: The backup process attempts to run
+        THEN: User should receive clear error message and application should handle gracefully
+        AND: The error message should provide specific guidance about permissions
+        """
+        # Arrange: Configure FC with parameters but filesystem backup fails
+        configured_application_state.flight_controller.fc_parameters = {
+            "BATT_MONITOR": 4,
+            "COMPASS_USE": 1,
+        }
+        # Simulate backup directory unavailable due to permissions
+        configured_application_state.local_filesystem.backup_fc_parameters_to_file.side_effect = PermissionError(
+            "Permission denied"
+        )
+
+        with patch("ardupilot_methodic_configurator.__main__.logging_error") as mock_error:
+            # Act: User attempts backup with unavailable directory
+            backup_fc_parameters(configured_application_state)
+
+            # Assert: User gets clear error feedback about permissions
+            assert mock_error.call_count >= 2, "User should receive both error description and actionable guidance"
+            error_calls = mock_error.call_args_list
+
+            # Check first error message contains permission information
+            first_message = str(error_calls[0])
+            assert "permission" in first_message.lower() or "denied" in first_message.lower(), (
+                "User should see clear indication of permission issue"
             )
 
-        # Verify no backups were created
-        mock_fs.backup_fc_parameters_to_file.assert_not_called()
+            # Check second error message provides actionable guidance
+            second_message = str(error_calls[1])
+            assert (
+                "check" in second_message.lower() and "permission" in second_message.lower()
+            ) or "write access" in second_message.lower(), "User should receive actionable steps to resolve permission issues"
 
-    def test_backup_filename_formatting(self) -> None:
-        """Test the formatting of backup filenames."""
-        # Test different numbers
-        for num in [0, 1, 5, 10, 99]:
-            filename = f"autobackup_{num:02d}.param"
-            expected = f"autobackup_{'0' + str(num) if num < 10 else str(num)}.param"
-            assert filename == expected, f"Expected {expected}, got {filename}"
+    def test_user_gets_helpful_error_when_disk_space_insufficient(
+        self, configured_application_state: ApplicationState
+    ) -> None:
+        """
+        User receives helpful guidance when insufficient disk space prevents backup.
+
+        GIVEN: A user has limited disk space on their storage device
+        WHEN: The backup process attempts to create backup files
+        THEN: User should receive actionable error message with clear guidance
+        AND: The error message should suggest specific remediation steps
+        """
+        # Arrange: Configure FC with parameters but disk space insufficient
+        configured_application_state.flight_controller.fc_parameters = {
+            "BATT_MONITOR": 4,
+            "COMPASS_USE": 1,
+        }
+        # Simulate insufficient disk space (common Linux/Windows disk full error)
+        configured_application_state.local_filesystem.backup_fc_parameters_to_file.side_effect = OSError(
+            "[Errno 28] No space left on device"
+        )
+
+        with patch("ardupilot_methodic_configurator.__main__.logging_error") as mock_error:
+            # Act: User attempts backup with insufficient space
+            backup_fc_parameters(configured_application_state)
+
+            # Assert: User gets actionable error guidance about disk space
+            assert mock_error.call_count >= 2, "User should receive both error description and actionable guidance"
+            error_calls = mock_error.call_args_list
+
+            # Check first error message contains disk space information
+            first_message = str(error_calls[0])
+            assert "space" in first_message.lower() or "disk" in first_message.lower(), (
+                "User should see clear indication of disk space issue"
+            )
+
+            # Check second error message provides actionable guidance
+            second_message = str(error_calls[1])
+            assert "free up" in second_message.lower() or "try again" in second_message.lower(), (
+                "User should receive actionable steps to resolve the issue"
+            )
+
+    def test_user_gets_general_error_feedback_for_unexpected_oserror(
+        self, configured_application_state: ApplicationState
+    ) -> None:
+        """
+        User receives appropriate feedback for other unexpected OS-level errors during backup.
+
+        GIVEN: A user encounters an unexpected OS-level error during backup
+        WHEN: The backup process attempts to create backup files
+        THEN: User should receive a general error message indicating the issue
+        AND: The error should be logged without crashing the application
+        """
+        # Arrange: Configure FC with parameters but unexpected OS error occurs
+        configured_application_state.flight_controller.fc_parameters = {
+            "BATT_MONITOR": 4,
+            "COMPASS_USE": 1,
+        }
+        # Simulate unexpected OS error (not disk space related)
+        configured_application_state.local_filesystem.backup_fc_parameters_to_file.side_effect = OSError(
+            "[Errno 5] Input/output error"
+        )
+
+        with patch("ardupilot_methodic_configurator.__main__.logging_error") as mock_error:
+            # Act: User attempts backup with unexpected OS error
+            backup_fc_parameters(configured_application_state)
+
+            # Assert: User gets appropriate error feedback for general OS error
+            assert mock_error.called, "User should receive error feedback for OS-level issues"
+            error_message = str(mock_error.call_args_list[0])
+            assert "failed to create backup files" in error_message.lower(), (
+                "User should see clear indication of backup failure"
+            )
+
+    def test_user_gets_graceful_handling_for_unexpected_exceptions(
+        self, configured_application_state: ApplicationState
+    ) -> None:
+        """
+        User experiences graceful error handling for completely unexpected exceptions.
+
+        GIVEN: A user encounters an unexpected exception during backup
+        WHEN: The backup process runs into an unforeseen error
+        THEN: The application should handle it gracefully and inform the user
+        AND: The application should continue running without crashing
+        """
+        # Arrange: Configure FC with parameters but unexpected exception occurs
+        configured_application_state.flight_controller.fc_parameters = {
+            "BATT_MONITOR": 4,
+            "COMPASS_USE": 1,
+        }
+        # Simulate unexpected exception
+        configured_application_state.local_filesystem.backup_fc_parameters_to_file.side_effect = ValueError(
+            "Unexpected validation error"
+        )
+
+        with patch("ardupilot_methodic_configurator.__main__.logging_error") as mock_error:
+            # Act: User encounters unexpected exception during backup
+            backup_fc_parameters(configured_application_state)
+
+            # Assert: User gets graceful error handling
+            assert mock_error.called, "User should be informed of unexpected errors"
+            error_message = str(mock_error.call_args_list[0])
+            assert "unexpected error" in error_message.lower(), "User should understand this was an unexpected issue"
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestParameterEditorStartup:
+    """Test parameter editor startup logic."""
+
+    def test_user_gets_appropriate_starting_file_based_on_configuration(self, application_state: ApplicationState) -> None:
+        """
+        User starts with appropriate parameter file based on their configuration.
+
+        GIVEN: A user has specific flight controller configuration
+        WHEN: Parameter editor starts
+        THEN: Appropriate starting file should be selected based on capabilities
+        """
+        # Arrange: FC with IMU temperature calibration capability
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"INS_TCAL1_ENABLE": 1, "PARAM2": 2.0}
+        application_state.flight_controller = mock_fc
+
+        mock_fs = MagicMock()
+        mock_fs.get_start_file.return_value = "05_imu_temperature_calibration.param"
+        application_state.local_filesystem = mock_fs
+
+        application_state.args.n = 0  # Start from beginning
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value="advanced"),
+            patch("ardupilot_methodic_configurator.__main__.ParameterEditorWindow") as mock_editor,
+        ):
+            # Act: Start parameter editor
+            parameter_editor_and_uploader(application_state)
+
+            # Assert: Advanced mode with IMU calibration considered
+            mock_fs.get_start_file.assert_called_once_with(0, True)  # noqa: FBT003 IMU tcal available and not simple GUI
+            mock_editor.assert_called_once_with("05_imu_temperature_calibration.param", mock_fc, mock_fs)
+
+    def test_user_gets_simplified_workflow_in_simple_mode(self, application_state: ApplicationState) -> None:
+        """
+        User gets simplified workflow when simple GUI mode is enabled.
+
+        GIVEN: A user prefers simple interface
+        WHEN: Parameter editor starts in simple mode
+        THEN: Advanced features should be disabled for cleaner experience
+        """
+        # Arrange: Simple GUI mode
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"INS_TCAL1_ENABLE": 1}
+        application_state.flight_controller = mock_fc
+
+        mock_fs = MagicMock()
+        application_state.local_filesystem = mock_fs
+        application_state.args.n = 0
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value="simple"),
+            patch("ardupilot_methodic_configurator.__main__.ParameterEditorWindow"),
+        ):
+            # Act: Start in simple mode
+            parameter_editor_and_uploader(application_state)
+
+            # Assert: IMU calibration disabled in simple mode
+            mock_fs.get_start_file.assert_called_once_with(0, False)  # noqa: FBT003 Simple GUI disables IMU tcal
+
+
+# ====== Component Editor Helper Function Tests ======
+
+
+class TestComponentEditorHelperFunctions:
+    """Test the refactored component editor helper functions for better testability."""
+
+    def test_create_and_configure_component_editor_basic_setup(self) -> None:
+        """
+        User can create and configure component editor with basic settings.
+
+        GIVEN: Valid application components
+        WHEN: Component editor is created and configured
+        THEN: Window should be properly initialized with basic settings
+        """
+        # Arrange: Mock dependencies
+        mock_filesystem = MagicMock()
+        mock_fc = MagicMock()
+        mock_fc.info.flight_sw_version_and_type = "ArduCopter V4.5.0"
+        mock_fc.info.vendor = "Pixhawk"
+        mock_fc.info.firmware_type = "CubeOrange"
+        mock_fc.info.mcu_series = "STM32H7xx"
+
+        with patch("ardupilot_methodic_configurator.__main__.ComponentEditorWindow") as mock_window_class:
+            mock_window = MagicMock()
+            mock_window_class.return_value = mock_window
+
+            # Act: Create and configure component editor
+            result = create_and_configure_component_editor("1.0.0", mock_filesystem, mock_fc, "ArduCopter", None)
+
+            # Assert: Window configured correctly
+            assert result == mock_window
+            mock_window.populate_frames.assert_called_once()
+            mock_window.set_vehicle_type_and_version.assert_called_once_with("ArduCopter", "ArduCopter V4.5.0")
+            mock_window.set_fc_manufacturer.assert_called_once_with("Pixhawk")
+            mock_window.set_fc_model.assert_called_once_with("CubeOrange")
+            mock_window.set_mcu_series.assert_called_once_with("STM32H7xx")
+
+    def test_create_and_configure_component_editor_with_vehicle_template(self) -> None:
+        """
+        User can configure component editor with vehicle template and FC parameter inference.
+
+        GIVEN: Vehicle directory window with configuration template
+        WHEN: Component editor is created with inference enabled
+        THEN: Component specs should be inferred from FC parameters
+        """
+        # Arrange: Mock with vehicle directory and inference
+        mock_filesystem = MagicMock()
+        mock_filesystem.doc_dict = {"PARAM1": "doc1"}
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"PARAM1": 1.0, "PARAM2": 2.0}
+        mock_fc.info.flight_sw_version_and_type = "ArduCopter V4.5.0"
+        mock_fc.info.vendor = "Pixhawk"
+        mock_fc.info.firmware_type = "CubeOrange"
+        mock_fc.info.mcu_series = "STM32H7xx"
+
+        mock_vehicle_dir_window = MagicMock()
+        mock_vehicle_dir_window.configuration_template = "template1"
+        mock_vehicle_dir_window.infer_comp_specs_and_conn_from_fc_params.get.return_value = True
+
+        with patch("ardupilot_methodic_configurator.__main__.ComponentEditorWindow") as mock_window_class:
+            mock_window = MagicMock()
+            mock_window_class.return_value = mock_window
+
+            # Act: Create with vehicle template
+            result = create_and_configure_component_editor(
+                "1.0.0", mock_filesystem, mock_fc, "ArduCopter", mock_vehicle_dir_window
+            )
+
+            # Assert: Inference and template configuration applied
+            assert result == mock_window
+            mock_window.set_values_from_fc_parameters.assert_called_once_with(mock_fc.fc_parameters, mock_filesystem.doc_dict)
+            mock_window.set_vehicle_configuration_template.assert_called_once_with("template1")
+
+    def test_should_open_firmware_documentation_when_enabled(self) -> None:
+        """
+        User gets firmware documentation opened when auto-open is enabled.
+
+        GIVEN: Auto-open documentation is enabled and firmware type is known
+        WHEN: Documentation opening decision is made
+        THEN: Function should return True to open documentation
+        """
+        # Arrange: Mock flight controller with known firmware
+        mock_fc = MagicMock()
+        mock_fc.info.firmware_type = "CubeOrange"
+
+        with patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=True):
+            # Act: Check if documentation should open
+            result = should_open_firmware_documentation(mock_fc)
+
+            # Assert: Should open documentation
+            assert result is True
+
+    def test_should_open_firmware_documentation_when_disabled(self) -> None:
+        """
+        User workflow is not interrupted when auto-documentation is disabled.
+
+        GIVEN: Auto-open documentation is disabled
+        WHEN: Documentation opening decision is made
+        THEN: Function should return False to skip documentation
+        """
+        # Arrange: Mock with disabled auto-open
+        mock_fc = MagicMock()
+        mock_fc.info.firmware_type = "CubeOrange"
+
+        with patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=False):
+            # Act: Check with disabled setting
+            result = should_open_firmware_documentation(mock_fc)
+
+            # Assert: Should not open documentation
+            assert result is False
+
+    def test_should_open_firmware_documentation_unknown_firmware(self) -> None:
+        """
+        User doesn't get irrelevant documentation when firmware type is unknown.
+
+        GIVEN: Firmware type is unknown or empty
+        WHEN: Documentation opening decision is made
+        THEN: Function should return False to avoid opening irrelevant documentation
+        """
+        # Arrange: Mock with unknown firmware
+        mock_fc = MagicMock()
+        mock_fc.info.firmware_type = "Unknown"
+
+        with patch("ardupilot_methodic_configurator.__main__.ProgramSettings.get_setting", return_value=True):
+            # Act: Check with unknown firmware
+            result = should_open_firmware_documentation(mock_fc)
+
+            # Assert: Should not open documentation for unknown firmware
+            assert result is False
+
+    def test_open_firmware_documentation_success(self) -> None:
+        """
+        User gets firmware documentation opened successfully.
+
+        GIVEN: Valid firmware type
+        WHEN: Documentation opening is attempted
+        THEN: URL should be verified and opened
+        """
+        with patch("ardupilot_methodic_configurator.__main__.verify_and_open_url", return_value=True) as mock_open:
+            # Act: Open documentation
+            result = open_firmware_documentation("CubeOrange")
+
+            # Assert: URL opened successfully
+            assert result is True
+            expected_url = (
+                "https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md"
+            )
+            mock_open.assert_called_once_with(expected_url)
+
+    def test_open_firmware_documentation_bdshot_fallback(self) -> None:
+        """
+        User gets correct documentation for bdshot firmware variants.
+
+        GIVEN: Firmware type with -bdshot suffix
+        WHEN: Primary URL is not found
+        THEN: Fallback URL without suffix should be tried
+        """
+        with patch("ardupilot_methodic_configurator.__main__.verify_and_open_url", side_effect=[False, True]) as mock_open:
+            # Act: Open documentation for bdshot variant
+            result = open_firmware_documentation("CubeOrange-bdshot")
+
+            # Assert: Fallback URL tried and succeeded
+            assert result is True
+            assert mock_open.call_count == 2
+            expected_primary_url = (
+                "https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange-bdshot/README.md"
+            )
+            expected_fallback_url = (
+                "https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/README.md"
+            )
+            mock_open.assert_any_call(expected_primary_url)
+            mock_open.assert_any_call(expected_fallback_url)
+
+    def test_process_component_editor_results_with_fc_params(self) -> None:
+        """
+        User gets proper parameter processing when FC parameters are used.
+
+        GIVEN: Component editor completed with FC parameter usage enabled
+        WHEN: Results are processed
+        THEN: FC parameters should be used as source for vehicle parameter update
+        """
+        # Arrange: Mock components with FC parameter usage
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"PARAM1": 1.0, "PARAM2": 2.0}
+        mock_filesystem = MagicMock()
+        mock_filesystem.update_and_export_vehicle_params_from_fc.return_value = None  # No error
+
+        mock_vehicle_dir_window = MagicMock()
+        mock_vehicle_dir_window.configuration_template = "template1"
+        mock_vehicle_dir_window.use_fc_params.get.return_value = True
+
+        # Act: Process results
+        process_component_editor_results(mock_fc, mock_filesystem, mock_vehicle_dir_window)
+
+        # Assert: FC parameters used as source
+        mock_filesystem.update_and_export_vehicle_params_from_fc.assert_called_once()
+        call_args = mock_filesystem.update_and_export_vehicle_params_from_fc.call_args
+        assert call_args.kwargs["source_param_values"] == mock_fc.fc_parameters
+
+    def test_process_component_editor_results_error_handling(self) -> None:
+        """
+        User gets clear error message when parameter processing fails.
+
+        GIVEN: Parameter processing encounters an error
+        WHEN: Results are processed
+        THEN: Error should be logged and application should exit with error code
+        """
+        # Arrange: Mock with error condition
+        mock_fc = MagicMock()
+        mock_fc.fc_parameters = {"PARAM1": 1.0}
+        mock_filesystem = MagicMock()
+        mock_filesystem.update_and_export_vehicle_params_from_fc.return_value = "Parameter error occurred"
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.logging_error") as mock_logging,
+            patch("ardupilot_methodic_configurator.__main__.show_error_message") as mock_show_error,
+            patch("ardupilot_methodic_configurator.__main__.sys_exit") as mock_exit,
+        ):
+            # Act & Assert: Error handling
+            process_component_editor_results(mock_fc, mock_filesystem, None)
+
+            mock_logging.assert_called_once_with("Parameter error occurred")
+            mock_show_error.assert_called_once()
+            mock_exit.assert_called_once_with(1)
+
+    def test_write_parameter_defaults_if_dirty_when_dirty(self, application_state: ApplicationState) -> None:
+        """
+        User gets parameter defaults saved when they have been modified.
+
+        GIVEN: Parameter defaults have been modified (dirty flag is True)
+        WHEN: Write function is called
+        THEN: Parameter defaults should be written to file
+        """
+        # Arrange: Mock filesystem and dirty parameters
+        mock_filesystem = MagicMock()
+        param_values = {"PARAM1": 1.0, "PARAM2": 2.0}
+
+        application_state.local_filesystem = mock_filesystem
+        application_state.param_default_values = param_values
+        application_state.param_default_values_dirty = True
+
+        # Act: Write when dirty
+        write_parameter_defaults_if_dirty(application_state)
+
+        # Assert: File written
+        mock_filesystem.write_param_default_values_to_file.assert_called_once_with(param_values)
+
+    def test_write_parameter_defaults_if_dirty_when_clean(self, application_state: ApplicationState) -> None:
+        """
+        User workflow is efficient when parameter defaults haven't changed.
+
+        GIVEN: Parameter defaults haven't been modified (dirty flag is False)
+        WHEN: Write function is called
+        THEN: No file operation should occur
+        """
+        # Arrange: Mock filesystem and clean parameters
+        mock_filesystem = MagicMock()
+        param_values = {"PARAM1": 1.0, "PARAM2": 2.0}
+
+        application_state.local_filesystem = mock_filesystem
+        application_state.param_default_values = param_values
+        application_state.param_default_values_dirty = False
+
+        # Act: Write when clean
+        write_parameter_defaults_if_dirty(application_state)
+
+        # Assert: No file operation
+        mock_filesystem.write_param_default_values_to_file.assert_not_called()
+
+
+class TestComponentEditorIntegration:
+    """Test the integrated component editor workflow."""
+
+    def test_component_editor_workflow_with_skip(self, application_state: ApplicationState) -> None:
+        """
+        User can skip component editor for automated workflows.
+
+        GIVEN: User wants to skip component editor
+        WHEN: Component editor workflow runs
+        THEN: GUI should close automatically without user interaction
+        """
+        # Note: component_editor is already imported at the top of the file
+
+        # Arrange: Mock arguments with skip option
+        application_state.args.skip_component_editor = True
+        application_state.vehicle_dir_window = MagicMock()
+
+        # Mock local filesystem with vehicle_type
+        mock_filesystem = MagicMock()
+        mock_filesystem.vehicle_type = "ArduCopter"
+        application_state.local_filesystem = mock_filesystem
+
+        with patch("ardupilot_methodic_configurator.__main__.create_and_configure_component_editor") as mock_create:
+            mock_window = MagicMock()
+            mock_create.return_value = mock_window
+
+            # Act: Run component editor with skip
+            component_editor(application_state)
+
+            # Assert: Window configured to auto-close
+            mock_window.root.after.assert_called_once_with(10, mock_window.root.destroy)
+            mock_window.root.mainloop.assert_called_once()
+
+    def test_component_editor_workflow_with_documentation(self, application_state: ApplicationState) -> None:
+        """
+        User gets firmware documentation opened during component editor workflow.
+
+        GIVEN: Auto-documentation is enabled and firmware is known
+        WHEN: Component editor workflow runs
+        THEN: Firmware documentation should open automatically
+        """
+        # Note: component_editor is already imported at the top of the file
+
+        # Arrange: Mock for documentation opening
+        application_state.args.skip_component_editor = False
+
+        # Mock flight controller with proper structure
+        mock_fc = MagicMock()
+        mock_fc.info.firmware_type = "CubeOrange"
+        application_state.flight_controller = mock_fc
+        application_state.vehicle_dir_window = None
+
+        # Mock local filesystem with vehicle_type
+        mock_filesystem = MagicMock()
+        mock_filesystem.vehicle_type = "ArduCopter"
+        application_state.local_filesystem = mock_filesystem
+
+        with (
+            patch("ardupilot_methodic_configurator.__main__.create_and_configure_component_editor") as mock_create,
+            patch("ardupilot_methodic_configurator.__main__.should_open_firmware_documentation", return_value=True),
+            patch("ardupilot_methodic_configurator.__main__.open_firmware_documentation") as mock_open_doc,
+        ):
+            mock_window = MagicMock()
+            mock_create.return_value = mock_window
+
+            # Act: Run component editor
+            component_editor(application_state)
+
+            # Assert: Documentation opened
+            mock_open_doc.assert_called_once_with("CubeOrange")


### PR DESCRIPTION
This pull request refactors the terminology and logic in the codebase and tests to replace "firmware" with "vehicle" for better clarity and alignment with the domain. Additionally, it updates the filtering logic to use prefix matching instead of substring matching for vehicle types.

### Terminology Refactoring:
* Replaced "firmware" with "vehicle" in variable names, function names, and test descriptions for consistency (`tests/test_frontend_tkinter_template_overview.py`). [[1]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L96-R97) [[2]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L110-R112) [[3]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L126-R126) [[4]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L1054-R1133)

### Filtering Logic Update:
* Updated the `_populate_treeview` method to use `startswith` for filtering vehicle types instead of checking for substring matches (`ardupilot_methodic_configurator/frontend_tkinter_template_overview.py`).

### Test Updates:
* Adjusted test cases to reflect the updated filtering logic and renamed test methods and fixtures to align with the new "vehicle" terminology (`tests/test_frontend_tkinter_template_overview.py`). [[1]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L1054-R1133) [[2]](diffhunk://#diff-801d6f21a04c4dd66dc166912bbb413394f34b6ef6e5ebb7bfb6fe62284e0340L1144-R1151)