### PR TITLE
Upgrade: numpy==2.3.4; python_version >= '3.13'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "matplotlib==3.10.3; python_version >= '3.10' and python_version < '3.14'",
     "matplotlib==3.10.7; python_version >= '3.14'",
     "numpy==2.0.2; python_version < '3.13'",
-    "numpy==2.2.2; python_version >= '3.13'",
+    "numpy==2.3.4; python_version >= '3.13'",
     "pillow==11.3.0",
     "pip_system_certs==4.0",
     "platformdirs==4.4.0",


### PR DESCRIPTION
```diff
-    "numpy==2.2.2; python_version >= '3.13'",
+    "numpy==2.3.4; python_version >= '3.13'",
```
https://numpy.org/doc/stable/release/2.3.0-notes.html
> The NumPy 2.3.0 release continues the work to improve free threaded Python support and annotations together with the usual set of bug fixes.