### PR TITLE
Add automatic release notes generation to Windows build workflow

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -292,6 +292,7 @@ jobs:
           prerelease: true
           name: "Development Build"
           files: windows/Output/*.*
+          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
@@ -300,4 +301,5 @@ jobs:
         with:
           prerelease: false
           files: windows/Output/*.*
+          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enable generate_release_notes for both pre-releases and releases to automatically create release notes from commit messages, pull requests, and contributors. This is required because the softprops/action-gh-release behaves differently from the version we were previously using