### PR TITLE
Small improvements

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -212,9 +212,11 @@ class ComponentEditorWindowBase(BaseWindow):  # pylint: disable=too-many-instanc
 
     def _on_complexity_changed(self, _event: Optional[tk.Event] = None) -> None:
         """Handle complexity combobox change."""
-        # Save the complexity setting
-        ProgramSettings.set_setting("gui_complexity", self.complexity_var.get())
-        self._refresh_component_display()
+        old_gui_complexity = ProgramSettings.get_setting("gui_complexity")
+        new_gui_complexity = self.complexity_var.get()
+        if new_gui_complexity != old_gui_complexity:
+            ProgramSettings.set_setting("gui_complexity", new_gui_complexity)
+            self._refresh_component_display()
 
     def _refresh_component_display(self) -> None:
         """Refresh the component display UI."""

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -318,6 +318,20 @@ class ComponentEditorWindowBase(BaseWindow):  # pylint: disable=too-many-instanc
         """Set component value in data model."""
         self.data_model.set_component_value(path, value)
 
+    def set_vehicle_configuration_template(self, configuration_template: str) -> None:
+        """Set the configuration template name in the data."""
+        self.data_model.set_configuration_template(configuration_template)
+
+    def set_values_from_fc_parameters(self, fc_parameters: dict, doc: dict) -> None:
+        """
+        Process flight controller parameters and update the data model.
+
+        This delegates to the data model's process_fc_parameters method to handle
+        all the business logic of processing parameters.
+        """
+        # Delegate to the data model for parameter processing
+        self.data_model.process_fc_parameters(fc_parameters, doc)
+
     def _update_widget_value(self, path: ComponentPath, value: str) -> None:
         """Update widget value in UI."""
         if path in self.entry_widgets:

--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor_base.py
@@ -347,6 +347,8 @@ class ComponentEditorWindowBase(BaseWindow):  # pylint: disable=too-many-instanc
         components = self.data_model.get_all_components()
         for key, value in components.items():
             self.add_widget(self.scroll_frame.view_port, key, value, [])
+        # Scroll to the top after (re-)populating
+        self.scroll_frame.canvas.yview("moveto", 0)
 
     def add_widget(self, parent: tk.Widget, key: str, value: ComponentValue, path: list[str]) -> None:
         """

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/FETtec-5/vehicle_components.json
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/FETtec-5/vehicle_components.json
@@ -102,7 +102,7 @@
                 "Version": "10_224"
             },
             "FC Connection": {
-                "Type": "SERIAL1",
+                "Type": "other",
                 "Protocol": "ESC"
             },
             "Notes": "ESC Telemetry is used as battery monitor"

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X11+/vehicle_components.json
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X11+/vehicle_components.json
@@ -102,7 +102,7 @@
                 "Version": ""
             },
             "FC Connection": {
-                "Type": "CAN1",
+                "Type": "other",
                 "Protocol": "ESC"
             },
             "Notes": "Voltage and current are monitored via the ESC."

--- a/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X13/vehicle_components.json
+++ b/ardupilot_methodic_configurator/vehicle_templates/ArduCopter/Hoverit_X13/vehicle_components.json
@@ -102,7 +102,7 @@
                 "Version": ""
             },
             "FC Connection": {
-                "Type": "CAN1",
+                "Type": "other",
                 "Protocol": "ESC"
             },
             "Notes": "Voltage and current are monitored via the ESC DatalinkV2."


### PR DESCRIPTION
This pull request introduces significant updates to the `ardupilot_methodic_configurator` codebase, focusing on improving data model handling, simplifying the frontend, and enhancing test coverage. The most notable changes include refactoring the JSON structure update logic, streamlining UI validation, and fixing legacy issues in vehicle configuration templates.

### Data Model Improvements:
* Refactored `update_json_structure` in `data_model_vehicle_components_base.py` to use a default structure and a new `_deep_merge_dicts` utility for cleaner and more maintainable code. This also includes handling legacy field renaming and battery monitor protocol migrations.

### Frontend Simplifications:
* Consolidated combobox and entry validation logic in `frontend_tkinter_component_editor.py` by introducing dedicated methods (`_validate_combobox`, `_validate_entry_limits_ui`) and removing redundant lambda bindings. [[1]](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41R172-R180) [[2]](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41L240-R237) [[3]](diffhunk://#diff-a7727a72bc95073635a5fd71b05f56e59cadfb091151dc205a03006606b05e41L288-R274)
* Added logic to scroll to the top of the UI after repopulating frames in `frontend_tkinter_component_editor_base.py`.

### Vehicle Template Updates:
* Updated several vehicle templates (`FETtec-5`, `Hoverit_X11+`, `Hoverit_X13`) to use "Type: other" for ESC protocols, reflecting the new battery monitor protocol migration logic. [[1]](diffhunk://#diff-67d25117b503df2466b12b25521d55464e6b5976d7bb430e72972e1094a292f3L105-R105) [[2]](diffhunk://#diff-e1dde51ce08b67e3cee994ab376800c7e63a39ec49b8dda87d41ec483a81c4c6L105-R105) [[3]](diffhunk://#diff-d5d89a53d6ec22b82647654996c5e0f6309cc96a3b759b43d08e449893b71effL105-R105)

### Test Enhancements:
* Modified tests in `test_data_model_vehicle_components_base.py` to use mocked schemas for better isolation and to validate the new data model structure handling. [[1]](diffhunk://#diff-0d70fd624d4f02f09b73cdc202467812e869790cf32f77eec1b78172ea0b7f8fL447-R448) [[2]](diffhunk://#diff-0d70fd624d4f02f09b73cdc202467812e869790cf32f77eec1b78172ea0b7f8fL570-R572)

### Minor Adjustments:
* Removed unused `Callable` import in `frontend_tkinter_component_editor.py`.
* Optimized complexity change handling in `frontend_tkinter_component_editor_base.py` to avoid unnecessary updates.