### PR TITLE
fix(startup): reduce auto-detection retries to minimize startup delay

### DIFF
--- a/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
@@ -195,12 +195,14 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
             logging_debug(_("Did not add empty connection"))
         return False
 
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def _register_and_try_connect(
         self,
         comport: Union[mavutil.SerialPort, serial.tools.list_ports_common.ListPortInfo],
         progress_callback: Union[None, Callable[[int, int], None]],
         baudrate: int,
         log_errors: bool,
+        retries: int = 3,
     ) -> str:
         """
         Register a device in the connection list (if missing) and attempt connection.
@@ -210,6 +212,7 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
             progress_callback: Optional callback for progress updates
             baudrate: Baud rate for serial connections
             log_errors: Whether to log errors
+            retries: Number of connection attempts (default: 3)
 
         Returns:
             str: empty string on success, or error message.
@@ -226,6 +229,7 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
             baudrate=baudrate,
             log_errors=log_errors,
             timeout=self.CONNECTION_RETRY_TIMEOUT,
+            retries=retries,
         )
 
     def connect(
@@ -307,6 +311,7 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
                 progress_callback=progress_callback,
                 baudrate=self._baudrate,
                 log_errors=False,
+                retries=2,
             )
             if err == "":
                 return ""

--- a/tests/test_startup_speed.py
+++ b/tests/test_startup_speed.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+"""
+Test for startup performance and connection logic.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from unittest.mock import MagicMock, patch
+
+from ardupilot_methodic_configurator.backend_flightcontroller_connection import (
+    FlightControllerConnection,
+)
+from ardupilot_methodic_configurator.data_model_flightcontroller_info import (
+    FlightControllerInfo,
+)
+
+
+@patch(
+    "ardupilot_methodic_configurator.backend_flightcontroller_connection.FlightControllerConnection._register_and_try_connect"
+)
+def test_startup_is_fast_when_no_drone_connected(mock_register_connect) -> None:
+    """
+    Scenario: User starts the application without a FC connected.
+
+    GIVEN: The application is launching and auto-detecting ports
+    WHEN: It attempts to connect to a TCP port that is closed
+    THEN: It should use a reduced retry count (2) to minimize startup delay
+    """
+    # GIVEN: A connection manager looking for devices on a network
+    info = FlightControllerInfo()
+    connection = FlightControllerConnection(info)
+
+    # Mock: Pretend we found one TCP port to check
+    connection.get_network_ports = MagicMock(return_value=["tcp:127.0.0.1:5760"])
+    # Mock: Pretend no serial ports exist (simplify the test)
+    # pylint: disable=protected-access
+    connection._auto_detect_serial = MagicMock(return_value=[])
+
+    # WHEN: The auto-connection logic runs
+    connection.connect(device="")
+
+    # THEN: The connection attempt should use retries=2 (not the default 3)
+    # Extract the arguments passed to the connection function
+    _, kwargs = mock_register_connect.call_args
+
+    # Check that 'retries' was passed explicitly
+    assert "retries" in kwargs, "FAIL: The 'retries' argument was not passed!"
+
+    # Check that it is set to 2 (Safety Compromise: 1 retry allowed)
+    actual_retries = kwargs["retries"]
+    assert actual_retries == 2, f"FAIL: Expected retries=2 for fast startup, but got {actual_retries}!"


### PR DESCRIPTION
Fixes #1198

### Problem
The application hangs for approximately 2 seconds on startup when no flight controller is connected. This is caused by the auto-detection logic using the default 3 retries for every checked port.

### Solution
* Updated `_register_and_try_connect` to accept a `retries` parameter.
* Changed the auto-detection loop to use `retries=2` (1 initial attempt + 1 retry).
* Added a test to verify the retry count.

```
2026-01-23 02:05:44,366 - INFO - Will connect to /dev/ttyS9 @ 115200 baud
2026-01-23 02:05:44,366 - INFO - Will connect to tcp:127.0.0.1:5760
[Errno 111] Connection refused sleeping
2026-01-23 02:05:45,367 - INFO - Will connect to udp:0.0.0.0:14550
```

### Reasoning
Set `retries=2` ensures there is still one safety retry for SITL, as suggested, but reduces the startup delay.