### PR TITLE
frontend(tkinter): add clickable link to tuning guide in step 11 dialog

### DIFF
--- a/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
+++ b/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
@@ -214,7 +214,7 @@
             "wiki_text": "Follow the blog instructions and use Mission Planner instead of this tool to configure the mandatory hardware parameters.",
             "wiki_url": "",
             "external_tool_text": "Mission Planner",
-            "external_tool_url": "https://github.com/ArduPilot/MethodicConfigurator/blob/latest/TUNING_GUIDE_ArduCopter.md#212-configure-mandatory-hardware-parameters-17",
+            "external_tool_url": "https://ardupilot.org/copter/docs/configuring-hardware.html",
             "mandatory_text": "100% mandatory (0% optional)",
             "auto_changed_by": "Mission Planner. If you have not done this step in Mission Planner yet, close this application and use Mission Planner",
             "old_filenames": ["11_mp_setup_mandatory_hardware.param"]

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -542,12 +542,13 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
             message_label.pack(padx=10, pady=10)
 
             # Clickable link to tuning guide
+            safe_font_config = get_safe_font_config()
             link_label = tk.Label(
                 dialog,
-                text=_("Open Tuning Guide relevant Section"),
+                text=_("Click here to open the Tuning Guide relevant Section"),
                 fg="blue",
                 cursor="hand2",
-                font=("TkDefaultFont", 9, "underline"),
+                font=(str(safe_font_config["family"]), int(safe_font_config["size"]), "underline"),
             )
             link_label.pack(pady=(0, 10))
             link_label.bind("<Button-1>", lambda _e: self.configuration_manager.open_documentation_in_browser(selected_file))


### PR DESCRIPTION
When transitioning from Step 11 (initial ATC PID tuning) to Step 12, if "Automatically open documentation links..." is disabled, the popup message previously mentioned the tuning guide but did not provide any clickable links, which was confusing to users.

This change adds a blue, underlined "Open Tuning Guide" label that opens the relevant ArduPilot tuning instructions page in the default web browser

Issue: #951 

Before :
<img width="905" height="566" alt="image" src="https://github.com/user-attachments/assets/6af89116-9aa7-48be-9fcc-98f986272ecc" />


After :
<img width="742" height="494" alt="after_change" src="https://github.com/user-attachments/assets/c5eb0d0c-ab7c-414f-9ddb-16d3d15c82b2" />

