### PR TITLE
Use the ruff version defined in the pyproject.toml file

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -35,7 +35,14 @@ jobs:
       # Ruff does not need a specific python version installed
       - name: Install dependencies
         run: |
-          python -m pip install 'ruff==0.11.13'
+          export RUFF_VERSION=$(grep -oP "^ruff\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+)" pyproject.toml || echo '')
+          if [ -z "$RUFF_VERSION" ]; then
+            echo "Could not detect Ruff version in pyproject.toml; falling back to latest."
+            python -m pip install ruff
+          else
+            echo "Will install ruff version $RUFF_VERSION."
+            python -m pip install "ruff==$RUFF_VERSION"
+          fi
 
       - name: Lint with Ruff
         run: |


### PR DESCRIPTION
Avoids code duplication

This pull request updates the Ruff installation process in the `.github/workflows/ruff.yml` file to dynamically detect the version from `pyproject.toml` or fall back to the latest version if no specific version is found.

Workflow improvements:

* [`.github/workflows/ruff.yml`](diffhunk://#diff-2648f2b57520d4056946a7e509a50cfed47a7a8b389c0861011416ba78ae0db5L38-R45): Modified the Ruff installation step to extract the version from `pyproject.toml` using a `grep` command. If no version is found, it defaults to installing the latest Ruff version. This ensures consistency with the project's configuration while providing a fallback mechanism.