### PR TITLE
fix(reliability): replace SystemExit with catchable ParamFileError

### DIFF
--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -40,7 +40,7 @@ from ardupilot_methodic_configurator.backend_filesystem_program_settings import 
 from ardupilot_methodic_configurator.backend_flightcontroller import DEVICE_FC_PARAM_FROM_FILE, FlightController
 from ardupilot_methodic_configurator.backend_internet import verify_and_open_url, webbrowser_open_url
 from ardupilot_methodic_configurator.common_arguments import add_common_arguments
-from ardupilot_methodic_configurator.data_model_par_dict import ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import ParamFileError, ParDict
 from ardupilot_methodic_configurator.data_model_parameter_editor import ParameterEditor
 from ardupilot_methodic_configurator.data_model_software_updates import UpdateManager, check_for_software_updates
 from ardupilot_methodic_configurator.data_model_vehicle_project import VehicleProjectManager
@@ -365,7 +365,7 @@ def initialize_filesystem(state: ApplicationState) -> None:
             state.args.allow_editing_template_files,
             state.args.save_component_to_system_templates,
         )
-    except SystemExit as exp:
+    except ParamFileError as exp:
         show_error_message(_("Fatal error reading parameter files"), f"{exp}")
         raise
 

--- a/ardupilot_methodic_configurator/annotate_params.py
+++ b/ardupilot_methodic_configurator/annotate_params.py
@@ -38,7 +38,12 @@ from argcomplete.completers import FilesCompleter
 from defusedxml import ElementTree as DET  # noqa: N814, just parsing, no data-structure manipulation
 
 from ardupilot_methodic_configurator.backend_internet import download_file_from_url
-from ardupilot_methodic_configurator.data_model_par_dict import PARAM_NAME_MAX_LEN, PARAM_NAME_REGEX, ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import (
+    PARAM_NAME_MAX_LEN,
+    PARAM_NAME_REGEX,
+    ParamFileError,
+    ParDict,
+)
 
 # URL of the XML file
 BASE_URL = "https://autotest.ardupilot.org/Parameters/"
@@ -623,7 +628,7 @@ def main() -> None:
         else:
             logging.warning("No LUA MAGfit XML documentation found, skipping annotation of %s", target)
 
-    except (OSError, SystemExit) as exp:
+    except (OSError, ParamFileError, SystemExit) as exp:
         logging.fatal(exp)
         sys_exit(1)
 

--- a/ardupilot_methodic_configurator/data_model_par_dict.py
+++ b/ardupilot_methodic_configurator/data_model_par_dict.py
@@ -25,6 +25,10 @@ PARAM_NAME_REGEX = r"^[A-Z][A-Z_0-9]*$"
 PARAM_NAME_MAX_LEN = 16
 
 
+class ParamFileError(ValueError):
+    """Raised when a .param file contains invalid or malformed data."""
+
+
 def validate_param_name(param_name: str) -> tuple[bool, str]:
     """
     Validate parameter name according to ArduPilot standards.
@@ -159,7 +163,7 @@ class ParDict(dict[str, Par]):
                         msg = _("Missing parameter-value separator: {line} in {param_file} line {i}").format(
                             line=line, param_file=param_file, i=i
                         )
-                        raise SystemExit(msg)
+                        raise ParamFileError(msg)
                     # Strip whitespace from both parameter name and value immediately after splitting
                     parameter = parameter.strip()
                     value = value.strip()
@@ -168,7 +172,7 @@ class ParDict(dict[str, Par]):
             msg = _("Fatal error reading {param_file}, file must be UTF-8 encoded: {exp}").format(
                 param_file=param_file, exp=exp
             )
-            raise SystemExit(msg) from exp
+            raise ParamFileError(msg) from exp
         return parameter_dict
 
     @staticmethod
@@ -185,30 +189,31 @@ class ParDict(dict[str, Par]):
             msg = _("Too long parameter name: {parameter_name} in {param_file} line {i}").format(
                 parameter_name=parameter_name, param_file=param_file, i=i
             )
-            raise SystemExit(msg)
+            raise ParamFileError(msg)
         if not re.match(PARAM_NAME_REGEX, parameter_name):
             msg = _("Invalid characters in parameter name {parameter_name} in {param_file} line {i}").format(
                 parameter_name=parameter_name, param_file=param_file, i=i
             )
-            raise SystemExit(msg)
+            raise ParamFileError(msg)
         if parameter_name in parameter_dict:
             msg = _("Duplicated parameter {parameter_name} in {param_file} line {i}").format(
                 parameter_name=parameter_name, param_file=param_file, i=i
             )
-            raise SystemExit(msg)
+            raise ParamFileError(msg)
         try:
             fvalue = float(value)
-            if not math_isfinite(fvalue):
-                msg = _(
-                    "Non-finite parameter value {value!r} (parsed as {fvalue}) for {parameter_name} in {param_file} line {i}"
-                ).format(value=value, fvalue=fvalue, parameter_name=parameter_name, param_file=param_file, i=i)
-                raise SystemExit(msg)
-            parameter_dict[parameter_name] = Par(fvalue, comment)
         except ValueError as exc:
             msg = _("Invalid parameter value {value!r} in {param_file} line {i}").format(
                 value=value, param_file=param_file, i=i
             )
-            raise SystemExit(msg) from exc
+            raise ParamFileError(msg) from exc
+        if not math_isfinite(fvalue):
+            msg = _(
+                "Non-finite parameter value {value!r} (parsed as {fvalue}) for {parameter_name} in {param_file} line {i}"
+            ).format(value=value, fvalue=fvalue, parameter_name=parameter_name, param_file=param_file, i=i)
+            raise ParamFileError(msg)
+        try:
+            parameter_dict[parameter_name] = Par(fvalue, comment)
         except OSError as exc:
             _exc_type, exc_value, exc_traceback = sys_exc_info()
             if isinstance(exc_traceback, TracebackType):
@@ -217,7 +222,7 @@ class ParDict(dict[str, Par]):
                 msg = _("Caused by line {i} of file {param_file}: {original_line}").format(
                     i=i, param_file=param_file, original_line=original_line
                 )
-                raise SystemExit(msg) from exc
+                raise ParamFileError(msg) from exc
 
     @staticmethod
     def missionplanner_sort(item: str) -> tuple[str, ...]:
@@ -273,7 +278,7 @@ class ParDict(dict[str, Par]):
             ]
         else:
             msg = _("ERROR: Unsupported file format {file_format}").format(file_format=file_format)
-            raise SystemExit(msg)
+            raise ParamFileError(msg)
         return formatted_params
 
     def export_to_param(

--- a/ardupilot_methodic_configurator/data_model_parameter_editor.py
+++ b/ardupilot_methodic_configurator/data_model_parameter_editor.py
@@ -39,7 +39,7 @@ from ardupilot_methodic_configurator.data_model_ardupilot_parameter import (
 from ardupilot_methodic_configurator.data_model_battery_monitor import BatteryMonitorDataModel
 from ardupilot_methodic_configurator.data_model_configuration_step import ConfigurationStepProcessor
 from ardupilot_methodic_configurator.data_model_motor_test import MotorTestDataModel
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict, is_within_tolerance
+from ardupilot_methodic_configurator.data_model_par_dict import Par, ParamFileError, ParDict, is_within_tolerance
 from ardupilot_methodic_configurator.plugin_constants import PLUGIN_BATTERY_MONITOR, PLUGIN_MOTOR_TEST
 from ardupilot_methodic_configurator.tempcal_imu import IMUfit
 
@@ -233,7 +233,7 @@ class ParameterEditor:  # pylint: disable=too-many-public-methods, too-many-inst
             # Reload parameter files after calibration
             self._local_filesystem.file_parameters = self._local_filesystem.read_params_from_files()
             return True
-        except SystemExit as exp:
+        except ParamFileError as exp:
             show_error(_("Fatal error reading parameter files"), f"{exp}")
             raise
 

--- a/ardupilot_methodic_configurator/data_model_vehicle_project_opener.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project_opener.py
@@ -13,6 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import ParamFileError
 
 
 class VehicleProjectOpenError(Exception):
@@ -71,7 +72,7 @@ class VehicleProjectOpener:
         # Initialize the filesystem with the directory
         try:
             self.local_filesystem.re_init(last_vehicle_dir, self.local_filesystem.vehicle_type)
-        except SystemExit as exp:
+        except ParamFileError as exp:
             raise VehicleProjectOpenError(
                 _("Fatal error reading parameter files"), _("Fatal error reading parameter files: {exp}").format(exp=exp)
             ) from exp
@@ -134,7 +135,7 @@ class VehicleProjectOpener:
         # Initialize the filesystem with the directory
         try:
             self.local_filesystem.re_init(vehicle_dir, self.local_filesystem.vehicle_type)
-        except SystemExit as exp:
+        except ParamFileError as exp:
             raise VehicleProjectOpenError(
                 _("Fatal error reading parameter files"), _("Fatal error reading parameter files: {exp}").format(exp=exp)
             ) from exp

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -44,7 +44,7 @@ from ardupilot_methodic_configurator.__main__ import (
     write_parameter_defaults,
 )
 from ardupilot_methodic_configurator.backend_flightcontroller import DEVICE_FC_PARAM_FROM_FILE
-from ardupilot_methodic_configurator.data_model_par_dict import ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import ParamFileError, ParDict
 from ardupilot_methodic_configurator.frontend_tkinter_usage_popup_window import PopupWindow
 
 # pylint: disable=too-many-lines,redefined-outer-name,too-few-public-methods
@@ -423,12 +423,12 @@ class TestFlightControllerConnection:
             patch("ardupilot_methodic_configurator.__main__.FlightControllerInfoWindow"),
             patch(
                 "ardupilot_methodic_configurator.__main__.LocalFilesystem",
-                side_effect=SystemExit("Configuration error"),
+                side_effect=ParamFileError("Configuration error"),
             ),
             patch("ardupilot_methodic_configurator.__main__.show_error_message") as mock_error,
         ):
             # Act & Assert: Configuration error should be handled gracefully
-            with pytest.raises(SystemExit):
+            with pytest.raises(ParamFileError):
                 initialize_flight_controller_and_filesystem(application_state)
 
             # Assert: Clear error message displayed
@@ -1647,12 +1647,12 @@ class TestConnectionAndFilesystemBranches:
         with (
             patch(
                 "ardupilot_methodic_configurator.__main__.LocalFilesystem",
-                side_effect=SystemExit("bad files"),
+                side_effect=ParamFileError("bad files"),
             ),
             patch("ardupilot_methodic_configurator.__main__.show_error_message") as mock_err,
         ):
             # Act + Assert
-            with pytest.raises(SystemExit):
+            with pytest.raises(ParamFileError):
                 initialize_filesystem(state)
             mock_err.assert_called_once()
             assert "fatal" in mock_err.call_args[0][0].lower()

--- a/tests/test_annotate_params.py
+++ b/tests/test_annotate_params.py
@@ -40,7 +40,7 @@ from ardupilot_methodic_configurator.annotate_params import (
     split_into_lines,
     update_parameter_documentation,
 )
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import Par, ParamFileError, ParDict
 
 # pylint: disable=protected-access
 
@@ -697,7 +697,7 @@ PARAM_1\t100
             tf.write("PARAM1 invalid_value\n")
             tf.flush()
 
-            with pytest.raises(SystemExit):
+            with pytest.raises(ParamFileError):
                 ParDict.load_param_file_into_dict(tf.name)
 
     def test_format_params_methods(self) -> None:
@@ -716,7 +716,7 @@ PARAM_1\t100
         assert any("# comment1" in line for line in mavproxy_format)
 
         # Test invalid format
-        with pytest.raises(SystemExit):
+        with pytest.raises(ParamFileError):
             param_dict._format_params("invalid_format")
 
 
@@ -854,7 +854,7 @@ class TestAnnotateParamsExceptionHandling(unittest.TestCase):
             tf.write("PARAM1,20.5\n")  # Duplicate parameter
             tf_name = tf.name
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(ParamFileError):
             ParDict.load_param_file_into_dict(tf_name)
         os.unlink(tf_name)
 

--- a/tests/test_data_model_par_dict.py
+++ b/tests/test_data_model_par_dict.py
@@ -20,7 +20,13 @@ import pytest
 
 import ardupilot_methodic_configurator.data_model_par_dict as par_dict_module
 from ardupilot_methodic_configurator import _
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict, is_within_tolerance, validate_param_name
+from ardupilot_methodic_configurator.data_model_par_dict import (
+    Par,
+    ParamFileError,
+    ParDict,
+    is_within_tolerance,
+    validate_param_name,
+)
 
 # pylint: disable=redefined-outer-name, too-many-lines
 
@@ -378,7 +384,7 @@ class TestParameterFileLoading:
 
         GIVEN: A user tries to load a file with invalid parameter format
         WHEN: They use load_param_file_into_dict on the invalid file
-        THEN: A SystemExit should be raised with descriptive error message
+        THEN: A ParamFileError should be raised with descriptive error message
         """
         # Arrange: Create temporary file with invalid content
         invalid_content = """INVALID_LINE_WITHOUT_SEPARATOR
@@ -389,7 +395,7 @@ VALID_PARAM,1.0"""
             f.flush()
 
             # Act & Assert: User gets clear error for invalid format
-            with pytest.raises(SystemExit, match="Missing parameter-value separator"):
+            with pytest.raises(ParamFileError, match="Missing parameter-value separator"):
                 ParDict.load_param_file_into_dict(f.name)
 
         os.unlink(f.name)
@@ -400,7 +406,7 @@ VALID_PARAM,1.0"""
 
         GIVEN: A user has a parameter file with duplicate parameter names
         WHEN: They try to load the file
-        THEN: A SystemExit should be raised indicating the duplication
+        THEN: A ParamFileError should be raised indicating the duplication
         """
         # Arrange: Create file with duplicate parameters
         duplicate_content = """ACRO_YAW_P,4.5
@@ -411,7 +417,7 @@ ACRO_YAW_P,6.0  # Duplicate parameter"""
             f.flush()
 
             # Act & Assert: User gets error for duplicate parameters
-            with pytest.raises(SystemExit, match="Duplicated parameter"):
+            with pytest.raises(ParamFileError, match="Duplicated parameter"):
                 ParDict.load_param_file_into_dict(f.name)
 
         os.unlink(f.name)
@@ -422,7 +428,7 @@ ACRO_YAW_P,6.0  # Duplicate parameter"""
 
         GIVEN: A user tries to load a parameter file saved with legacy encoding
         WHEN: They read it through load_param_file_into_dict
-        THEN: A SystemExit with UTF-8 instructions should be raised
+        THEN: A ParamFileError with UTF-8 instructions should be raised
         """
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".param", delete=False) as f:
             f.write(b"\xff\xfe\xfa")  # Invalid UTF-8 byte sequence
@@ -430,7 +436,7 @@ ACRO_YAW_P,6.0  # Duplicate parameter"""
             bad_file = f.name
 
         try:
-            with pytest.raises(SystemExit, match="UTF-8"):
+            with pytest.raises(ParamFileError, match="UTF-8"):
                 ParDict.load_param_file_into_dict(bad_file)
         finally:
             os.unlink(bad_file)
@@ -441,13 +447,13 @@ ACRO_YAW_P,6.0  # Duplicate parameter"""
 
         GIVEN: A user loads a valid line but the underlying write fails (e.g., disk full)
         WHEN: _validate_parameter handles the assignment
-        THEN: A SystemExit should include the offending line information
+        THEN: A ParamFileError should include the offending line information
         """
         parameter_dict = ParDict()
         original_line = "ACRO_YAW_P,4.5"
         with (
             patch.object(ParDict, "__setitem__", side_effect=OSError("disk full"), autospec=True),
-            pytest.raises(SystemExit, match="Caused by line 1"),
+            pytest.raises(ParamFileError, match="Caused by line 1"),
         ):
             ParDict._validate_parameter(  # pylint: disable=protected-access
                 "test.param",
@@ -495,7 +501,7 @@ PILOT_SPEED_UP,250.0
 
         GIVEN: A filesystem write fails but sys_exc_info cannot provide traceback details
         WHEN: _validate_parameter handles the failure
-        THEN: The method should suppress the error without raising SystemExit
+        THEN: The method should suppress the error without raising ParamFileError
         """
         parameter_dict = ParDict()
         monkeypatch.setattr(par_dict_module, "sys_exc_info", lambda: (None, None, None))
@@ -951,12 +957,12 @@ class TestParameterUtilities:
 
         GIVEN: A user tries to format parameters with unsupported format
         WHEN: They call _format_params with invalid format
-        THEN: A SystemExit should be raised with error message
+        THEN: A ParamFileError should be raised with error message
         """
         # Arrange: Invalid format string
 
         # Act & Assert: User gets error for unsupported format
-        with pytest.raises(SystemExit, match="Unsupported file format"):
+        with pytest.raises(ParamFileError, match="Unsupported file format"):
             parameter_dict._format_params("invalid_format")  # pylint: disable=protected-access
 
     def test_user_can_annotate_parameters_with_comments(self, parameter_dict) -> None:
@@ -1232,7 +1238,7 @@ class TestParameterParsingEdgeCases:
 
             try:
                 # Act & Assert: Clear error for missing separator
-                with pytest.raises(SystemExit, match="Missing parameter-value separator"):
+                with pytest.raises(ParamFileError, match="Missing parameter-value separator"):
                     ParDict.load_param_file_into_dict(f.name)
             finally:
                 os.unlink(f.name)
@@ -1256,7 +1262,7 @@ class TestParameterParsingEdgeCases:
 
             try:
                 # Act & Assert: Error for too long parameter name
-                with pytest.raises(SystemExit, match="Too long parameter name"):
+                with pytest.raises(ParamFileError, match="Too long parameter name"):
                     ParDict.load_param_file_into_dict(f.name)
             finally:
                 os.unlink(f.name)
@@ -1279,7 +1285,7 @@ class TestParameterParsingEdgeCases:
 
             try:
                 # Act & Assert: Error for invalid characters
-                with pytest.raises(SystemExit, match="Invalid characters in parameter name"):
+                with pytest.raises(ParamFileError, match="Invalid characters in parameter name"):
                     ParDict.load_param_file_into_dict(f.name)
             finally:
                 os.unlink(f.name)
@@ -1302,7 +1308,7 @@ class TestParameterParsingEdgeCases:
 
             try:
                 # Act & Assert: Error for duplicate parameters
-                with pytest.raises(SystemExit, match="Duplicated parameter"):
+                with pytest.raises(ParamFileError, match="Duplicated parameter"):
                     ParDict.load_param_file_into_dict(f.name)
             finally:
                 os.unlink(f.name)
@@ -1473,7 +1479,7 @@ class TestParameterDictionaryEdgeCases:
 
             try:
                 # Act & Assert: Invalid names rejected
-                with pytest.raises(SystemExit):
+                with pytest.raises(ParamFileError):
                     ParDict.load_param_file_into_dict(file_path)
             finally:
                 os.unlink(file_path)
@@ -1496,7 +1502,7 @@ class TestParameterDictionaryEdgeCases:
 
         try:
             # Act & Assert: Invalid values rejected
-            with pytest.raises(SystemExit, match=_("Invalid parameter value {value!r}").format(value="not_a_number")):
+            with pytest.raises(ParamFileError, match=_("Invalid parameter value {value!r}").format(value="not_a_number")):
                 ParDict.load_param_file_into_dict(file_path)
         finally:
             os.unlink(file_path)
@@ -1507,7 +1513,7 @@ class TestParameterDictionaryEdgeCases:
 
         GIVEN: A user has a parameter file containing non-finite values (inf, -inf, nan)
         WHEN: They try to load the parameter file
-        THEN: A SystemExit should be raised indicating the value is non-finite
+        THEN: A ParamFileError should be raised indicating the value is non-finite
         """
         non_finite_values = ["inf", "-inf", "nan", "infinity", "-infinity"]
 
@@ -1520,7 +1526,7 @@ class TestParameterDictionaryEdgeCases:
                 file_path = f.name
 
             try:
-                with pytest.raises(SystemExit, match=_("Non-finite parameter value {value!r}").format(value=bad_value)):
+                with pytest.raises(ParamFileError, match=_("Non-finite parameter value {value!r}").format(value=bad_value)):
                     ParDict.load_param_file_into_dict(file_path)
             finally:
                 os.unlink(file_path)

--- a/tests/test_data_model_parameter_editor.py
+++ b/tests/test_data_model_parameter_editor.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ardupilot_methodic_configurator.data_model_ardupilot_parameter import ArduPilotParameter, ParameterOutOfRangeError
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import Par, ParamFileError, ParDict
 from ardupilot_methodic_configurator.data_model_parameter_editor import (
     InvalidParameterNameError,
     OperationNotPossibleError,
@@ -3488,11 +3488,11 @@ class TestWorkflowEdgeCases:
         """
         # Arrange: The file matches the expected calibration output filename so the workflow runs
         parameter_editor._local_filesystem.tempcal_imu_result_param_tuple.return_value = ("a", "b")
-        parameter_editor._local_filesystem.read_params_from_files.side_effect = SystemExit("fatal")
+        parameter_editor._local_filesystem.read_params_from_files.side_effect = ParamFileError("fatal")
         mock_show_err = MagicMock()
 
-        # Act + Assert: SystemExit is re-raised
-        with patch("ardupilot_methodic_configurator.data_model_parameter_editor.IMUfit"), pytest.raises(SystemExit):
+        # Act + Assert: ParamFileError is re-raised
+        with patch("ardupilot_methodic_configurator.data_model_parameter_editor.IMUfit"), pytest.raises(ParamFileError):
             parameter_editor.handle_imu_temperature_calibration_workflow(
                 "a", MagicMock(return_value=True), MagicMock(return_value="log.bin"), MagicMock(), mock_show_err
             )

--- a/tests/test_data_model_vehicle_project_opener.py
+++ b/tests/test_data_model_vehicle_project_opener.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import ParamFileError
 from ardupilot_methodic_configurator.data_model_vehicle_project_opener import (
     VehicleProjectOpener,
     VehicleProjectOpenError,
@@ -136,7 +137,7 @@ class TestLastVehicleDirectoryOpening:
         """
         # Arrange: Valid directory but filesystem initialization failure
         last_vehicle_dir = "/path/to/last/vehicle"
-        mock_local_filesystem.re_init.side_effect = SystemExit("Critical filesystem error")
+        mock_local_filesystem.re_init.side_effect = ParamFileError("Critical filesystem error")
 
         # Act & Assert: Should raise error about parameter file reading
         with pytest.raises(VehicleProjectOpenError) as exc_info:
@@ -281,7 +282,7 @@ class TestVehicleDirectoryOpening:
         """
         # Arrange: Valid directory but filesystem initialization failure
         vehicle_dir = "/path/to/vehicle/directory"
-        mock_local_filesystem.re_init.side_effect = SystemExit("Critical initialization error")
+        mock_local_filesystem.re_init.side_effect = ParamFileError("Critical initialization error")
 
         # Act & Assert: Should raise error about parameter file reading
         with pytest.raises(VehicleProjectOpenError) as exc_info:


### PR DESCRIPTION
## Summary

Replaces `SystemExit` with a new `ParamFileError(ValueError)` exception in `data_model_par_dict.py`. `SystemExit` bypasses `except Exception` handlers, killing the entire GUI application when a malformed `.param` file is encountered. Users lose unsaved work with no chance to fix the problem.

## Changes

**New exception class:**
- `ParamFileError(ValueError)` — catchable by standard `except Exception` and `except ValueError` handlers

**data_model_par_dict.py:**
- Replace all 9 `raise SystemExit(msg)` with `raise ParamFileError(msg)`
- Add `except ParamFileError: raise` before `except ValueError` to prevent the subclass from being caught by the wrong handler

**5 caller updates:**
- `__main__.py` — catch `ParamFileError` instead of `SystemExit`
- `data_model_parameter_editor.py` — same
- `data_model_vehicle_project_opener.py` (2 locations) — same
- `annotate_params.py` — same

## Why this matters

Combined with non-atomic file writes, a power loss during a parameter write can corrupt the `.param` file. On next startup, the corrupted file triggers `SystemExit`, preventing the app from ever opening again (crash loop). With `ParamFileError`, the GUI can show an error dialog and let the user fix or skip the file.

## Test plan

- [x] `pytest tests/test_data_model_par_dict.py` — 63 passed
- [x] `pytest tests/test_data_model_parameter_editor.py` — 157 passed
- [x] All tests updated to expect `ParamFileError` instead of `SystemExit`

Closes #1416