### PR TITLE
Added Docker support for development and SITL testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+.venv/
+*.pyc
+__pycache__/
+*.egg-info/
+.eggs/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+.ruff_cache/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project-specific
+sitl-cache/
+*.log

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,50 @@
+name: Docker CI
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker-ci.yml'
+      - 'ardupilot_methodic_configurator/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker-ci.yml'
+      - 'ardupilot_methodic_configurator/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+  workflow_dispatch:
+
+jobs:
+  docker-test:
+    name: Docker Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build and Run Tests
+        run: |
+          docker compose run --rm test
+
+      - name: Run Linter in Docker
+        if: always()
+        run: |
+          docker compose run --rm lint
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose down --volumes --remove-orphans

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,65 @@ The above scripts will:
 * Set up pre-commit hooks for linting and formatting
 * Install GNU gettext tools for internationalization support
 
+## Alternative: Using Docker for Development
+
+As an alternative to setting up the development environment locally, you can use Docker to run the project in a containerized environment.
+This ensures consistency across different machines and simplifies dependency management.
+
+### Prerequisites
+
+* [Install Docker](https://docs.docker.com/get-docker/) on your computer
+* [Install Docker Compose](https://docs.docker.com/compose/install/) (usually included with Docker Desktop)
+
+### Building and Running
+
+1. Clone the repository and navigate into it:
+
+    ```bash
+    git clone https://github.com/YOUR_USER_NAME/MethodicConfigurator.git
+    cd MethodicConfigurator
+    ```
+
+2. Build the Docker image:
+
+    ```bash
+    docker compose build
+    ```
+
+3. Run the development environment:
+
+    To start an interactive shell in the container:
+
+    ```bash
+    docker compose run --rm dev
+    ```
+
+    To run tests:
+
+    ```bash
+    docker compose run --rm test
+    ```
+
+    To run SITL (Software In The Loop) integration tests:
+
+    ```bash
+    docker compose run --rm sitl
+    ```
+
+    To run linters:
+
+    ```bash
+    docker compose run --rm lint
+    ```
+
+### Benefits of Docker Development
+
+* Consistent environment across all contributors
+* No need to install Python, dependencies, or tools locally
+* Isolated from your system's Python installation
+* Easy to test against different Python versions by changing the Dockerfile
+* Faster onboarding for new contributors
+
 ## Executing the code
 
 You can either install the Methodic Configurator as a package or run it locally from your development codebase.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM python:3.12-slim-bookworm
+
+LABEL maintainer="ArduPilot Methodic Configurator Team"
+LABEL description="Development environment for ArduPilot Methodic Configurator with SITL support"
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV DISPLAY=:99
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    python3-tk \
+    xvfb \
+    x11-utils \
+    gnome-screenshot \
+    libusb-1.0-0 \
+    procps \
+    libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE.md ./
+COPY ardupilot_methodic_configurator/ ./ardupilot_methodic_configurator/
+COPY tests/ ./tests/
+COPY scripts/ ./scripts/
+
+RUN pip install -e ".[dev]"
+
+RUN chmod +x scripts/*.sh && \
+    mkdir -p sitl sitl-cache && \
+    touch /root/.Xauthority && \
+    echo '#!/bin/bash' > /entrypoint.sh && \
+    echo 'rm -f /tmp/.X99-lock' >> /entrypoint.sh && \
+    echo 'Xvfb :99 -screen 0 1024x768x24 -ac &' >> /entrypoint.sh && \
+    echo 'sleep 2' >> /entrypoint.sh && \
+    echo 'exec "$@"' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["python", "-m", "pytest", "-v", "-rs"]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -180,3 +180,8 @@ SPDX-License-Identifier = "MIT"
 path = ["windows/ardupilot_methodic_configurator*", "windows/settings_template.json"]
 SPDX-FileCopyrightText = "2024-2026 Amilcar Lucas"
 SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
+path = [".dockerignore", "docker-compose.yml", "Dockerfile"]
+SPDX-FileCopyrightText = "2026 ArduPilot methodic configurator developers"
+SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  dev:
+    build: .
+    volumes:
+      - .:/app
+      - sitl-cache:/app/sitl-cache
+    working_dir: /app
+    stdin_open: true
+    tty: true
+    command: bash
+
+  test:
+    build: .
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: pytest tests/ -v -m "not sitl and not integration"
+
+  sitl:
+    build: .
+    volumes:
+      - .:/app
+      - sitl-cache:/app/sitl-cache
+    working_dir: /app
+    command: >
+      bash -c "./scripts/run_sitl_tests.sh download &&
+               ./scripts/run_sitl_tests.sh test"
+
+  lint:
+    build: .
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: >
+      bash -c "ruff format && ruff check . && pyright && pylint ardupilot_methodic_configurator/"
+
+volumes:
+  sitl-cache:


### PR DESCRIPTION

This PR introduces Docker support to streamline development and testing workflows.
It provides a consistent, isolated environment that removes the need for local dependency setup.

**Verification:**

* `docker compose build` completes successfully.
* `docker compose run sitl` downloads the simulator and passes all 8 MAVLink signing integration tests.
* `docker compose run lint` runs ruff and pylint as expected.

**Key Additions:**

* **Dockerfile:** Sets up all dependencies and configures Xvfb for running Tkinter-based components in a headless container.
* **docker-compose.yml:** Defines services for testing, SITL, and linting to make running tasks simple and repeatable.
* **.dockerignore:** Excludes unnecessary files like local venvs and caches to reduce build context size.

**Usage:**

```bash
docker compose build
docker compose run sitl     # Run MAVLink signing integration tests
docker compose run test     # Run unit and BDD tests
docker compose run lint     # Run linters
```

This setup ensures reliable testing and a smoother onboarding experience for contributors.
