### PR TITLE
Add autoreconnect feature

### DIFF
--- a/ardupilot_methodic_configurator/backend_flightcontroller_factory_mavlink.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_factory_mavlink.py
@@ -50,6 +50,7 @@ class SystemMavlinkConnectionFactory:  # pylint: disable=too-few-public-methods
                 timeout=timeout,
                 retries=retries,
                 progress_callback=progress_callback,
+                autoreconnect=True,
             )
         except (OSError, TimeoutError, ValueError) as exc:
             # Preserve the root cause in a ConnectionError so callers can display


### PR DESCRIPTION
Adds an autoreconnect feature to the flight controller connection by enabling the autoreconnect=True parameter in the MAVLink connection setup.

Unfortunately is does not work correctly yet!
