### PR TITLE
Fix upload checkbuttons init

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -181,12 +181,13 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors, 
         """Update the parameter table with the given parameters."""
         current_param_name: str = ""
         show_upload_column = self._should_show_upload_column(gui_complexity)
+        fc_connected = bool(fc_parameters)
 
         try:
             for i, (param_name, param) in enumerate(params.items(), 1):
                 current_param_name = param_name
 
-                column: list[tk.Widget] = self._create_column_widgets(param_name, param, show_upload_column)
+                column: list[tk.Widget] = self._create_column_widgets(param_name, param, show_upload_column, fc_connected)
                 self._grid_column_widgets(column, i, show_upload_column)
 
             # Add the "Add" button at the bottom of the table
@@ -205,7 +206,9 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors, 
 
         self._configure_table_columns(show_upload_column)
 
-    def _create_column_widgets(self, param_name: str, param: ArduPilotParameter, show_upload_column: bool) -> list[tk.Widget]:
+    def _create_column_widgets(
+        self, param_name: str, param: ArduPilotParameter, show_upload_column: bool, fc_connected: bool
+    ) -> list[tk.Widget]:
         """Create all column widgets for a parameter row."""
         column: list[tk.Widget] = []
         change_reason_widget = self._create_change_reason_entry(param)
@@ -219,7 +222,7 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors, 
         column.append(self._create_unit_label(param))
 
         if show_upload_column:
-            column.append(self._create_upload_checkbutton(param_name, param.has_fc_value))
+            column.append(self._create_upload_checkbutton(param_name, fc_connected))
 
         column.append(change_reason_widget)
 

--- a/tests/test_frontend_tkinter_parameter_editor_documentation_frame.py
+++ b/tests/test_frontend_tkinter_parameter_editor_documentation_frame.py
@@ -48,7 +48,7 @@ class TestDocumentationFrame(unittest.TestCase):
         assert isinstance(self.doc_frame.documentation_frame, ttk.LabelFrame)
         assert self.doc_frame.documentation_frame.cget("text") == "test_file Documentation"
 
-        expected_labels = ["Forum Blog:", "Wiki:", "External tool:"]
+        expected_labels = [self.doc_frame.BLOG_LABEL, self.doc_frame.WIKI_LABEL, self.doc_frame.EXTERNAL_TOOL_LABEL]
         for label in expected_labels:
             assert label in self.doc_frame.documentation_labels
 
@@ -118,14 +118,14 @@ class TestDocumentationFrame(unittest.TestCase):
         self.doc_frame.refresh_documentation_labels(self.current_file)
 
         # Check regular labels
-        assert self.doc_frame.documentation_labels["Forum Blog:"].cget("text") == "Blog text"
-        assert self.doc_frame.documentation_labels["Wiki:"].cget("text") == "Wiki text"
-        assert self.doc_frame.documentation_labels["External tool:"].cget("text") == "External tool text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("text") == "Blog text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("text") == "Wiki text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("text") == "External tool text"
 
         # Check colors for clickable links
-        assert str(self.doc_frame.documentation_labels["Forum Blog:"].cget("foreground")) == "blue"
-        assert str(self.doc_frame.documentation_labels["Wiki:"].cget("foreground")) == "blue"
-        assert str(self.doc_frame.documentation_labels["External tool:"].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("foreground")) == "blue"
 
         # Check mandatory level progress bar
         assert self.doc_frame.mandatory_level.cget("value") == 75
@@ -143,9 +143,9 @@ class TestDocumentationFrame(unittest.TestCase):
         self.doc_frame.refresh_documentation_labels(self.current_file)
 
         # Simulate clicking on the labels
-        self.doc_frame.documentation_labels["Forum Blog:"].event_generate("<Button-1>")
-        self.doc_frame.documentation_labels["Wiki:"].event_generate("<Button-1>")
-        self.doc_frame.documentation_labels["External tool:"].event_generate("<Button-1>")
+        self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].event_generate("<Button-1>")
+        self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].event_generate("<Button-1>")
+        self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].event_generate("<Button-1>")
 
         mock_webbrowser_open_.assert_any_call("http://blog.url")
         mock_webbrowser_open_.assert_any_call("http://wiki.url")
@@ -163,14 +163,14 @@ class TestDocumentationFrame(unittest.TestCase):
         self.doc_frame.refresh_documentation_labels(self.current_file)
 
         # Check regular labels
-        assert self.doc_frame.documentation_labels["Forum Blog:"].cget("text") == "Blog text"
-        assert self.doc_frame.documentation_labels["Wiki:"].cget("text") == "Wiki text"
-        assert self.doc_frame.documentation_labels["External tool:"].cget("text") == "External tool text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("text") == "Blog text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("text") == "Wiki text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("text") == "External tool text"
 
         # Check colors for non-clickable text
-        assert str(self.doc_frame.documentation_labels["Forum Blog:"].cget("foreground")) == "black"
-        assert str(self.doc_frame.documentation_labels["Wiki:"].cget("foreground")) == "black"
-        assert str(self.doc_frame.documentation_labels["External tool:"].cget("foreground")) == "black"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("foreground")) == "black"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("foreground")) == "black"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("foreground")) == "black"
 
         # Check mandatory level progress bar
         assert self.doc_frame.mandatory_level.cget("value") == 0
@@ -187,17 +187,19 @@ class TestDocumentationFrame(unittest.TestCase):
 
         self.doc_frame.refresh_documentation_labels(self.current_file)
 
-        assert self.doc_frame.documentation_labels["Forum Blog:"].cget("text") == "Blog text"
-        assert self.doc_frame.documentation_labels["Wiki:"].cget("text") == "Wiki text"
-        assert self.doc_frame.documentation_labels["External tool:"].cget("text") == "External tool text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("text") == "Blog text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("text") == "Wiki text"
+        assert self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("text") == "External tool text"
 
-        assert str(self.doc_frame.documentation_labels["Forum Blog:"].cget("foreground")) == "blue"
-        assert str(self.doc_frame.documentation_labels["Wiki:"].cget("foreground")) == "blue"
-        assert str(self.doc_frame.documentation_labels["External tool:"].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL].cget("foreground")) == "blue"
+        assert str(self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL].cget("foreground")) == "blue"
 
-        mock_show_tooltip_.assert_any_call(self.doc_frame.documentation_labels["Forum Blog:"], "http://blog.url")
-        mock_show_tooltip_.assert_any_call(self.doc_frame.documentation_labels["Wiki:"], "http://wiki.url")
-        mock_show_tooltip_.assert_any_call(self.doc_frame.documentation_labels["External tool:"], "http://external_tool.url")
+        mock_show_tooltip_.assert_any_call(self.doc_frame.documentation_labels[self.doc_frame.BLOG_LABEL], "http://blog.url")
+        mock_show_tooltip_.assert_any_call(self.doc_frame.documentation_labels[self.doc_frame.WIKI_LABEL], "http://wiki.url")
+        mock_show_tooltip_.assert_any_call(
+            self.doc_frame.documentation_labels[self.doc_frame.EXTERNAL_TOOL_LABEL], "http://external_tool.url"
+        )
         expected_tooltip = f"This configuration step ({self.current_file} intermediate parameter file) is 50% mandatory"
         mock_show_tooltip_.assert_any_call(self.doc_frame.mandatory_level, expected_tooltip)
 
@@ -219,7 +221,7 @@ class TestDocumentationFrame(unittest.TestCase):
     @pytest.mark.usefixtures("mock_show_tooltip")
     def test_refresh_documentation_label_with_url(self) -> None:
         """Test refresh_documentation_label with valid URL."""
-        label_key = "Forum Blog:"
+        label_key = self.doc_frame.BLOG_LABEL
         text = "Test text"
         url = "http://test.url"
 
@@ -237,7 +239,7 @@ class TestDocumentationFrame(unittest.TestCase):
     @pytest.mark.usefixtures("mock_show_tooltip")
     def test_refresh_documentation_label_without_url(self) -> None:
         """Test refresh_documentation_label without URL."""
-        label_key = "Forum Blog:"
+        label_key = self.doc_frame.BLOG_LABEL
         text = "Test text"
         url = ""
 

--- a/tests/test_frontend_tkinter_parameter_editor_table.py
+++ b/tests/test_frontend_tkinter_parameter_editor_table.py
@@ -653,6 +653,7 @@ class TestColumnManagementBehavior:
         param_name = "TEST_PARAM"
         param = create_mock_data_model_ardupilot_parameter()
         show_upload_column = True
+        fc_connected = True
 
         # Mock individual widget creation methods using patch.object
         with (
@@ -664,7 +665,7 @@ class TestColumnManagementBehavior:
             patch.object(parameter_editor_table, "_create_upload_checkbutton", return_value=MagicMock()) as mock_upload,
             patch.object(parameter_editor_table, "_create_change_reason_entry", return_value=MagicMock()) as mock_reason,
         ):
-            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column)
+            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column, fc_connected)
 
             assert len(column) == 8  # With upload column
             mock_delete.assert_called_once()
@@ -680,6 +681,7 @@ class TestColumnManagementBehavior:
         param_name = "TEST_PARAM"
         param = create_mock_data_model_ardupilot_parameter()
         show_upload_column = False
+        fc_connected = True
 
         # Mock individual widget creation methods using patch.object
         with (
@@ -690,7 +692,7 @@ class TestColumnManagementBehavior:
             patch.object(parameter_editor_table, "_create_unit_label", return_value=MagicMock()) as mock_unit,
             patch.object(parameter_editor_table, "_create_change_reason_entry", return_value=MagicMock()) as mock_reason,
         ):
-            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column)
+            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column, fc_connected)
 
             assert len(column) == 7  # Without upload column
             mock_delete.assert_called_once()

--- a/tests/test_integration_parameter_editor_table.py
+++ b/tests/test_integration_parameter_editor_table.py
@@ -275,12 +275,13 @@ class TestWidgetCreationIntegration:
             fc_value=1.5,
         )
         show_upload_column = True
+        fc_connected = True
 
         # Mock widget creation methods to return real widgets
         with patch.object(parameter_editor_table, "_create_new_value_entry") as mock_new_value:
             mock_new_value.return_value = ttk.Entry(parameter_editor_table.view_port)
 
-            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column)
+            column = parameter_editor_table._create_column_widgets(param_name, param, show_upload_column, fc_connected)
 
             # Should create 8 widgets (including upload column)
             assert len(column) == 8


### PR DESCRIPTION
When an FC was connected, but the parameter hidden, the upload checkbox wrongly defaulted to false and disabled. Both are incorrect. This fixes that.