### PR TITLE
test(pytest): The tkinter initialization error

### DIFF
--- a/tests/test_frontend_tkinter_base_window.py
+++ b/tests/test_frontend_tkinter_base_window.py
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import contextlib  # noqa: I001
+import contextlib
 import os
 import tempfile
 import time
@@ -22,10 +22,10 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PIL import Image
 
 # Import shared configuration from conftest
 from conftest import MockConfiguration
+from PIL import Image
 
 from ardupilot_methodic_configurator.frontend_tkinter_base_window import BaseWindow
 
@@ -621,7 +621,7 @@ class TestCompleteWorkflows:
 class TestRealImageIntegration:
     """Test image operations with real files and Tkinter."""
 
-    def test_user_sees_images_loaded_correctly_in_real_environment(self, tk_root, sample_image_file) -> None:
+    def test_user_sees_images_loaded_correctly_in_real_environment(self, root, sample_image_file) -> None:
         """
         User sees images loaded correctly in real environment.
 
@@ -631,7 +631,7 @@ class TestRealImageIntegration:
         """
         try:
             # Arrange: Set up real window and image file
-            window = BaseWindow(tk_root)
+            window = BaseWindow(root)
 
             # Act: User loads real image into the application
             label = window.put_image_in_label(window.main_frame, sample_image_file, image_height=50)
@@ -647,7 +647,7 @@ class TestRealImageIntegration:
                 pytest.skip(f"Tkinter image/display not available in test environment: {e}")
             raise
 
-    def test_user_sees_properly_scaled_images_across_dpi_settings(self, tk_root, sample_image_file) -> None:
+    def test_user_sees_properly_scaled_images_across_dpi_settings(self, root, sample_image_file) -> None:
         """
         User sees properly scaled images across DPI settings.
 
@@ -656,7 +656,7 @@ class TestRealImageIntegration:
         THEN: Should scale images appropriately for good visual experience
         """
         try:  # Arrange: Set up real window environment
-            window = BaseWindow(tk_root)
+            window = BaseWindow(root)
 
             # Test different image heights for various UI contexts
             heights = [25, 50, 100]
@@ -676,7 +676,7 @@ class TestRealImageIntegration:
                 pytest.skip(f"Tkinter image/display not available in test environment: {e}")
             raise
 
-    def test_user_can_load_multiple_images_without_performance_issues(self, tk_root) -> None:
+    def test_user_can_load_multiple_images_without_performance_issues(self, root) -> None:
         """
         User can load multiple images without performance issues.
 
@@ -686,7 +686,7 @@ class TestRealImageIntegration:
         """
         try:
             # Arrange: Set up window and prepare for multiple image loading
-            window = BaseWindow(tk_root)
+            window = BaseWindow(root)
             temp_files = []
             labels = []
 
@@ -866,7 +866,7 @@ class TestWindowPositioningIntegration:
 class TestPerformanceIntegration:
     """Test performance characteristics with real Tkinter operations."""
 
-    def test_user_experiences_responsive_window_creation(self) -> None:
+    def test_user_experiences_responsive_window_creation(self, root) -> None:
         """
         User experiences responsive window creation.
 
@@ -881,7 +881,7 @@ class TestPerformanceIntegration:
         try:
             # Act: User rapidly creates 10 windows (simulating busy workflow)
             for _ in range(10):
-                window = BaseWindow()
+                window = BaseWindow(root)
                 windows.append(window)
 
             creation_time = time.time() - start_time
@@ -899,9 +899,10 @@ class TestPerformanceIntegration:
             # Cleanup: Close all windows
             for window in windows:
                 with contextlib.suppress(tk.TclError):
-                    window.root.destroy()
+                    if hasattr(window, "root") and window.root != root:  # Don't destroy the session root
+                        window.root.destroy()
 
-    def test_user_experiences_smooth_image_loading_performance(self, sample_image_file) -> None:
+    def test_user_experiences_smooth_image_loading_performance(self, root, sample_image_file) -> None:
         """
         User experiences smooth image loading performance.
 
@@ -912,7 +913,7 @@ class TestPerformanceIntegration:
         # Arrange: Prepare for image loading performance test
         window = None
         try:
-            window = BaseWindow()
+            window = BaseWindow(root)
 
             start_time = time.time()
             labels = []
@@ -933,10 +934,8 @@ class TestPerformanceIntegration:
         except tk.TclError:
             pytest.skip("Tkinter display not available")
         finally:
-            # Cleanup: Close window properly
-            if window is not None and hasattr(window, "root"):
-                with contextlib.suppress(tk.TclError):
-                    window.root.destroy()
+            # Cleanup: Don't destroy the session root, it's managed by conftest.py
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/test_frontend_tkinter_component_template_manager.py
+++ b/tests/test_frontend_tkinter_component_template_manager.py
@@ -10,7 +10,6 @@ SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import tkinter as tk
 from tkinter import ttk
 from unittest.mock import MagicMock, patch
 
@@ -23,14 +22,6 @@ class TestComponentTemplateManager:
     """Test suite for ComponentTemplateManager."""
 
     @pytest.fixture
-    def setup_tkinter(self) -> tk.Tk:
-        """Setup tkinter root window for testing."""
-        root = tk.Tk()
-        root.withdraw()  # Hide the window
-        yield root
-        root.destroy()
-
-    @pytest.fixture
     def mock_callbacks(self) -> tuple[MagicMock, MagicMock, MagicMock]:
         """Setup mock callbacks for testing."""
         get_component_data = MagicMock(return_value={"Model": "XYZ", "Version": "1.0"})
@@ -39,9 +30,8 @@ class TestComponentTemplateManager:
         return get_component_data, update_data, derive_name
 
     @pytest.fixture
-    def entry_widgets(self, setup_tkinter) -> dict[tuple, ttk.Entry]:
+    def entry_widgets(self, root) -> dict[tuple, ttk.Entry]:
         """Setup entry widgets for testing."""
-        root = setup_tkinter
         frame = ttk.Frame(root)
 
         entry1 = ttk.Entry(frame)
@@ -60,21 +50,19 @@ class TestComponentTemplateManager:
         }
 
     @pytest.fixture
-    def template_manager(self, setup_tkinter, entry_widgets, mock_callbacks) -> ComponentTemplateManager:
+    def template_manager(self, root, entry_widgets, mock_callbacks) -> ComponentTemplateManager:
         """Create ComponentTemplateManager instance for testing."""
         get_data_callback, update_callback, derive_name_callback = mock_callbacks
-        manager = ComponentTemplateManager(
-            setup_tkinter, entry_widgets, get_data_callback, update_callback, derive_name_callback
-        )
+        manager = ComponentTemplateManager(root, entry_widgets, get_data_callback, update_callback, derive_name_callback)
         # Mock the VehicleComponents to avoid actual file operations
         manager.template_manager = MagicMock()
         return manager
 
-    def test_initialization(self, template_manager, setup_tkinter, entry_widgets, mock_callbacks) -> None:
+    def test_initialization(self, template_manager, root, entry_widgets, mock_callbacks) -> None:
         """Test that initialization correctly sets up instance variables."""
         get_data_callback, update_callback, derive_name_callback = mock_callbacks
 
-        assert template_manager.root == setup_tkinter
+        assert template_manager.root == root
         assert template_manager.entry_widgets == entry_widgets
         assert template_manager.buttons == {}
         assert template_manager.current_menu is None
@@ -92,9 +80,8 @@ class TestComponentTemplateManager:
         derive_name_callback.assert_called_once_with(component_data)
         assert template_name == "XYZ_1.0"  # From the mock's return value
 
-    def test_add_template_controls(self, setup_tkinter, template_manager) -> None:
+    def test_add_template_controls(self, root, template_manager) -> None:
         """Test that add_template_controls creates and adds buttons correctly."""
-        root = setup_tkinter
         parent_frame = ttk.LabelFrame(root, text="Test Component")
 
         template_manager.add_template_controls(parent_frame, "TestComponent")
@@ -220,9 +207,8 @@ class TestComponentTemplateManager:
             assert "Test Template" in args[1]
             assert "Component1" in args[1]
 
-    def test_create_template_dropdown_button(self, setup_tkinter, template_manager) -> None:
+    def test_create_template_dropdown_button(self, root, template_manager) -> None:
         """Test creating a template dropdown button."""
-        root = setup_tkinter
         frame = ttk.Frame(root)
 
         button = template_manager.create_template_dropdown_button(frame, "TestComponent")

--- a/tests/test_frontend_tkinter_component_template_manager.py
+++ b/tests/test_frontend_tkinter_component_template_manager.py
@@ -17,6 +17,8 @@ import pytest
 
 from ardupilot_methodic_configurator.frontend_tkinter_component_template_manager import ComponentTemplateManager
 
+# pylint: disable=redefined-outer-name
+
 
 class TestComponentTemplateManager:
     """Test suite for ComponentTemplateManager."""
@@ -218,6 +220,13 @@ class TestComponentTemplateManager:
         assert button["width"] == 2
 
     def test_save_component_as_template_no_data(self, template_manager, mock_callbacks) -> None:
+        """
+        Test that saving a component with no data shows an error.
+
+        GIVEN: A component with no data to save
+        WHEN: User attempts to save it as a template
+        THEN: An error message should be displayed and no template should be saved
+        """
         get_data_callback, _, _ = mock_callbacks
         get_data_callback.return_value = {}
 
@@ -226,6 +235,13 @@ class TestComponentTemplateManager:
             mock_error.assert_called_once()
 
     def test_apply_template_missing_keys(self, template_manager, entry_widgets, mock_callbacks) -> None:
+        """
+        Test applying a template that doesn't contain all required keys.
+
+        GIVEN: A template with incomplete data for a component
+        WHEN: User applies the template to the component
+        THEN: Only matching fields should be updated and other fields remain unchanged
+        """
         _, update_callback, _ = mock_callbacks  # pylint: disable=unused-variable
         template = {"name": "Incomplete", "data": {"SomeOtherField": "value"}}
 

--- a/tests/test_frontend_tkinter_directory_selection.py
+++ b/tests/test_frontend_tkinter_directory_selection.py
@@ -10,7 +10,6 @@ SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import contextlib
 import tkinter as tk
 from collections.abc import Generator
 from tkinter import ttk
@@ -28,34 +27,6 @@ from ardupilot_methodic_configurator.frontend_tkinter_directory_selection import
 
 # pylint: disable=redefined-outer-name,unused-argument,line-too-long,too-many-lines
 # ruff: noqa: SIM117
-
-
-@pytest.fixture(scope="session")
-def root() -> Generator[tk.Tk, None, None]:
-    """Create and clean up Tk root window for testing."""
-    # Try to reuse existing root or create new one
-    try:
-        root = tk._default_root  # type: ignore[attr-defined]
-        if root is None:
-            root = tk.Tk()
-    except (AttributeError, tk.TclError):
-        root = tk.Tk()
-
-    root.withdraw()  # Hide the main window during tests
-
-    # Patch the iconphoto method to prevent errors with mock PhotoImage
-    original_iconphoto = root.iconphoto
-    # Use a property-like approach instead of direct assignment
-    root.iconphoto = MagicMock()  # type: ignore[method-assign]
-
-    yield root
-
-    # Restore original method and destroy root
-    root.iconphoto = original_iconphoto  # type: ignore[method-assign]
-
-    # Only destroy if we're the last test
-    with contextlib.suppress(tk.TclError):
-        root.quit()  # Close the event loop
 
 
 @pytest.fixture

--- a/tests/test_frontend_tkinter_directory_selection_integration.py
+++ b/tests/test_frontend_tkinter_directory_selection_integration.py
@@ -10,7 +10,6 @@ SPDX-FileCopyrightText: 2024-2025 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import contextlib
 import os
 import tkinter as tk
 from collections.abc import Callable, Generator
@@ -54,37 +53,6 @@ class WidgetEventTracker:
             self.widget.unbind(event_name)
         self.bindings.clear()
         self.events.clear()
-
-
-@pytest.fixture(scope="session")
-def root() -> Generator[tk.Tk, None, None]:
-    """Create and clean up Tk root window for testing."""
-    # Try to reuse existing root or create new one
-    try:
-        root = tk._default_root  # type: ignore[attr-defined]
-        if root is None:
-            root = tk.Tk()
-    except (AttributeError, tk.TclError):
-        root = tk.Tk()
-
-    root.withdraw()  # Hide the main window during tests
-
-    # Patch the iconphoto method to prevent errors with mock PhotoImage
-    original_iconphoto = root.iconphoto
-
-    def mock_iconphoto(*args, **kwargs) -> None:
-        pass
-
-    root.iconphoto = mock_iconphoto  # type: ignore[method-assign]
-
-    yield root
-
-    # Restore original method and destroy root
-    root.iconphoto = original_iconphoto  # type: ignore[method-assign]
-
-    # Only destroy if we're the last test
-    with contextlib.suppress(tk.TclError):
-        root.quit()  # Close the event loop
 
 
 # pylint: disable=duplicate-code


### PR DESCRIPTION
- was caused by multiple test files trying to create separate Tk instances in a headless environment
- Moved the robust root fixture to conftest.py - This eliminates code duplication and ensures consistency
- Session-scoped fixture - Prevents multiple Tk instance creation across test sessions
- Robust error handling - Uses contextlib.suppress() for graceful cleanup
- Smart root reuse - Tries to reuse existing root or creates new one safely