### PR TITLE
Use astral-sh/ruff-action with no explicit version

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -28,7 +28,26 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install 'mypy==1.16.0' 'types-requests==2.32.0.20250602'
+          export MYPY_VERSION=$(grep -oP 'mypy\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+          export TYPES_REQUESTS_VERSION=$(grep -oP 'types-requests\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+
+          if [ -z "$MYPY_VERSION" ]; then
+            echo "Could not detect mypy version in pyproject.toml; falling back to latest."
+            MYPY_INSTALL="mypy"
+          else
+            echo "Will install mypy version $MYPY_VERSION."
+            MYPY_INSTALL="mypy==$MYPY_VERSION"
+          fi
+
+          if [ -z "$TYPES_REQUESTS_VERSION" ]; then
+            echo "Could not detect types-requests version in pyproject.toml; falling back to latest."
+            TYPES_REQUESTS_INSTALL="types-requests"
+          else
+            echo "Will install types-requests version $TYPES_REQUESTS_VERSION."
+            TYPES_REQUESTS_INSTALL="types-requests==$TYPES_REQUESTS_VERSION"
+          fi
+
+          python -m pip install "$MYPY_INSTALL" "$TYPES_REQUESTS_INSTALL"
 
       - name: Lint the code with mypy
         uses: sasanquaneuf/mypy-github-action@a3f3a66f97792cac0cfd11d3e5c87088e5c8f6a9 # releases/v1.3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,13 +1,21 @@
 name: mypy
 
 on:
+  pull_request:
+    paths:
+      - '**/*.py'        # Watch for changes in any Python files
+      - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   push:
     paths:
       - '**/*.py'        # Watch for changes in any Python files
-      - 'pyproject.yml'  # Watch for changes in the pyproject.yml file
+      - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   workflow_dispatch:
   release:
     types: [published]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,10 @@
 name: Pylint
 
 on:
+  pull_request:
+    paths:
+      - '**/*.py'        # Watch for changes in any Python files
+      - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   push:
     paths:
       - '**/*.py'        # Watch for changes in any Python files
@@ -8,6 +12,10 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -11,6 +11,10 @@ on:
       - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -19,9 +19,6 @@ permissions:
 jobs:
   ruff:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['py39']
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -32,15 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # Ruff does not need a specific python version installed
-      - name: Install dependencies
-        run: |
-          python -m pip install 'ruff==0.11.13'
-
       - name: Lint with Ruff
-        run: |
-          ruff check --target-version ${{ matrix.python-version }} --output-format=github
+        uses: astral-sh/ruff-action@v3
 
       - name: Check format with Ruff
-        run: |
-          ruff format --check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -31,8 +31,11 @@ jobs:
 
       - name: Lint with Ruff
         uses: astral-sh/ruff-action@v3
+        with:
+          version-file: pyproject.toml
 
       - name: Check format with Ruff
         uses: astral-sh/ruff-action@v3
         with:
+          version-file: pyproject.toml
           args: format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,17 +1,21 @@
 name: Ruff
 
 on:
+  pull_request:
+    paths:
+      - '**/*.py'        # Watch for changes in any Python files
+      - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   push:
     paths:
       - '**/*.py'        # Watch for changes in any Python files
-      - 'pyproject.yml'  # Watch for changes in the pyproject.yml file
+      - 'pyproject.toml' # Watch for changes in the pyproject.toml file
   workflow_dispatch:
   release:
     types: [published]
 
-#concurrency:
-#  group: ci-${{github.workflow}}-${{ github.ref }}
-#  cancel-in-progress: true
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/ardupilot_methodic_configurator/annotate_params.py
+++ b/ardupilot_methodic_configurator/annotate_params.py
@@ -157,6 +157,10 @@ class Par:
             return self.value == other.value and self.comment == other.comment
         return False
 
+    def __hash__(self) -> int:
+        """Hash operation for using Par objects in sets and as dict keys."""
+        return hash((self.value, self.comment))
+
     @staticmethod
     def load_param_file_into_dict(param_file: str) -> dict[str, "Par"]:
         """
@@ -319,8 +323,7 @@ class Par:
         try:
             # Ensure newline character is LF, even on windows
             with open(filename_out, "w", encoding="utf-8", newline="\n") as output_file:
-                for line in formatted_params:
-                    output_file.write(line + "\n")
+                output_file.writelines(line + "\n" for line in formatted_params)
         except OSError as e:
             msg = f"ERROR: writing to file {filename_out}: {e}"
             raise SystemExit(msg) from e

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -511,8 +511,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                     with open(source, encoding="utf-8") as file:
                         lines = file.readlines()
                     with open(dest, "w", encoding="utf-8") as file:
-                        for line in lines:
-                            file.write(line.split("#")[0].strip() + "\n")
+                        file.writelines(line.split("#")[0].strip() + "\n" for line in lines)
                 elif os_path.isdir(source):
                     shutil_copytree(source, dest)
                 else:
@@ -742,7 +741,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
     def get_git_commit_hash() -> str:
         # Try to get git hash using git command
         try:
-            result = run(  # noqa: S603
+            result = run(
                 ["git", "rev-parse", "HEAD"],  # noqa: S607
                 capture_output=True,
                 text=True,

--- a/extract_missing_translations.py
+++ b/extract_missing_translations.py
@@ -211,8 +211,7 @@ def output_to_files(missing_translations: list[tuple[int, str]], output_file_bas
 
         # Write untranslated msgids along with their indices to the output file
         with open(current_output_file, "w", encoding="utf-8") as f:
-            for index, item in missing_translations[start_index:end_index]:
-                f.write(f"{index}:{item}\n")
+            f.writelines(f"{index}:{item}\n" for index, item in missing_translations[start_index:end_index])
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,9 @@ indent-width = 4
 "ardupilot_methodic_configurator/backend_mavftp.py" = ["PGH004", "N801", "ANN001"]
 "ardupilot_methodic_configurator/backend_mavftp_example.py" = ["ANN001"]
 "ardupilot_methodic_configurator/tempcal_imu.py" = ["ANN001"]
+"ardupilot_methodic_configurator/annotate_params.py" = ["PLC0415"]
+"ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py" = ["PLC0415"]
+"ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py" = ["PLC0415"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 22  # Default is 10

--- a/scripts/crawl_ardupilot_wiki.py
+++ b/scripts/crawl_ardupilot_wiki.py
@@ -200,13 +200,11 @@ def main() -> None:
         except (requests.RequestException, requests.Timeout) as e:
             logging.error("Network error crawling %s: %s", current_url, str(e))
             broken_urls.add(current_url)
-            if current_url in visited_urls:
-                visited_urls.remove(current_url)
+            visited_urls.discard(current_url)
         except (KeyError, ValueError) as e:
             logging.error("URL processing error for %s: %s", current_url, str(e))
             broken_urls.add(current_url)
-            if current_url in visited_urls:
-                visited_urls.remove(current_url)
+            visited_urls.discard(current_url)
     output_urls(visited_urls, broken_urls, start_time)
 
 
@@ -214,8 +212,7 @@ def output_urls(visited_urls: set[str], broken_urls: set[str], start_time: float
     # Write all html URLs to file
     raw_pages = len(visited_urls)
     with open("gurubase.io_url_list_raw.txt", "w", encoding="utf-8") as f:
-        for url in sorted(visited_urls):
-            f.write(f"{url}\n")  # Output to file
+        f.writelines(f"{url}\n" for url in sorted(visited_urls))  # Output to file
 
     visited_urls -= set(URL_BLACKLIST)
     dedup_urls = remove_duplicates(visited_urls)

--- a/tests/test_battery_cell_voltages.py
+++ b/tests/test_battery_cell_voltages.py
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import unittest
-from math import nan
+from math import isnan
 
 from ardupilot_methodic_configurator.battery_cell_voltages import BatteryCell, battery_cell_voltages
 
@@ -34,15 +34,15 @@ class TestBatteryCell(unittest.TestCase):  # pylint: disable=missing-class-docst
 
     def test_recommended_max_voltage(self) -> None:
         assert BatteryCell.recommended_max_voltage("LiIon") == 4.1
-        assert BatteryCell.recommended_max_voltage("NonExistentChemistry") is nan
+        assert isnan(BatteryCell.recommended_max_voltage("NonExistentChemistry"))
 
     def test_recommended_low_voltage(self) -> None:
         assert BatteryCell.recommended_low_voltage("LiIon") == 3.1
-        assert BatteryCell.recommended_low_voltage("NonExistentChemistry") is nan
+        assert isnan(BatteryCell.recommended_low_voltage("NonExistentChemistry"))
 
     def test_recommended_crit_voltage(self) -> None:
         assert BatteryCell.recommended_crit_voltage("LiIon") == 2.8
-        assert BatteryCell.recommended_crit_voltage("NonExistentChemistry") is nan
+        assert isnan(BatteryCell.recommended_crit_voltage("NonExistentChemistry"))
 
     def test_voltage_monoticity(self) -> None:
         for chemistry in BatteryCell.chemistries():


### PR DESCRIPTION
This pull request streamlines the Ruff linting workflow in GitHub Actions and updates the Ruff dependency to a newer version. The most important changes include replacing custom linting commands with the official Ruff GitHub Action and upgrading Ruff in the `pyproject.toml` file.

### Workflow improvements:
* [`.github/workflows/ruff.yml`](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L22-L24): Removed the Python version matrix and the manual installation of Ruff. Replaced custom commands for linting and format checking with the `astral-sh/ruff-action` GitHub Action. [[1]](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L22-L24) [[2]](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L35-R38)

### Dependency updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L75-R75): Upgraded Ruff from version `0.11.13` to `0.12.0`.