### PR TITLE
Correct feedback when saving component templates fails

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_component_template_manager.py
@@ -105,13 +105,19 @@ class ComponentTemplateManager:  # pylint: disable=too-many-instance-attributes
                 confirm = messagebox.askyesno(_("Template exists"), _("A template with this name already exists. Overwrite?"))
                 if confirm:
                     templates[component_name][i] = new_template
-                    self.template_manager.save_component_templates(templates)
-                    messagebox.showinfo(_("Template Saved"), _("Template has been updated"))
+                    error, msg = self.template_manager.save_component_templates(templates)
+                    if error:
+                        messagebox.showerror(_("Template not Saved"), msg)
+                    else:
+                        messagebox.showinfo(_("Template Saved"), _("Template has been updated to file '{}'").format(msg))
                 return
 
         templates[component_name].append(new_template)
-        self.template_manager.save_component_templates(templates)
-        messagebox.showinfo(_("Template Saved"), _("Template has been saved"))
+        error, msg = self.template_manager.save_component_templates(templates)
+        if error:
+            messagebox.showerror(_("Template not Saved"), msg)
+        else:
+            messagebox.showinfo(_("Template Saved"), _("Template has been saved to file '{}'").format(msg))
 
     def derive_initial_template_name(self, component_data: dict[str, Any]) -> str:
         """Derive an initial template name from the component data."""

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -659,7 +659,7 @@ class TestVehicleComponents:
 
         # Verify results
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Verify directory was created
         mock_makedirs.assert_called_once_with("/templates", exist_ok=True)
@@ -722,7 +722,7 @@ class TestVehicleComponents:
 
         # Verify results
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Verify only Template A was saved (with is_user_modified flag removed)
         expected_save = {"Component1": [{"name": "Template A", "data": {"original": "value"}}]}
@@ -771,7 +771,7 @@ class TestVehicleComponents:
 
         # Verify results
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Verify Template A was saved with new data
         expected_save = {"Component1": [{"name": "Template A", "data": {"modified": "new_value"}}]}
@@ -821,7 +821,7 @@ class TestVehicleComponents:
 
         # Verify results
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Verify only the new template was saved
         expected_save = {"Component1": [{"name": "New Template", "data": {"new": "value"}}]}
@@ -960,7 +960,7 @@ class TestVehicleComponents:
 
         # Verify results
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
         # Should save empty dict
         mock_json_dump.assert_called_once_with({}, mock_file(), indent=4)
 
@@ -1024,14 +1024,14 @@ class TestVehicleComponents:
 
         # Mock loading system templates
         mock_load_system.return_value = system_templates
-        mock_save_to_file.return_value = (False, "")  # No error
+        mock_save_to_file.return_value = (False, "/templates/system_vehicle_components_template.json")  # No error
 
         # Call the method
         result, msg = self.vehicle_components.save_component_templates(new_templates)
 
         # Verify success
         assert not result  # False means success
-        assert msg == ""
+        assert msg == "/templates/system_vehicle_components_template.json"
 
         # Capture what was passed to save_component_templates_to_file
         saved_templates = mock_save_to_file.call_args[0][0]
@@ -1165,14 +1165,14 @@ class TestVehicleComponents:
         }
 
         mock_load_system.return_value = system_templates
-        mock_save_to_file.return_value = (False, "")
+        mock_save_to_file.return_value = (False, "/templates/user_vehicle_components_template.json")
 
         # Call the method
         result, msg = self.vehicle_components.save_component_templates(templates_with_flag)
 
         # Verify success
         assert not result
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # pylint: disable=duplicate-code  # Common assertion pattern
         # Get the templates that were saved
@@ -1206,14 +1206,14 @@ class TestVehicleComponents:
         }
 
         mock_load_system.return_value = system_templates
-        mock_save_to_file.return_value = (False, "")
+        mock_save_to_file.return_value = (False, "/templates/user_vehicle_components_template.json")
 
         # Call the method
         result, msg = self.vehicle_components.save_component_templates(modified_templates)
 
         # Verify success
         assert not result
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Get the templates that were saved
         saved_templates = mock_save_to_file.call_args[0][0]
@@ -1244,14 +1244,14 @@ class TestVehicleComponents:
         }
 
         mock_load_system.return_value = system_templates
-        mock_save_to_file.return_value = (False, "")
+        mock_save_to_file.return_value = (False, "/templates/user_vehicle_components_template.json")
 
         # Call the method
         result, msg = self.vehicle_components.save_component_templates(identical_templates)
 
         # Verify success
         assert not result
-        assert msg == ""
+        assert msg == "/templates/user_vehicle_components_template.json"
 
         # Get the templates that were saved
         saved_templates = mock_save_to_file.call_args[0][0]
@@ -1391,14 +1391,14 @@ class TestVehicleComponents:
 
         # pylint: disable=duplicate-code  # Common assertion pattern
         mock_load_system.return_value = system_templates
-        mock_save_to_file.return_value = (False, "")
+        mock_save_to_file.return_value = (False, "/templates/system_vehicle_components_template.json")
 
         # Call the method
         result, msg = vehicle_components_system.save_component_templates(new_templates)
 
         # Verify success
         assert not result
-        assert msg == ""
+        assert msg == "/templates/system_vehicle_components_template.json"
 
         # Get the templates that were saved
         saved_templates = mock_save_to_file.call_args[0][0]

--- a/tests/test_frontend_tkinter_component_template_manager.py
+++ b/tests/test_frontend_tkinter_component_template_manager.py
@@ -108,6 +108,10 @@ class TestComponentTemplateManager:
 
         # Setup mock for template manager
         template_manager.template_manager.load_component_templates.return_value = {"TestComponent": []}
+        template_manager.template_manager.save_component_templates.return_value = (
+            False,
+            "/test/path/user_vehicle_components_template.json",
+        )
 
         # Call the method
         template_manager.save_component_as_template("TestComponent")
@@ -138,6 +142,10 @@ class TestComponentTemplateManager:
         # Setup mock for template manager with existing template
         existing_templates = {"TestComponent": [{"name": "Existing Template", "data": {"old": "data"}}]}
         template_manager.template_manager.load_component_templates.return_value = existing_templates
+        template_manager.template_manager.save_component_templates.return_value = (
+            False,
+            "/test/path/user_vehicle_components_template.json",
+        )
 
         # Call the method
         template_manager.save_component_as_template("TestComponent")
@@ -269,6 +277,10 @@ class TestComponentTemplateManager:
         # When we load templates, the system and user templates will be merged
         merged_templates = {"TestComponent": [{"name": "System Template", "data": {"Model": "Original", "Version": "1.0"}}]}
         template_manager.template_manager.load_component_templates.return_value = merged_templates
+        template_manager.template_manager.save_component_templates.return_value = (
+            False,
+            "/test/path/user_vehicle_components_template.json",
+        )
 
         # Call the method
         template_manager.save_component_as_template("TestComponent")
@@ -299,6 +311,10 @@ class TestComponentTemplateManager:
         # Setup templates - no existing template for this name
         templates = {"TestComponent": [{"name": "Other Template", "data": {}}]}
         template_manager.template_manager.load_component_templates.return_value = templates
+        template_manager.template_manager.save_component_templates.return_value = (
+            False,
+            "/test/path/user_vehicle_components_template.json",
+        )
 
         # Call the method
         template_manager.save_component_as_template("TestComponent")


### PR DESCRIPTION
When saving component templates to file fails (e.g., permission denied), the UI now shows an error message with details instead of a false success message. On success, the message includes the file path where the template was saved.

Also ensures that if a local system template file (from a developer's git repository)exists, it is used instead of the system directory for saving system templates.

Resolves #1222