### PR TITLE
Fix pre-commit failure with noqa: ANN401

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
@@ -368,7 +368,7 @@ class VehicleComponents:
                 },
             }
 
-            def is_empty(val: Any) -> bool:
+            def is_empty(val: Any) -> bool:  # noqa: ANN401
                 return val in (None, "", 0, 0.0, {}) or (isinstance(val, dict) and not val)
 
             def merge_defaults(target: dict, defaults: dict) -> None:


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/any-type

Also, why not make this change?
```diff
  def is_empty(val: Any) -> bool:
-     return val in (None, "", 0, 0.0, {}) or (isinstance(val, dict) and not val)
+     return not val
```