### PR TITLE
Disable pylint on python 3.12

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12", "3.13"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
The CI jobs test both 3.9 and 3.13 and that is enough