### PR TITLE
Add user confirmation for derived parameter changes and address review feedback

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -51,7 +51,7 @@ from ardupilot_methodic_configurator.frontend_tkinter_flightcontroller_connectio
 from ardupilot_methodic_configurator.frontend_tkinter_flightcontroller_info import FlightControllerInfoWindow
 from ardupilot_methodic_configurator.frontend_tkinter_parameter_editor import ParameterEditorWindow
 from ardupilot_methodic_configurator.frontend_tkinter_project_opener import VehicleProjectOpenerWindow
-from ardupilot_methodic_configurator.frontend_tkinter_show import show_error_message
+from ardupilot_methodic_configurator.frontend_tkinter_show import ask_yesno_message, show_error_message
 from ardupilot_methodic_configurator.frontend_tkinter_usage_popup_window import PopupWindow
 from ardupilot_methodic_configurator.frontend_tkinter_usage_popup_windows import display_workflow_explanation
 from ardupilot_methodic_configurator.plugin_constants import PLUGIN_MOTOR_TEST
@@ -515,7 +515,9 @@ def process_component_editor_results(
 
     # Update and export vehicle parameters
     error_message = local_filesystem.update_and_export_vehicle_params_from_fc(
-        source_param_values=source_param_values, existing_fc_params=existing_fc_params
+        source_param_values=source_param_values,
+        existing_fc_params=existing_fc_params,
+        ask_user_confirmation=ask_yesno_message,
     )
 
     if error_message:

--- a/ardupilot_methodic_configurator/frontend_tkinter_show.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_show.py
@@ -389,6 +389,19 @@ def show_warning_message(title: str, message: str, root: Optional[tk.Tk] = None)
         messagebox.showwarning(title, message)
 
 
+def ask_yesno_message(title: str, message: str, root: Optional[tk.Tk] = None) -> bool:
+    if root is None:
+        root = tk.Tk(className="ArduPilotMethodicConfigurator")
+        # Set the theme to 'alt'
+        style = ttk.Style()
+        style.theme_use("alt")
+        root.withdraw()  # Hide the main window
+        result = messagebox.askyesno(title, message)
+        root.destroy()
+        return result
+    return messagebox.askyesno(title, message)
+
+
 def show_no_param_files_error(_dirname: str) -> None:
     error_message = _(
         "No intermediate parameter files found in the selected '{_dirname}' vehicle directory.\n"


### PR DESCRIPTION
**Updates After Review**

Moved annotate_doc = bool(ProgramSettings.get_setting("annotate_docs_into_param_files")) outside the loop so it is evaluated only once

Replaced derived_changed_by_file dictionary with a single derived_changed boolean since files are processed sequentially

Added a file-existence check so confirmation is only requested when overwriting an existing file