### PR TITLE
Handle read-only installation directories for parameter downloads

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
@@ -323,6 +323,11 @@ class ProgramSettings:
         return str(package_path / "vehicle_templates")
 
     @staticmethod
+    def get_vehicles_default_dir() -> Path:
+        settings_directory = Path(ProgramSettings._user_config_dir())
+        return settings_directory / "vehicles"
+
+    @staticmethod
     def get_recently_used_dirs() -> tuple[str, str, str]:
         settings_directory = ProgramSettings._user_config_dir()
         vehicles_default_dir = os_path.join(settings_directory, "vehicles")


### PR DESCRIPTION
When frozen executables are installed in system directories like Program Files on Windows, the default vehicle directory becomes read-only, causing permission denied errors when downloading complete.param and 00_default.param files.

This change detects when the vehicle directory is not writable and automatically switches to a user-writable configuration directory instead.

Fixes #1151