### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/bump_version_and_tag.yml
+++ b/.github/workflows/bump_version_and_tag.yml
@@ -40,8 +40,25 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install 'pip==25.0.1'
-          pip install 'packaging==24.0'
+          export PIP_VERSION=$(grep -oP 'pip\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+          if [ -z "$PIP_VERSION" ]; then
+            echo '::warning title=Could not detect pip version::in pyproject.toml; falling back to latest.'
+            PIP_INSTALL="pip"
+          else
+            echo "Will install pip version $PIP_VERSION."
+            PIP_INSTALL="pip==$PIP_VERSION"
+          fi
+          python -m pip install "$PIP_INSTALL"
+
+          export PACKAGING_VERSION=$(grep -oP 'packaging\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+          if [ -z "$PACKAGING_VERSION" ]; then
+            echo '::warning title=Could not detect packaging version::in pyproject.toml; falling back to latest.'
+            PACKAGING_INSTALL="packaging"
+          else
+            echo "Will install packaging version $PACKAGING_VERSION."
+            PACKAGING_INSTALL="packaging==$PACKAGING_VERSION"
+          fi
+          pip install "$PACKAGING_INSTALL"
 
       - name: Validate version format
         run: |

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -48,7 +48,26 @@ jobs:
 
       - name: Install python-gettext requirement
         run: |
-          python -m pip install 'pip==25.0.1' 'python-gettext==5.0'
+          export PIP_VERSION=$(grep -oP 'pip\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+          export PYTHON_GETTEXT_VERSION=$(grep -oP 'python-gettext\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
+
+          if [ -z "$PIP_VERSION" ]; then
+            echo '::warning title=Could not detect pip version::in pyproject.toml; falling back to latest.'
+            PIP_INSTALL="pip"
+          else
+            echo "Will install pip version $PIP_VERSION."
+            PIP_INSTALL="pip==$PIP_VERSION"
+          fi
+
+          if [ -z "$PYTHON_GETTEXT_VERSION" ]; then
+            echo '::warning title=Could not detect python-gettext version::in pyproject.toml; falling back to 5.0.'
+            PYTHON_GETTEXT_INSTALL="python-gettext==5.0"
+          else
+            echo "Will install python-gettext version $PYTHON_GETTEXT_VERSION."
+            PYTHON_GETTEXT_INSTALL="python-gettext==$PYTHON_GETTEXT_VERSION"
+          fi
+
+          python -m pip install "$PIP_INSTALL" "$PYTHON_GETTEXT_INSTALL"
 
       - name: Extract strings
         run: |

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -40,7 +40,7 @@ jobs:
           export TYPES_REQUESTS_VERSION=$(grep -oP 'types-requests\s*==\s*\K([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)' pyproject.toml || echo '')
 
           if [ -z "$MYPY_VERSION" ]; then
-            echo "Could not detect mypy version in pyproject.toml; falling back to latest."
+            echo '::warning title=Could not detect mypy version::in pyproject.toml; falling back to latest.'
             MYPY_INSTALL="mypy"
           else
             echo "Will install mypy version $MYPY_VERSION."
@@ -48,7 +48,7 @@ jobs:
           fi
 
           if [ -z "$TYPES_REQUESTS_VERSION" ]; then
-            echo "Could not detect types-requests version in pyproject.toml; falling back to latest."
+            echo '::warning title=Could not detect types-requests version::in pyproject.toml; falling back to latest.'
             TYPES_REQUESTS_INSTALL="types-requests"
           else
             echo "Will install types-requests version $TYPES_REQUESTS_VERSION."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,9 +55,10 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
 
-      - name: Install dependencies
+      - name: Install dependencies and application
+        # without --editable the coverage report is not generated correctly
         run: |
-          pip install .[dev]
+          pip install --editable .[dev]
 
       - name: Test with pytest
         id: pytest

--- a/ardupilot_methodic_configurator/annotate_params.py
+++ b/ardupilot_methodic_configurator/annotate_params.py
@@ -394,8 +394,8 @@ def get_xml_data(base_url: str, directory: str, filename: str, vehicle_type: str
         # No locally cached file exists, get it from the internet
         try:
             # pylint: disable=import-outside-toplevel
-            from requests import exceptions as requests_exceptions  # type: ignore[import-untyped]
-            from requests import get as requests_get
+            from requests import exceptions as requests_exceptions  # type: ignore[import-untyped] # noqa: PLC0415
+            from requests import get as requests_get  # noqa: PLC0415
 
             # pylint: enable=import-outside-toplevel
         except ImportError as exc:

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -559,7 +559,7 @@ class ComponentEditorWindowBase(BaseWindow):  # pylint: disable=too-many-instanc
 
         """
         # Import MagicMock at the method level to avoid import issues
-        from unittest.mock import MagicMock  # pylint: disable=import-outside-toplevel
+        from unittest.mock import MagicMock  # pylint: disable=import-outside-toplevel # noqa: PLC0415
 
         if local_filesystem is None:
             # Create a minimal mock filesystem for testing

--- a/ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py
@@ -249,8 +249,8 @@ def main() -> None:
     root.geometry("400x100")  # Set a size for the window
 
     # Generate 20 random strings between 4 and 70 characters
-    import random  # pylint: disable=import-outside-toplevel
-    import string  # pylint: disable=import-outside-toplevel
+    import random  # pylint: disable=import-outside-toplevel # noqa: PLC0415
+    import string  # pylint: disable=import-outside-toplevel # noqa: PLC0415
 
     random_strings = [
         "".join(random.choices(string.ascii_letters + string.digits, k=random.randint(4, 70)))  # noqa: S311

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,9 +211,6 @@ indent-width = 4
 "ardupilot_methodic_configurator/backend_mavftp.py" = ["PGH004", "N801", "ANN001"]
 "ardupilot_methodic_configurator/backend_mavftp_example.py" = ["ANN001"]
 "ardupilot_methodic_configurator/tempcal_imu.py" = ["ANN001"]
-"ardupilot_methodic_configurator/annotate_params.py" = ["PLC0415"]
-"ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py" = ["PLC0415"]
-"ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py" = ["PLC0415"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 22  # Default is 10


### PR DESCRIPTION
This pull request introduces changes to improve dependency management in GitHub workflows by dynamically detecting versions from `pyproject.toml`, adjusts import handling in Python scripts to include `noqa` comments for specific linting rules, and updates the `pyproject.toml` configuration to remove `PLC0415` rule exclusions. Below are the key changes grouped by theme:

### Dependency Management in GitHub Workflows:
* Updated `.github/workflows/bump_version_and_tag.yml` to dynamically detect and install specific versions of `pip` and `packaging` from `pyproject.toml`. Fallbacks to latest versions are provided with warnings if detection fails.
* Updated `.github/workflows/i18n-extract.yml` to dynamically detect and install specific versions of `pip` and `python-gettext` from `pyproject.toml`. Fallbacks to default versions are provided with warnings if detection fails.
* Improved warnings in `.github/workflows/mypy.yml` when `mypy` or `types-requests` versions cannot be detected in `pyproject.toml`.

### Import Handling in Python Scripts:
* Added `# noqa: PLC0415` comments to imports in `ardupilot_methodic_configurator/annotate_params.py`, `frontend_tkinter_component_editor_base.py`, and `frontend_tkinter_pair_tuple_combobox.py` to suppress linting errors related to import placement. [[1]](diffhunk://#diff-a810ac5cd54a305cbe2a466865aeaa31bf27e3078169fef0321c7a93e5d32724L397-R398) [[2]](diffhunk://#diff-7f3397e9355b08ace5f25e2a3f881656ea2b7b934ae6de417f3cac9e9e320dabL562-R562) [[3]](diffhunk://#diff-faf72790a12c45986df59a2fa6a8b0e870f8134081ee4096c9996a8af5f416fcL252-R253)

### Configuration Updates:
* Removed `PLC0415` rule exclusions from `pyproject.toml` for specific files, ensuring consistent linting without suppressing this rule globally.