### PR TITLE
GitHub Actions: Run pytest on Python 3.14

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,11 +27,12 @@ jobs:
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && !github.event.pull_request) || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         # python-version: ["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.9", "3.14", "3.14t"]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/
Unfortunately, free threaded Python 3.14t fails, so we will drop back to 3.14 for now.