### PR TITLE
Auto-refresh available ports every 3 seconds

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
@@ -10,6 +10,7 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import contextlib
 import tkinter as tk
 from argparse import ArgumentParser, Namespace
 from logging import basicConfig as logging_basicConfig
@@ -59,6 +60,8 @@ class ConnectionSelectionWidgets:  # pylint: disable=too-many-instance-attribute
             else None
         )
         self.connection_progress_window: ProgressWindow
+        self._refresh_timer_id: Union[None, str] = None
+        self._is_refreshing = False
 
         # Create a new frame for the flight controller connection selection label and combobox
         self.container_frame = ttk.Frame(parent_frame)
@@ -113,6 +116,49 @@ class ConnectionSelectionWidgets:  # pylint: disable=too-many-instance-attribute
             self.baudrate_combobox,
             _("Select the baudrate for the connection\nMost flight controllers use 115200"),
         )
+
+        # Start periodic port refresh
+        self.start_periodic_refresh()
+
+    def start_periodic_refresh(self) -> None:
+        """Start periodic refresh of available ports every 3 seconds."""
+        if self._refresh_timer_id is None:
+            self._refresh_ports()
+
+    def _refresh_ports(self) -> None:
+        """Refresh the list of available ports and update the combobox."""
+        if self._is_refreshing:
+            return
+
+        self._is_refreshing = True
+        try:
+            # Scan for new ports and get current data
+            current_selection = self.conn_selection_combobox.get_selected_key()
+            self.flight_controller.discover_connections(progress_callback=None)
+            new_connection_tuples = self.flight_controller.get_connection_tuples()
+
+            # update the UI
+            if new_connection_tuples != self.conn_selection_combobox.get_entries_tuple():
+                logging_debug("Port list changed, updating UI")
+                self.conn_selection_combobox.set_entries_tuple(new_connection_tuples, current_selection)
+
+        except (OSError, AttributeError, RuntimeError) as e:
+            logging_debug("Error refreshing ports: %s", e)
+
+        finally:
+            self._is_refreshing = False
+            try:
+                if self.parent.root.winfo_exists():
+                    self._refresh_timer_id = self.parent.root.after(3000, self._refresh_ports)
+            except tk.TclError:
+                self.stop_periodic_refresh()
+
+    def stop_periodic_refresh(self) -> None:
+        """Stop the periodic port refresh."""
+        if self._refresh_timer_id is not None:
+            with contextlib.suppress(tk.TclError, AttributeError):
+                self.parent.root.after_cancel(self._refresh_timer_id)
+            self._refresh_timer_id = None
 
     def on_select_connection_combobox_change(self, _event: tk.Event) -> None:
         selected_connection = self.conn_selection_combobox.get_selected_key()
@@ -207,6 +253,8 @@ class ConnectionSelectionWidgets:  # pylint: disable=too-many-instance-attribute
             show_no_connection_error(error_message)
             return True
         self.connection_progress_window.destroy()
+        # Stop periodic refresh when connection is established
+        self.stop_periodic_refresh()
         # Store the current connection as the previous selection
         if self.flight_controller.comport and hasattr(self.flight_controller.comport, "device"):
             self.previous_selection = self.flight_controller.comport.device
@@ -327,6 +375,9 @@ class ConnectionSelectionWindow(BaseWindow):
         self.root.protocol("WM_DELETE_WINDOW", self.close_and_quit)
 
     def close_and_quit(self) -> None:
+        # Stop periodic refresh when window is closing
+        if hasattr(self, "connection_selection_widgets"):
+            self.connection_selection_widgets.stop_periodic_refresh()
         sys_exit(0)
 
     def fc_autoconnect(self) -> None:
@@ -335,6 +386,9 @@ class ConnectionSelectionWindow(BaseWindow):
     def skip_fc_connection(self, flight_controller: FlightController) -> None:
         logging_warning(_("Will proceed without FC connection. FC parameters will not be downloaded nor uploaded"))
         logging_warning(_("Only the intermediate '.param' files on the PC disk will be edited"))
+        # Stop periodic refresh when skipping connection
+        if hasattr(self, "connection_selection_widgets"):
+            self.connection_selection_widgets.stop_periodic_refresh()
         flight_controller.disconnect()
         self.root.destroy()
 

--- a/ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_pair_tuple_combobox.py
@@ -172,6 +172,10 @@ class PairTupleCombobox(ttk.Combobox):  # pylint: disable=too-many-ancestors
         except IndexError:
             return None
 
+    def get_entries_tuple(self) -> list[tuple[str, str]]:
+        """Return the current list of key-value tuples."""
+        return list(zip(self.list_keys, self.list_shows))
+
     # SPDX-SnippetEnd
 
     def _on_key_up(self, _event: tk.Event) -> str:

--- a/tests/test_frontend_tkinter_pair_tuple_combobox.py
+++ b/tests/test_frontend_tkinter_pair_tuple_combobox.py
@@ -926,6 +926,44 @@ class TestPairTupleComboboxMissingCoverage:
                 # Then: Should return early (None) and not proceed with style modifications
                 mock_style.lookup.assert_called_once()
 
+    def test_get_entries_tuple(self) -> None:
+        """
+        Test get_entries_tuple returns the current list of key-value tuples.
+
+        GIVEN: A PairTupleCombobox with populated key-value pairs
+        WHEN: get_entries_tuple is called
+        THEN: It should return the correct list of tuples matching list_keys and list_shows
+        """
+        # Given: Create combobox with test data
+        combobox = PairTupleCombobox(self.root, self.test_data, "key1", "test_combo")
+
+        # When: Call get_entries_tuple
+        result = combobox.get_entries_tuple()
+
+        # Then: Result should match the original test_data
+        assert result == self.test_data
+        assert isinstance(result, list)
+        assert all(isinstance(item, tuple) for item in result)
+        assert all(len(item) == 2 for item in result)
+
+    def test_get_entries_tuple_empty(self) -> None:
+        """
+        Test get_entries_tuple with empty combobox.
+
+        GIVEN: A PairTupleCombobox with no items
+        WHEN: get_entries_tuple is called
+        THEN: It should return an empty list
+        """
+        # Given: Create combobox with no data
+        combobox = PairTupleCombobox(self.root, [], None, "test_combo")
+
+        # When: Call get_entries_tuple
+        result = combobox.get_entries_tuple()
+
+        # Then: Result should be an empty list
+        assert not result
+        assert isinstance(result, list)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
 Fixes #1298

Changes added on top of Copilot's work:

- Fixed the UI: Removed the broken `master is None` condition that permanently killed the refresh timer when the initial auto-connection failed.
- Fixed the CI Pipeline

Tested with a FC (APM 2.8).

Logs
```
2026-03-01 18:09:06,113 - INFO - Available connection ports are:
2026-03-01 18:09:06,113 - INFO - tcp:127.0.0.1:5760 - tcp:127.0.0.1:5760
2026-03-01 18:09:06,113 - INFO - udp:0.0.0.0:14550 - udp:0.0.0.0:14550
2026-03-01 18:09:09,132 - INFO - Available connection ports are:
2026-03-01 18:09:09,132 - INFO - COM3 - Arduino Mega 2560 (COM3)
2026-03-01 18:09:09,132 - INFO - tcp:127.0.0.1:5760 - tcp:127.0.0.1:5760
2026-03-01 18:09:09,132 - INFO - udp:0.0.0.0:14550 - udp:0.0.0.0:14550
2026-03-01 18:09:12,137 - INFO - Available connection ports are:
```

Continuing #1303
