### PR TITLE
Update to version 6.4.3. Version 6.3.3 is no longer available

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -47,7 +47,7 @@ jobs:
           uv pip install .[win_dist]
 
       - name: Download Inno Setup installer
-        run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.3.3.exe
+        run: curl -L -o installer.exe http://files.jrsoftware.org/is/6/innosetup-6.4.3.exe
 
       - name: Install Inno Setup
         run: ./installer.exe /verysilent /allusers /dir=inst


### PR DESCRIPTION
This pull request updates the Inno Setup installer version in the Windows build workflow.

* [`.github/workflows/windows_build.yml`](diffhunk://#diff-4f99d7a5ccc527af64c0d4fca4d4065b5400c04c60f188181d532fcbc0a5af8eL50-R50): Updated the download URL for the Inno Setup installer from version 6.3.3 to version 6.4.3 to ensure the workflow uses the latest version.