### PR TITLE
Fix motor test plugin loading on windows instalations

### DIFF
--- a/ardupilot_methodic_configurator/data_model_motor_test.py
+++ b/ardupilot_methodic_configurator/data_model_motor_test.py
@@ -142,7 +142,7 @@ class MotorTestDataModel:  # pylint: disable=too-many-public-methods, too-many-i
             self._cached_frame_options = None
 
             if not self._motor_data:
-                logging_warning(_("Failed to load motor test data from AP_Motors_test.json"))
+                logging_error(_("Failed to load motor test data from AP_Motors_test.json"))
             else:
                 logging_debug(
                     _("Successfully loaded motor test data with %(layouts)d layouts"),

--- a/windows/ardupilot_methodic_configurator.iss
+++ b/windows/ardupilot_methodic_configurator.iss
@@ -96,6 +96,7 @@ Source: "..\git_hash.txt"; DestDir: "{app}\_internal\ardupilot_methodic_configur
 Source: "..\windows\ardupilot_methodic_configurator.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\images\*.png"; DestDir: "{app}\_internal\ardupilot_methodic_configurator\images"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\images\*.svg"; DestDir: "{app}\_internal\ardupilot_methodic_configurator\images"; Flags: ignoreversion
+Source: "..\ardupilot_methodic_configurator\AP_Motors_test*.json"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\configuration_steps_*.json"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\ardupilot_methodic_configurator\vehicle_components_schema.json"; DestDir: "{app}\_internal\ardupilot_methodic_configurator"; Flags: ignoreversion
 Source: "..\LICENSES\*.*"; DestDir: "{app}\LICENSES"; Flags: ignoreversion


### PR DESCRIPTION
It was causing this error:

2026-01-07 19:04:42,832 - WARNING - Failed to load motor test data from AP_Motors_test.json
2026-01-07 19:04:42,833 - ERROR - Failed to update frame configuration: No motor configuration found for frame class 1 and type 1
Exception in Tkinter callback
Traceback (most recent call last):
  File "tkinter\__init__.py", line 2074, in __call__
  File "ardupilot_methodic_configurator\frontend_tkinter_parameter_editor.py", line 983, in on_param_file_combobox_change
  File "ardupilot_methodic_configurator\frontend_tkinter_parameter_editor.py", line 573, in _update_plugin_layout
  File "ardupilot_methodic_configurator\frontend_tkinter_parameter_editor.py", line 633, in _swap_plugin_in_place
  File "ardupilot_methodic_configurator\frontend_tkinter_parameter_editor.py", line 740, in _load_plugin
  File "ardupilot_methodic_configurator\data_model_parameter_editor.py", line 1968, in create_plugin_data_model
  File "ardupilot_methodic_configurator\data_model_motor_test.py", line 130, in __init__
  File "ardupilot_methodic_configurator\data_model_motor_test.py", line 238, in _update_frame_configuration
  File "ardupilot_methodic_configurator\data_model_motor_test.py", line 207, in _configure_frame_layout
RuntimeError: No motor configuration found for frame class 1 and type 1
