### PR TITLE
Backup previous version and configs

### DIFF
--- a/ardupilot_methodic_configurator/backend_internet.py
+++ b/ardupilot_methodic_configurator/backend_internet.py
@@ -196,7 +196,7 @@ def create_backup(progress_callback: Optional[Callable[[float, str], None]] = No
 
         return True
 
-    except (CalledProcessError, FileNotFoundError, PermissionError, OSError) as e:
+    except (PermissionError, OSError) as e:
         logging_error(_("Backup failed: %s"), e)
         return False
 


### PR DESCRIPTION
As stated in the todo list for the Installation Process, this creates a backup to CONFIG_DIR/.ardupilot_methodic_configurator/backups/VERSION/
The current software is backed up as a wheel package pulled from PyPI (not local install). In addition to this, the vehicles directory is also backed up to the same location.

To restore the backed up version, run the following inside the AMC venv:

pip install --force-reinstall CONFIG_DIR/.ardupilot_methodic_configurator/backups/VERSION/ardupilot_methodic_configurator-VERSION-py3-none-any.whl

In case the python modules that are dependencies chnage versions later and you wish to restore the versions of the dependencies that are required by the backed up version, run the following inside the venv:

pip install --force-reinstall CONFIG_DIR/.ardupilot_methodic_configurator/backups/VERSION/*.whl

@amilcarlucas, I guess this is what you meant by backing up, so just tried my hand at this
