### PR TITLE
Handle functools.partial objects in type name access

### DIFF
--- a/ardupilot_methodic_configurator/data_model_vehicle_components_base.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_components_base.py
@@ -157,7 +157,8 @@ class ComponentDataModelBase:
 
             # Special handling for list/dict types
             if datatype in (list, dict):
-                logging_error(_("Invalid datatype '%s' for path %s"), value, datatype.__name__, path)
+                type_name = getattr(datatype, "__name__", repr(datatype))
+                logging_error(_("Invalid value '%s' for datatype %s at path %s"), value, type_name, path)
                 return ""
 
             # Standard type conversion
@@ -165,7 +166,8 @@ class ComponentDataModelBase:
 
         except (ValueError, TypeError, AttributeError) as e:
             # Log the error and fall back to the original processing method
-            logging_warning(_("Failed to cast value '%s' to %s for path %s: %s"), value, datatype.__name__, path, e)
+            type_name = getattr(datatype, "__name__", repr(datatype))
+            logging_warning(_("Failed to cast value '%s' to %s for path %s: %s"), value, type_name, path, e)
             return self._process_value(path, str(value) if value is not None else None)
 
     def _process_value(self, path: ComponentPath, value: Union[str, None]) -> ComponentValue:

--- a/ardupilot_methodic_configurator/data_model_vehicle_components_validation.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_components_validation.py
@@ -451,12 +451,14 @@ class ComponentDataModelValidation(ComponentDataModelBase):
             try:
                 typed_value = data_type(value)
                 if typed_value < limits[0] or typed_value > limits[1]:
-                    error_msg = _("{name} must be a {data_type.__name__} between {limits[0]} and {limits[1]}")
+                    error_msg = _("{name} must be a {data_type_name} between {min} and {max}")
                     limited_value = limits[0] if typed_value < limits[0] else limits[1]
-                    return error_msg.format(name=name, data_type=data_type, limits=limits), limited_value
+                    type_name = getattr(data_type, "__name__", repr(data_type))
+                    return error_msg.format(name=name, data_type_name=type_name, min=limits[0], max=limits[1]), limited_value
             except ValueError:
-                error_msg = _("Invalid {data_type.__name__} value for {name}")
-                return error_msg.format(data_type=data_type, name=name), None
+                error_msg = _("Invalid {data_type_name} value for {name}")
+                type_name = getattr(data_type, "__name__", repr(data_type))
+                return error_msg.format(data_type_name=type_name, name=name), None
 
             # Validate takeoff weight limits
             if path[0] == "Frame" and path[1] == "Specifications" and "TOW" in path[2]:


### PR DESCRIPTION
Replace direct __name__ attribute access with getattr() fallback pattern to safely handle functools.partial objects and other callable types that may not have a __name__ attribute. This prevents AttributeError when validating component data types that use partial functions.

- Use getattr(type, "__name__", repr(type)) for safe attribute access
- Apply fix in data_model_vehicle_components_validation.py (2 locations)
- Apply fix in data_model_vehicle_components_base.py (2 locations)

Fixes #1244