### PR TITLE
Sort the current value tooltip numerically.

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -366,8 +366,12 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
                 flightcontroller_value = ttk.Label(self.view_port, text=value_str)
         else:
             flightcontroller_value = ttk.Label(self.view_port, text=_("N/A"), background="orange")
-        if doc_tooltip:
-            show_tooltip(flightcontroller_value, doc_tooltip)
+
+        # Use numerically sorted tooltip for Current Value column if available
+        param_metadata = self.local_filesystem.doc_dict.get(param_name, {})
+        sorted_tooltip = param_metadata.get("doc_tooltip_sorted_numerically", doc_tooltip)
+        if sorted_tooltip:
+            show_tooltip(flightcontroller_value, sorted_tooltip)
         return flightcontroller_value
 
     def _update_combobox_style_on_selection(


### PR DESCRIPTION
implements #481

This pull request introduces a new feature to format and display parameter tooltips with numeric sorting, enhancing the usability and clarity of tooltips in the parameter editor. The most important changes include the addition of a helper method for formatting values into numerically sorted columns, updates to parameter metadata to include these sorted tooltips, and modifications to the frontend to use the new tooltips.

### Backend Enhancements:

* **Added `_format_columns_sorted_numerically` method**: This helper method formats a dictionary of values into column-major, horizontally aligned columns sorted numerically by key. It handles both numeric and string sorting, ensures optimal column width, and adjusts the number of columns dynamically. (`ardupilot_methodic_configurator/backend_filesystem.py`, [ardupilot_methodic_configurator/backend_filesystem.pyR189-R249](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716R189-R249))
* **Updated parameter metadata**: Modified the `__extend_and_reformat_parameter_documentation_metadata` method to generate a new `doc_tooltip_sorted_numerically` field for each parameter. This field contains a numerically sorted version of the tooltip for better readability. (`ardupilot_methodic_configurator/backend_filesystem.py`, [ardupilot_methodic_configurator/backend_filesystem.pyR303-R316](diffhunk://#diff-cf28409654b00ab8706721d7366feaf693978b04612204ba7b945adac7563716R303-R316))

### Frontend Integration:

* **Enhanced tooltip display**: Updated the `_create_flightcontroller_value` method to prioritize the use of `doc_tooltip_sorted_numerically` for the "Current Value" column tooltips if available, falling back to the original tooltip otherwise. (`ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py`, [ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.pyL369-R374](diffhunk://#diff-a1fc77b2f824d73d73195abb5559fad566982d510708937a5c52ba2c86de71acL369-R374))