### PR TITLE
Add automated copyright year update workflow

### DIFF
--- a/.github/workflows/update_copyright_year.yml
+++ b/.github/workflows/update_copyright_year.yml
@@ -1,0 +1,80 @@
+name: Update Copyright Year
+
+on:
+  # Run on January 1st at 8:00 AM UTC
+  schedule:
+    - cron: '0 8 1 1 *'
+  # Enable manual trigger for testing
+  workflow_dispatch:
+
+# prevent race conditions
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-copyright:
+    permissions:
+      contents: write       # for creating branches and commits
+      pull-requests: write  # for creating PRs
+    runs-on: ubuntu-latest
+    env:
+      COPYRIGHT_CHANGED: false
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Update copyright years
+        run: |
+          # Calculate current and previous year
+          CURRENT_YEAR=$(date +%Y)
+          PREVIOUS_YEAR=$((CURRENT_YEAR - 1))
+
+          # Export to GITHUB_ENV for use in subsequent steps
+          echo "CURRENT_YEAR=${CURRENT_YEAR}" >> $GITHUB_ENV
+          echo "PREVIOUS_YEAR=${PREVIOUS_YEAR}" >> $GITHUB_ENV
+
+          echo "Updating copyright from $PREVIOUS_YEAR to $CURRENT_YEAR"
+
+          # Find all files containing SPDX-FileCopyrightText
+          # Replace previous year with current year on lines containing SPDX-FileCopyrightText
+          grep -rl "SPDX-FileCopyrightText" . --exclude-dir=.git 2>/dev/null | while read -r file; do
+            sed -i "/SPDX-FileCopyrightText/ s/${PREVIOUS_YEAR}/${CURRENT_YEAR}/g" "$file"
+          done
+
+      - name: Check for changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "COPYRIGHT_CHANGED=true" >> $GITHUB_ENV
+            echo "Changes detected:"
+            git diff --stat
+          else
+            echo "No copyright changes detected"
+          fi
+
+      - name: Create Pull Request
+        if: env.COPYRIGHT_CHANGED == 'true'
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(copyright): Auto-update copyright year to ${{ env.CURRENT_YEAR }}'
+          title: 'Update copyright year to ${{ env.CURRENT_YEAR }}'
+          body: |
+            This PR updates copyright years in all files containing SPDX-FileCopyrightText headers.
+
+            All occurrences of `${{ env.PREVIOUS_YEAR }}` were replaced with `${{ env.CURRENT_YEAR }}` on lines containing SPDX-FileCopyrightText.
+
+            This automated update runs annually on January 1st to keep copyright notices current.
+          branch: update-copyright-year-${{ env.CURRENT_YEAR }}
+          delete-branch: true
+          labels: automated-pr, maintenance
+          reviewers: ${{ github.actor }}


### PR DESCRIPTION
Add GitHub Actions workflow that automatically updates copyright years in files containing SPDX-FileCopyrightText headers. The workflow:
- Runs annually on January 1st at 8:00 AM UTC
- Can be triggered manually for testing
- Updates year ranges (e.g., 2024-2025 to 2024-2026)
- Updates standalone years in copyright lines
- Creates a pull request with the changes