### PR TITLE
Do not skip component editor if blanking component data was selected

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -317,7 +317,12 @@ def component_editor(state: ApplicationState) -> None:
     )
 
     # Handle skip component editor option
-    if state.args.skip_component_editor:
+    should_skip_editor = state.args.skip_component_editor and not (
+        state.vehicle_dir_window
+        and state.vehicle_dir_window.configuration_template
+        and state.vehicle_dir_window.blank_component_data.get()
+    )
+    if should_skip_editor:
         component_editor_window.root.after(10, component_editor_window.root.destroy)
     elif should_open_firmware_documentation(state.flight_controller):
         open_firmware_documentation(state.flight_controller.info.firmware_type)

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1151,7 +1151,11 @@ class TestComponentEditorIntegration:
 
         # Arrange: Mock arguments with skip option
         application_state.args.skip_component_editor = True
-        application_state.vehicle_dir_window = MagicMock()
+
+        # Mock vehicle_dir_window to ensure skip condition is met
+        # The skip condition requires that NOT(vehicle_dir_window AND configuration_template AND blank_component_data.get())
+        # So we need to set vehicle_dir_window to None or make one of the other conditions False
+        application_state.vehicle_dir_window = None
 
         # Mock local filesystem with vehicle_type
         mock_filesystem = MagicMock()


### PR DESCRIPTION
The user needs to enter the component data before proceeding, skipping is not an option

This pull request refines the logic in the `component_editor` function within `ardupilot_methodic_configurator/__main__.py` to ensure that the component editor is only skipped under specific conditions.

### Logic refinement:

* Updated the condition for skipping the component editor to include additional checks. The editor is now skipped only if `state.args.skip_component_editor` is true and the `vehicle_dir_window` has a valid `configuration_template` and non-empty `blank_component_data`.