### PR TITLE
Close local file handle on session terminate

### DIFF
--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -432,7 +432,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     def __terminate_session(self) -> None:
         """Terminate current session."""
         self.__send(FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None))
-        self.fh = None
+        # Ensure any open local file handle is properly closed to release OS resources
+        try:
+            if self.fh is not None:
+                self.fh.close()
+        except Exception as ex:  # pylint: disable=broad-except
+            logging.error("FTP: error closing local file handle: %s", ex)
+        finally:
+            self.fh = None
         self.filename = None
         self.write_list = None
         if self.callback is not None:


### PR DESCRIPTION
Close self.fh in __terminate_session() before clearing it so the OS file descriptor is released. This prevents PermissionError when saving complete.param on subsequent downloads. Log any close errors for diagnostics.

Closes #1151