### PR TITLE
fix(io): use atomic writes for .param, JSON, and settings files

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_json_with_schema.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_json_with_schema.py
@@ -22,6 +22,7 @@ from typing import Any, Union
 from jsonschema import ValidationError, validate, validators
 
 from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.backend_safe_file_io import safe_write
 
 
 class FilesystemJSONWithSchema:
@@ -124,11 +125,11 @@ class FilesystemJSONWithSchema:
 
         filepath = os_path.join(data_dir, self.json_filename)
         try:
-            with open(filepath, "w", encoding="utf-8", newline="\n") as file:
-                json_str = json_dumps(data, indent=4)
-                # Strip the last newline to avoid double newlines
-                # This is to ensure compatibility with pre-commit's end-of-file-fixer
-                file.write(json_str.rstrip("\n") + "\n")
+            json_str = json_dumps(data, indent=4)
+            # Strip the last newline to avoid double newlines
+            # This is to ensure compatibility with pre-commit's end-of-file-fixer
+            content = json_str.rstrip("\n") + "\n"
+            safe_write(filepath, lambda f: f.write(content))
         except FileNotFoundError:
             msg = _("Directory '{}' not found").format(data_dir)
             logging_error(msg)

--- a/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
@@ -34,6 +34,7 @@ from typing import Any, Optional, Union
 from platformdirs import site_config_dir, user_config_dir
 
 from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.backend_safe_file_io import safe_write
 from ardupilot_methodic_configurator.data_model_recent_items_history_list import RecentItemsHistoryList
 
 # Platform detection constant to avoid repeated system calls
@@ -320,9 +321,7 @@ class ProgramSettings:  # pylint: disable=too-many-public-methods
     @staticmethod
     def _set_settings_from_dict(settings: dict) -> None:
         settings_path = os_path.join(ProgramSettings._user_config_dir(), "settings.json")
-
-        with open(settings_path, "w", encoding="utf-8", newline="\n") as settings_file:
-            json_dump(settings, settings_file, indent=4)
+        safe_write(settings_path, lambda f: json_dump(settings, f, indent=4))
 
     @staticmethod
     def _is_template_directory(vehicle_dir: str) -> bool:

--- a/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
@@ -27,6 +27,7 @@ from typing import Any, Union
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.backend_filesystem_json_with_schema import FilesystemJSONWithSchema
 from ardupilot_methodic_configurator.backend_filesystem_program_settings import ProgramSettings
+from ardupilot_methodic_configurator.backend_safe_file_io import safe_write
 from ardupilot_methodic_configurator.data_model_template_overview import TemplateOverview
 from ardupilot_methodic_configurator.data_model_vehicle_components_json_schema import VehicleComponentsJsonSchema
 
@@ -264,8 +265,7 @@ class VehicleComponents:
         templates = {**existing_templates, **templates_to_save} if existing_templates else templates_to_save
 
         try:
-            with open(filepath, "w", encoding="utf-8", newline="\n") as file:  # use Linux line endings even on Windows
-                json_dump(templates, file, indent=4)
+            safe_write(filepath, lambda f: json_dump(templates, f, indent=4))
             return False, normalized_filepath  # Success, return the filepath
         except FileNotFoundError:
             msg = _("File not found when writing to '{}': {}").format(normalized_filepath, _("Path not found"))

--- a/ardupilot_methodic_configurator/backend_safe_file_io.py
+++ b/ardupilot_methodic_configurator/backend_safe_file_io.py
@@ -1,0 +1,75 @@
+"""
+Crash-safe file writing utilities.
+
+Provides atomic write operations that prevent data corruption from
+crashes, power loss, or OS-level interruptions during file writes.
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import os
+import tempfile
+from contextlib import suppress
+from typing import IO, Callable
+
+
+def safe_write(filepath: str, write_func: Callable[[IO[str]], object]) -> None:
+    """
+    Write to a temporary file, then atomically replace the target.
+
+    This ensures the target file is either fully written or untouched —
+    never truncated or empty due to a crash mid-write.
+
+    Args:
+        filepath: The target file path to write to.
+        write_func: A callable that receives an open file handle and writes content to it.
+
+    """
+    dir_name = os.path.dirname(filepath) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    replaced = False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as tmp_file:
+            write_func(tmp_file)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+
+        # Preserve permissions and ownership from the existing target file.
+        # For new files, apply umask-derived default (0o666 & ~umask) so the
+        # result matches what open("w") would have created.
+        try:
+            st = os.stat(filepath)
+            with suppress(PermissionError):
+                os.chmod(tmp_path, st.st_mode)
+            if hasattr(os, "chown"):
+                with suppress(PermissionError):
+                    os.chown(tmp_path, st.st_uid, st.st_gid)
+        except FileNotFoundError:
+            current_umask = os.umask(0)
+            os.umask(current_umask)
+            default_mode = 0o666 & ~current_umask
+            os.chmod(tmp_path, default_mode)
+
+        os.replace(tmp_path, filepath)  # atomic on POSIX, near-atomic on Windows
+        replaced = True
+
+        # Best-effort: fsync the containing directory so the rename is durable
+        dir_fd = None
+        try:
+            flags = getattr(os, "O_RDONLY", 0)
+            if hasattr(os, "O_DIRECTORY"):
+                flags |= os.O_DIRECTORY
+            dir_fd = os.open(dir_name, flags)
+            os.fsync(dir_fd)
+        except (OSError, AttributeError):
+            pass
+        finally:
+            if dir_fd is not None:
+                with suppress(OSError):
+                    os.close(dir_fd)
+    finally:
+        if not replaced:
+            with suppress(OSError):
+                os.unlink(tmp_path)

--- a/ardupilot_methodic_configurator/data_model_par_dict.py
+++ b/ardupilot_methodic_configurator/data_model_par_dict.py
@@ -16,9 +16,10 @@ from os import path as os_path
 from os import popen as os_popen
 from sys import exc_info as sys_exc_info
 from types import TracebackType
-from typing import Callable, Optional, Union
+from typing import IO, Callable, Optional, Union
 
 from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.backend_safe_file_io import safe_write
 
 # ArduPilot parameter names start with a capital letter and can have capital letters, numbers and _
 PARAM_NAME_REGEX = r"^[A-Z][A-Z_0-9]*$"
@@ -294,10 +295,13 @@ class ParDict(dict[str, Par]):
 
         """
         formatted_params = self._format_params(file_format)
-        with open(filename_out, "w", encoding="utf-8", newline="\n") as output_file:  # use Linux line endings even on Windows
+
+        def _write(output_file: IO[str]) -> None:
             if content_header:
                 output_file.write("\n".join(content_header) + "\n")
             output_file.writelines(line + "\n" for line in formatted_params)
+
+        safe_write(filename_out, _write)
 
     @staticmethod
     def print_out(formatted_params: list[str], name: str) -> None:

--- a/tests/test_backend_filesystem_json_with_schema.py
+++ b/tests/test_backend_filesystem_json_with_schema.py
@@ -432,7 +432,9 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/output/directory/output.json",
             ),
-            patch("builtins.open", mock_open()) as mock_file,
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+            ) as mock_safe_write,
             patch(
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.json_dumps",
                 return_value='{"name": "Test Output", "count": 42}',
@@ -444,7 +446,8 @@ class TestJSONDataSaving:
             # Assert: Data saved successfully
             assert error_occurred is False
             assert error_message == ""
-            mock_file.assert_called_once_with("/output/directory/output.json", "w", encoding="utf-8", newline="\n")
+            mock_safe_write.assert_called_once()
+            assert mock_safe_write.call_args[0][0] == "/output/directory/output.json"
             mock_dumps.assert_called_once_with(valid_data, indent=4)
             # Assert: Internal cache updated immediately (regression test for commit ccc53bb)
             assert json_manager_with_schema.data == valid_data
@@ -501,7 +504,10 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/nonexistent/directory/output.json",
             ),
-            patch("builtins.open", side_effect=FileNotFoundError),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+                side_effect=FileNotFoundError,
+            ),
             patch("ardupilot_methodic_configurator.backend_filesystem_json_with_schema.logging_error") as mock_error,
         ):
             # Act: User attempts to save to missing directory
@@ -530,7 +536,10 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/protected/directory/output.json",
             ),
-            patch("builtins.open", side_effect=PermissionError),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+                side_effect=PermissionError,
+            ),
             patch("ardupilot_methodic_configurator.backend_filesystem_json_with_schema.logging_error") as mock_error,
         ):
             # Act: User attempts to save without permissions
@@ -559,7 +568,10 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/test/directory/output.json",
             ),
-            patch("builtins.open", side_effect=IsADirectoryError),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+                side_effect=IsADirectoryError,
+            ),
             patch("ardupilot_methodic_configurator.backend_filesystem_json_with_schema.logging_error") as mock_error,
         ):
             # Act: User attempts to save to directory path
@@ -589,7 +601,10 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/test/directory/output.json",
             ),
-            patch("builtins.open", side_effect=os_error),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+                side_effect=os_error,
+            ),
             patch("ardupilot_methodic_configurator.backend_filesystem_json_with_schema.logging_error") as mock_error,
         ):
             # Act: User encounters OS error
@@ -619,7 +634,6 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/test/directory/output.json",
             ),
-            patch("builtins.open", mock_open()),
             patch(
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.json_dumps",
                 side_effect=TypeError("Object not serializable"),
@@ -652,7 +666,6 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/test/directory/output.json",
             ),
-            patch("builtins.open", mock_open()),
             patch(
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.json_dumps",
                 side_effect=ValueError("Circular reference in data"),
@@ -687,7 +700,10 @@ class TestJSONDataSaving:
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.os_path.join",
                 return_value="/test/directory/output.json",
             ),
-            patch("builtins.open", side_effect=unexpected_error),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
+                side_effect=unexpected_error,
+            ),
             patch("ardupilot_methodic_configurator.backend_filesystem_json_with_schema.logging_error") as mock_error,
         ):
             # Act: User encounters unexpected error
@@ -731,10 +747,10 @@ class TestFilesystemJSONWithSchemaIntegration:
             ),
             patch(
                 "builtins.open",
-                side_effect=[
-                    mock_open(read_data=json.dumps(schema_data)).return_value,  # Schema file
-                    mock_open().return_value,  # Data file for saving
-                ],
+                return_value=mock_open(read_data=json.dumps(schema_data)).return_value,  # Schema file
+            ),
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.safe_write",
             ),
             patch(
                 "ardupilot_methodic_configurator.backend_filesystem_json_with_schema.json_dumps",

--- a/tests/test_backend_filesystem_program_settings.py
+++ b/tests/test_backend_filesystem_program_settings.py
@@ -578,14 +578,16 @@ class TestSettingsFileOperations:
         with (
             patch.object(ProgramSettings, "_user_config_dir", return_value=mock_user_config["config_dir"]),
             patch("os.path.join", return_value=mock_user_config["settings_file"]),
-            patch("builtins.open", mock_open()) as mock_file,
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_program_settings.safe_write",
+            ) as mock_safe_write,
         ):
             # Act: Save settings to file
             ProgramSettings._set_settings_from_dict(mock_settings)
 
-            # Assert: File is opened correctly and data is written
-            mock_file.assert_called_once_with(mock_user_config["settings_file"], "w", encoding="utf-8", newline="\n")
-            mock_file().write.assert_called()
+            # Assert: safe_write is called with the correct file path
+            mock_safe_write.assert_called_once()
+            assert mock_safe_write.call_args[0][0] == mock_user_config["settings_file"]
 
 
 class TestUsagePopupSettings:

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -10,6 +10,8 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import io
+import json as json_mod
 import os.path
 from json.decoder import JSONDecodeError as RealJSONDecodeError
 from unittest.mock import mock_open, patch
@@ -633,12 +635,11 @@ class TestVehicleComponents:
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_basic(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
-        self, mock_get_base_dir, mock_makedirs, mock_json_dump, mock_file, mock_load_user, mock_load_system
+        self, mock_get_base_dir, mock_makedirs, mock_safe_write, mock_load_user, mock_load_system
     ) -> None:
         """
         Save Component Templates Basic.
@@ -652,6 +653,16 @@ class TestVehicleComponents:
         mock_load_system.return_value = {}
         mock_load_user.return_value = {}
 
+        # Capture written data via safe_write callback
+        captured_data = {}
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            captured_data.update(json_mod.loads(fake_file.getvalue()))
+
+        mock_safe_write.side_effect = capture_safe_write
+
         templates = {"Component1": [{"name": "Test Template", "data": {"param": "value"}, "is_user_modified": True}]}
 
         # Call method
@@ -664,29 +675,25 @@ class TestVehicleComponents:
         # Verify directory was created
         mock_makedirs.assert_called_once_with("/templates", exist_ok=True)
 
-        # Verify file was opened correctly
+        # Verify safe_write was called with the correct file path
         expected_path = os.path.join("/templates", "user_vehicle_components_template.json")
-        mock_file.assert_called_once_with(expected_path, "w", encoding="utf-8", newline="\n")
+        mock_safe_write.assert_called_once()
+        assert mock_safe_write.call_args[0][0] == expected_path
 
-        # Verify JSON was dumped with is_user_modified flag removed
+        # Verify JSON was written with is_user_modified flag removed
         expected_save = {"Component1": [{"name": "Test Template", "data": {"param": "value"}}]}
-        mock_json_dump.assert_called_once()
-        args, kwargs = mock_json_dump.call_args
-        assert args[0] == expected_save  # First argument should be the data
-        assert kwargs["indent"] == 4
+        assert captured_data == expected_save
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_only_modified(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,  # pylint: disable=unused-argument
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -717,6 +724,16 @@ class TestVehicleComponents:
         mock_load_system.return_value = system_templates
         mock_load_user.return_value = {}
 
+        # Capture and verify written data
+        captured_data = {}
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            captured_data.update(json_mod.loads(fake_file.getvalue()))
+
+        mock_safe_write.side_effect = capture_safe_write
+
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
 
@@ -726,22 +743,18 @@ class TestVehicleComponents:
 
         # Verify only Template A was saved (with is_user_modified flag removed)
         expected_save = {"Component1": [{"name": "Template A", "data": {"original": "value"}}]}
-        mock_json_dump.assert_called_once()
-        args, _kwargs = mock_json_dump.call_args
-        assert args[0] == expected_save
+        assert captured_data == expected_save
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_different_data(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,  # pylint: disable=unused-argument
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -766,6 +779,16 @@ class TestVehicleComponents:
         mock_load_system.return_value = system_templates
         mock_load_user.return_value = {}
 
+        # Capture and verify written data
+        captured_data = {}
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            captured_data.update(json_mod.loads(fake_file.getvalue()))
+
+        mock_safe_write.side_effect = capture_safe_write
+
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
 
@@ -775,22 +798,18 @@ class TestVehicleComponents:
 
         # Verify Template A was saved with new data
         expected_save = {"Component1": [{"name": "Template A", "data": {"modified": "new_value"}}]}
-        mock_json_dump.assert_called_once()
-        args, _kwargs = mock_json_dump.call_args
-        assert args[0] == expected_save
+        assert captured_data == expected_save
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_not_in_system(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,  # pylint: disable=unused-argument
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -816,6 +835,16 @@ class TestVehicleComponents:
         mock_load_system.return_value = system_templates
         mock_load_user.return_value = {}
 
+        # Capture and verify written data
+        captured_data = {}
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            captured_data.update(json_mod.loads(fake_file.getvalue()))
+
+        mock_safe_write.side_effect = capture_safe_write
+
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
 
@@ -825,9 +854,7 @@ class TestVehicleComponents:
 
         # Verify only the new template was saved
         expected_save = {"Component1": [{"name": "New Template", "data": {"new": "value"}}]}
-        mock_json_dump.assert_called_once()
-        args, _kwargs = mock_json_dump.call_args
-        assert args[0] == expected_save
+        assert captured_data == expected_save
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
@@ -860,12 +887,11 @@ class TestVehicleComponents:
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_directory_creation_error(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
-        self, mock_get_base_dir, mock_makedirs, mock_json_dump, mock_file, mock_load_user, mock_load_system
+        self, mock_get_base_dir, mock_makedirs, mock_safe_write, mock_load_user, mock_load_system
     ) -> None:
         """
         Save Component Templates Directory Creation Error.
@@ -888,21 +914,18 @@ class TestVehicleComponents:
         assert result  # True means error
         assert "Failed to create templates directory" in msg
         assert "Access denied" in msg
-        mock_file.assert_not_called()
-        mock_json_dump.assert_not_called()
+        mock_safe_write.assert_not_called()
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open")
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_file_errors(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,  # pylint: disable=unused-argument
-        mock_file,
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -918,7 +941,7 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Test permission error
-        mock_file.side_effect = PermissionError()
+        mock_safe_write.side_effect = PermissionError()
 
         templates = {"Component1": [{"name": "Test Template", "data": {"param": "value"}}]}
 
@@ -931,16 +954,14 @@ class TestVehicleComponents:
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_empty_input(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -955,6 +976,20 @@ class TestVehicleComponents:
         mock_load_system.return_value = {}
         mock_load_user.return_value = {}
 
+        # Capture and verify written data
+        captured_data: dict = {}
+        wrote_empty = [False]
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            value = fake_file.getvalue()
+            captured_data.update(json_mod.loads(value))
+            if json_mod.loads(value) == {}:
+                wrote_empty[0] = True
+
+        mock_safe_write.side_effect = capture_safe_write
+
         # Call method with empty dictionary
         result, msg = self.vehicle_components.save_component_templates({})
 
@@ -962,20 +997,18 @@ class TestVehicleComponents:
         assert not result  # False means success
         assert msg == "/templates/user_vehicle_components_template.json"
         # Should save empty dict
-        mock_json_dump.assert_called_once_with({}, mock_file(), indent=4)
+        assert wrote_empty[0], "Expected empty dict to be written"
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_json_error(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,  # pylint: disable=unused-argument
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -989,7 +1022,7 @@ class TestVehicleComponents:
         mock_get_base_dir.return_value = "/templates"
         mock_load_system.return_value = {}
         mock_load_user.return_value = {}
-        mock_json_dump.side_effect = TypeError("Cannot serialize circular reference")
+        mock_safe_write.side_effect = TypeError("Cannot serialize circular reference")
 
         templates = {"Component1": [{"name": "Test Template", "data": {"param": "value"}}]}
 
@@ -1051,16 +1084,14 @@ class TestVehicleComponents:
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_dump")
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_preserves_existing_user_components(  # type: ignore[misc] # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_get_base_dir,
         mock_makedirs,  # pylint: disable=unused-argument
-        mock_json_dump,
-        mock_file,  # pylint: disable=unused-argument
+        mock_safe_write,
         mock_load_user,
         mock_load_system,
     ) -> None:
@@ -1079,6 +1110,16 @@ class TestVehicleComponents:
         existing_user_templates = {"Battery": [{"name": "6S 5000mAh LiPo", "data": {"Capacity mAh": 5000, "Cells": 6}}]}
         mock_load_user.return_value = existing_user_templates
 
+        # Capture the write_func callback passed to safe_write to verify data
+        captured_data = {}
+
+        def capture_safe_write(_filepath, write_func) -> None:
+            fake_file = io.StringIO()
+            write_func(fake_file)
+            captured_data.update(json_mod.loads(fake_file.getvalue()))
+
+        mock_safe_write.side_effect = capture_safe_write
+
         # Save a new ESC template (Battery is NOT included in this call)
         templates_to_save = {"ESC": [{"name": "BLHeli32 60A", "data": {"protocol": "DSHOT600"}, "is_user_modified": True}]}
 
@@ -1088,20 +1129,19 @@ class TestVehicleComponents:
         assert not result  # False means success
         assert msg == "/templates/user_vehicle_components_template.json"
 
-        # Verify the data written to disk contains both components
-        mock_json_dump.assert_called_once()
-        written_data = mock_json_dump.call_args[0][0]
+        # Verify safe_write was called
+        mock_safe_write.assert_called_once()
 
         # Pre-existing Battery templates must be preserved
-        assert "Battery" in written_data, "Pre-existing Battery templates were lost after saving ESC template"
-        assert written_data["Battery"] == existing_user_templates["Battery"]
+        assert "Battery" in captured_data, "Pre-existing Battery templates were lost after saving ESC template"
+        assert captured_data["Battery"] == existing_user_templates["Battery"]
 
         # New ESC template must also be present
-        assert "ESC" in written_data, "Newly saved ESC template is missing"
-        assert len(written_data["ESC"]) == 1
-        assert written_data["ESC"][0]["name"] == "BLHeli32 60A"
+        assert "ESC" in captured_data, "Newly saved ESC template is missing"
+        assert len(captured_data["ESC"]) == 1
+        assert captured_data["ESC"][0]["name"] == "BLHeli32 60A"
         # is_user_modified flag must be stripped before writing
-        assert "is_user_modified" not in written_data["ESC"][0]
+        assert "is_user_modified" not in captured_data["ESC"][0]
 
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.FilesystemJSONWithSchema")
     def test_load_schema_invalid_json(self, mock_fs_class) -> None:

--- a/tests/unit_backend_filesystem_vehicle_components.py
+++ b/tests/unit_backend_filesystem_vehicle_components.py
@@ -87,10 +87,12 @@ class TestVehicleComponentsInternals:
         assert error is True
         assert "Failed to create templates directory" in msg
 
-    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
-    def test_save_component_templates_to_file_generic_exception(self, mock_get_base_dir, mock_makedirs, mock_file) -> None:
+    def test_save_component_templates_to_file_generic_exception(  # type: ignore[misc]
+        self, mock_get_base_dir, mock_makedirs, mock_safe_write
+    ) -> None:
         """
         Test internal error handling for unexpected exceptions.
 
@@ -100,7 +102,7 @@ class TestVehicleComponentsInternals:
         """
         mock_get_base_dir.return_value = "/test/templates"
         mock_makedirs.return_value = None
-        mock_file.side_effect = ValueError("Unexpected error")
+        mock_safe_write.side_effect = ValueError("Unexpected error")
 
         templates_to_save = {"Component1": [{"name": "Test", "data": {}}]}
 
@@ -109,10 +111,12 @@ class TestVehicleComponentsInternals:
         assert error is True
         assert "Unexpected error saving templates" in msg
 
-    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
-    def test_save_component_templates_to_file_permission_error(self, mock_get_base_dir, mock_makedirs, mock_file) -> None:
+    def test_save_component_templates_to_file_permission_error(  # type: ignore[misc]
+        self, mock_get_base_dir, mock_makedirs, mock_safe_write
+    ) -> None:
         """
         Test internal error handling for PermissionError.
 
@@ -122,7 +126,7 @@ class TestVehicleComponentsInternals:
         """
         mock_get_base_dir.return_value = "/test/templates"
         mock_makedirs.return_value = None
-        mock_file.side_effect = PermissionError("Access denied")
+        mock_safe_write.side_effect = PermissionError("Access denied")
 
         templates_to_save = {"Component1": [{"name": "Test", "data": {}}]}
 
@@ -131,10 +135,10 @@ class TestVehicleComponentsInternals:
         assert error is True
         assert "Permission denied" in msg
 
-    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
-    def test_save_component_templates_to_file_os_error(self, mock_get_base_dir, mock_makedirs, mock_file) -> None:
+    def test_save_component_templates_to_file_os_error(self, mock_get_base_dir, mock_makedirs, mock_safe_write) -> None:
         """
         Test internal error handling for OSError during file write.
 
@@ -144,7 +148,7 @@ class TestVehicleComponentsInternals:
         """
         mock_get_base_dir.return_value = "/test/templates"
         mock_makedirs.return_value = None
-        mock_file.side_effect = OSError("Disk full")
+        mock_safe_write.side_effect = OSError("Disk full")
 
         templates_to_save = {"Component1": [{"name": "Test", "data": {}}]}
 


### PR DESCRIPTION
## Summary

All file-writing operations used a simple `open("w") → write()` pattern. If the application crashes, the OS kills the process, or power is lost mid-write, the target file is left truncated or empty.

This is especially dangerous for:
- **`.param` files** — uploading an incomplete parameter set to a flight controller could cause unpredictable behavior
- **`vehicle_components.json`** — a corrupted components file breaks all derived parameter computations on next startup
- **`settings.json`** — a truncated settings file causes `JSONDecodeError`, losing user preferences

## Changes

Add a `safe_write()` utility (`backend_safe_file_io.py`) that writes to a temporary file in the same directory, then atomically replaces the target via `os.replace()`. The utility also:
- Flushes and fsyncs the file before replacing
- Preserves file permissions and ownership from the original target
- Fsyncs the parent directory after replace for full rename durability
- Cleans up temp files on failure

Applied to the four most critical persistence paths:
- `ParDict.export_to_param()` — `.param` files
- `FilesystemJSONWithSchema.save_json_data()` — JSON data files
- `ProgramSettings._set_settings_from_dict()` — `settings.json`
- `VehicleComponents.save_component_templates_to_file()` — vehicle templates

All save-related tests updated to patch `safe_write` directly and verify written data content via captured callbacks.

`os.replace()` is atomic on POSIX and near-atomic on Windows (`MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`).

Continuation of #1430 (accidentally closed after force push).
Closes #1428

Signed-off-by: Yash Goel <yashhzd@users.noreply.github.com>