### PR TITLE
Pytest was hiting github.com rate limits

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -153,6 +153,8 @@ jobs:
         id: pytest
         continue-on-error: false
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             export LIBGL_ALWAYS_SOFTWARE=1

--- a/ardupilot_methodic_configurator/backend_internet.py
+++ b/ardupilot_methodic_configurator/backend_internet.py
@@ -127,6 +127,19 @@ def _get_verify_param() -> Union[str, bool]:
     return certifi_path
 
 
+def _get_github_api_headers() -> dict[str, str]:
+    """
+    Return Authorization header for GitHub API requests if GITHUB_TOKEN is set.
+
+    When GITHUB_TOKEN is present (e.g. in GitHub Actions), requests are
+    authenticated and the rate limit rises from 60 to 5 000 requests/hour.
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
 def _attempt_download_once(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     url: str,
     local_filename: str,
@@ -258,7 +271,7 @@ def get_release_info(name: str, should_be_pre_release: bool, timeout: int = 30) 
 
     try:
         url = urljoin(GITHUB_API_URL_RELEASES, name.lstrip("/"))
-        response = requests_get(url, timeout=timeout, verify=_get_verify_param())
+        response = requests_get(url, timeout=timeout, verify=_get_verify_param(), headers=_get_github_api_headers())
         response.raise_for_status()
 
         release_info = response.json()

--- a/tests/unit_backend_internet.py
+++ b/tests/unit_backend_internet.py
@@ -883,8 +883,10 @@ def test_get_release_info_key_error(mock_get) -> None:
 
 @patch("ardupilot_methodic_configurator.backend_internet.requests_get")
 @patch("ardupilot_methodic_configurator.backend_internet._get_verify_param")
-def test_get_release_info_correct_url_formation(mock_verify, mock_get) -> None:
+@patch("ardupilot_methodic_configurator.backend_internet._get_github_api_headers")
+def test_get_release_info_correct_url_formation(mock_headers, mock_verify, mock_get) -> None:
     """Test correct URL formation with different input formats."""
+    mock_headers.return_value = {}
     mock_verify.return_value = "/path/to/certs.pem"
     mock_response = Mock()
     mock_response.json.return_value = {"prerelease": False}
@@ -893,14 +895,20 @@ def test_get_release_info_correct_url_formation(mock_verify, mock_get) -> None:
     # Test with leading slash
     get_release_info("/latest", should_be_pre_release=False)
     mock_get.assert_called_with(
-        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest", timeout=30, verify="/path/to/certs.pem"
+        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest",
+        timeout=30,
+        verify="/path/to/certs.pem",
+        headers={},
     )
     mock_get.reset_mock()
 
     # Test without leading slash
     get_release_info("latest", should_be_pre_release=False)
     mock_get.assert_called_with(
-        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest", timeout=30, verify="/path/to/certs.pem"
+        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest",
+        timeout=30,
+        verify="/path/to/certs.pem",
+        headers={},
     )
     mock_get.reset_mock()
 
@@ -910,13 +918,16 @@ def test_get_release_info_correct_url_formation(mock_verify, mock_get) -> None:
         "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/tags/v1.0.0",
         timeout=30,
         verify="/path/to/certs.pem",
+        headers={},
     )
 
 
 @patch("ardupilot_methodic_configurator.backend_internet.requests_get")
 @patch("ardupilot_methodic_configurator.backend_internet._get_verify_param")
-def test_get_release_info_custom_timeout(mock_verify, mock_get) -> None:
+@patch("ardupilot_methodic_configurator.backend_internet._get_github_api_headers")
+def test_get_release_info_custom_timeout(mock_headers, mock_verify, mock_get) -> None:
     """Test custom timeout parameter."""
+    mock_headers.return_value = {}
     mock_verify.return_value = "/path/to/certs.pem"
     mock_response = Mock()
     mock_response.json.return_value = {"prerelease": False}
@@ -924,7 +935,10 @@ def test_get_release_info_custom_timeout(mock_verify, mock_get) -> None:
 
     get_release_info("latest", should_be_pre_release=False, timeout=60)
     mock_get.assert_called_with(
-        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest", timeout=60, verify="/path/to/certs.pem"
+        "https://api.github.com/repos/ArduPilot/MethodicConfigurator/releases/latest",
+        timeout=60,
+        verify="/path/to/certs.pem",
+        headers={},
     )
 
 


### PR DESCRIPTION
The integration tests make unauthenticated GitHub API requests, which are limited to 60 requests/hour per source IP. macOS GitHub Actions runners frequently share the same egress IPs across many concurrent workflows, exhausting the quota. Linux/Windows runners are less susceptible due to different network allocation.

Fix 1 — backend_internet.py:130:
Added _get_github_api_headers() which reads GITHUB_TOKEN from the environment and returns an Authorization: Bearer <token> header. This header is now passed to every get_release_info() call. An authenticated request raises the rate limit from 60 to 5,000 requests/hour.

Fix 2 — pytest.yml:156:
Added env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} to the pytest step. secrets.GITHUB_TOKEN is a built-in token automatically available in every GitHub Actions run — no repository secret configuration is required. All three OS matrix runners (Ubuntu, Windows, macOS) will now use authenticated requests.