### PR TITLE
fix(review): address Copilot bot review comments from merged PRs

### DIFF
--- a/ardupilot_methodic_configurator/data_model_par_dict.py
+++ b/ardupilot_methodic_configurator/data_model_par_dict.py
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import re
-from math import isfinite as math_isfinite
+from math import isfinite
 from os import path as os_path
 from os import popen as os_popen
 from sys import exc_info as sys_exc_info
@@ -198,7 +198,7 @@ class ParDict(dict[str, Par]):
             raise SystemExit(msg)
         try:
             fvalue = float(value)
-            if not math_isfinite(fvalue):
+            if not isfinite(fvalue):
                 msg = _(
                     "Non-finite parameter value {value!r} (parsed as {fvalue}) for {parameter_name} in {param_file} line {i}"
                 ).format(value=value, fvalue=fvalue, parameter_name=parameter_name, param_file=param_file, i=i)

--- a/tests/test_data_model_par_dict.py
+++ b/tests/test_data_model_par_dict.py
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import os
+import re
 import tempfile
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
@@ -19,7 +20,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import ardupilot_methodic_configurator.data_model_par_dict as par_dict_module
-from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict, is_within_tolerance, validate_param_name
 
 # pylint: disable=redefined-outer-name, too-many-lines
@@ -1496,7 +1496,7 @@ class TestParameterDictionaryEdgeCases:
 
         try:
             # Act & Assert: Invalid values rejected
-            with pytest.raises(SystemExit, match=_("Invalid parameter value {value!r}").format(value="not_a_number")):
+            with pytest.raises(SystemExit, match=r"not_a_number"):
                 ParDict.load_param_file_into_dict(file_path)
         finally:
             os.unlink(file_path)
@@ -1520,7 +1520,7 @@ class TestParameterDictionaryEdgeCases:
                 file_path = f.name
 
             try:
-                with pytest.raises(SystemExit, match=_("Non-finite parameter value {value!r}").format(value=bad_value)):
+                with pytest.raises(SystemExit, match=re.escape(bad_value)):
                     ParDict.load_param_file_into_dict(file_path)
             finally:
                 os.unlink(file_path)


### PR DESCRIPTION
## Summary

Addresses actionable Copilot bot review comments from PRs #1391 and #1406:

- Rename unconventional `math_isfinite` alias to direct `isfinite` import for clarity
- Replace brittle i18n test assertions that matched on `_()` translated strings with locale-independent matches on stable parameter values (e.g., `r"not_a_number"`, `re.escape(bad_value)`)
- Remove unused `_` import from test module

## Context

Copilot flagged these across several merged PRs. The i18n assertion brittleness was a recurring theme — tests matching on gettext-translated error messages would break under non-default locales. The fix matches on the stable, locale-independent parts of the error (the parameter value itself).

## Test plan

- [x] `pytest tests/test_data_model_par_dict.py` — 63 passed, 0 failed
- [x] `isfinite` rename verified with import check