### PR TITLE
Fix macOS tooltips persisting indefinitely (2nd attempt)

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_show.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_show.py
@@ -526,7 +526,7 @@ class Tooltip:
         self.position_tooltip()
         # Bind to tooltip to prevent hiding when mouse is over it
         self.tooltip.bind("<Enter>", self._cancel_hide)
-        self.tooltip.bind("<Leave>", self.hide)
+        self.tooltip.bind("<Leave>", self.destroy_hide)
 
     def position_tooltip(self) -> None:
         """Position tooltip within monitor bounds, handling widget destruction gracefully."""

--- a/tests/bdd_frontend_tkinter_show.py
+++ b/tests/bdd_frontend_tkinter_show.py
@@ -788,7 +788,7 @@ class TestTooltipFunctionality:  # pylint: disable=too-many-public-methods
             assert tooltip.tooltip == mock_toplevel
             mock_label.assert_called_once()
             mock_toplevel.bind.assert_any_call("<Enter>", tooltip._cancel_hide)
-            mock_toplevel.bind.assert_any_call("<Leave>", tooltip.hide)
+            mock_toplevel.bind.assert_any_call("<Leave>", tooltip.destroy_hide)
 
     def test_tooltip_position_tooltip(self, mock_widget, mock_toplevel) -> None:
         """


### PR DESCRIPTION
On macOS, tooltips remain visible after the mouse leaves, cluttering the UI.

fixes #1299 

## Root Cause

The `create_show` method binds the tooltip window's `<Leave>` event to `self.hide` instead of `self.destroy_hide`. On macOS, tooltips use lazy creation and must be destroyed (not withdrawn) when dismissed:

```python
# Line 529 in frontend_tkinter_show.py
# Before:
self.tooltip.bind("<Leave>", self.hide)  # withdraw() - window persists

# After:
self.tooltip.bind("<Leave>", self.destroy_hide)  # destroy() - window cleaned up
```

This aligns with the widget's own `<Leave>` binding (lines 466/469), which correctly calls `destroy_hide`.

## Changes

- **frontend_tkinter_show.py:529**: Change tooltip `<Leave>` binding from `hide` to `destroy_hide`
- **bdd_frontend_tkinter_show.py:791**: Update test assertion to match
