### PR TITLE
Add internationalization support to validation messages

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
@@ -75,12 +75,15 @@ def validate_connection_string(connection_string: str) -> None:
         ValueError: If connection string is invalid
 
     """
-    if not connection_string or not connection_string.strip():
-        msg = "Connection string cannot be empty or whitespace-only"
+    stripped_connection_string = connection_string.strip()
+    if not stripped_connection_string:
+        msg = _("Connection string cannot be empty or whitespace-only")
         raise ValueError(msg)
 
-    if len(connection_string.strip()) > 200:
-        msg = f"Connection string is too long ({len(connection_string.strip())} chars), maximum is 200"
+    if len(stripped_connection_string) > 200:
+        msg = _(
+            "Connection string is too long (%(length)d chars), maximum is 200",
+        ) % {"length": len(stripped_connection_string)}
         raise ValueError(msg)
 
 

--- a/ardupilot_methodic_configurator/data_model_recent_items_history_list.py
+++ b/ardupilot_methodic_configurator/data_model_recent_items_history_list.py
@@ -10,10 +10,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import Any, Callable, Optional
 
+from ardupilot_methodic_configurator import _
+
 
 class RecentItemsHistoryList:
     """
-    Helper class to manage most-recent-first (FIFO) history lists with deduplication.
+    Helper class to manage most-recent-first (LIFO) history lists with deduplication.
 
     This class provides a reusable pattern for managing history lists in settings,
     with configurable validation, normalization, and comparison strategies.
@@ -87,10 +89,10 @@ class RecentItemsHistoryList:
         """
         # Minimal validation: reject truly invalid inputs
         if not item:
-            msg = "Cannot store empty string in history"
+            msg = _("Cannot store empty string in history")
             raise ValueError(msg)
         if "\x00" in item:
-            msg = "Cannot store item with null byte in history"
+            msg = _("Cannot store item with null byte in history")
             raise ValueError(msg)
 
         # Call the validator if provided


### PR DESCRIPTION
- Add translation support to error messages in validate_connection_string() using _() wrapper for gettext
- Add i18n support to store_item() error messages in RecentItemsHistoryList
- Fix docstring: change FIFO to LIFO in RecentItemsHistoryList class
- Optimize validate_connection_string() to avoid redundant strip() calls