### PR TITLE
Skip coverage PR comment on fork pull requests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -373,7 +373,7 @@ jobs:
           coverage report --fail-under=89
 
   add_coverage_to_pullrequest:
-    if: github.event_name == 'pull_request' && (success() || failure())
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (success() || failure())
     runs-on: ubuntu-latest
     needs: pytest  # This will ensure this job runs after 'pytest'
     permissions:


### PR DESCRIPTION
The `orgoro/coverage` action requires `pull-requests: write` permissions to post its summary comment. However, GitHub's default security model restricts the `GITHUB_TOKEN` to read-only for pull requests originating from external forks, which was resulting in pipeline failures with: `HttpError: Resource not accessible by integration`.

Added a condition to ensure the job only evaluates when `github.event.pull_request.head.repo.full_name == github.repository`, cleanly skipping the step for external contributors instead of failing.