### PR TITLE
fix: Increase choice box size in Component Editor

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_editor.py
@@ -200,6 +200,7 @@ class ComponentEditorWindow(ComponentEditorWindowBase):
                 f"{' > '.join(path)}",
             )
             cb.config(foreground=fg_color)
+            cb.config(width=20)
 
             cb.bind("<FocusOut>", on_validate_combobox)
             cb.bind("<KeyRelease>", on_validate_combobox)


### PR DESCRIPTION
FC Connection Protocol is impossible to select if Type is chosen as analog, this fixes the issue