### PR TITLE
Fix import causing issues in pyinstaller

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_flightcontroller_connection_progress.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_flightcontroller_connection_progress.py
@@ -8,15 +8,19 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import sys
 import tkinter as tk
 from logging import error as logging_error
 from types import TracebackType
 from typing import Literal, Optional
 
-from typing_extensions import Self
-
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.frontend_tkinter_progress_window import ProgressWindow
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:  # Python 3.9 and 3.10
+    from typing_extensions import Self
 
 PROGRESS_FC_INIT_COMPLETE = 20
 


### PR DESCRIPTION
  File "__main__.py", line 48, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "ardupilot_methodic_configurator\frontend_tkinter_flightcontroller_connection_progress.py", line 16, in <module>
ModuleNotFoundError: No module named 'typing_extensions'
[PYI-34648:ERROR] Failed to execute script '__main__' due to unhandled exception!