### PR TITLE
fix(params): guard against inf/nan from safe_evaluate reaching FC upload

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
@@ -13,6 +13,7 @@ from json import load as json_load
 from logging import error as logging_error
 from logging import info as logging_info
 from logging import warning as logging_warning
+from math import isfinite
 from os import path as os_path
 from typing import Optional, TypedDict
 
@@ -160,7 +161,7 @@ class ConfigurationSteps:
                         parameter,
                     )
 
-    def compute_parameters(  # pylint: disable=too-many-branches, too-many-arguments, too-many-positional-arguments
+    def compute_parameters(  # noqa: PLR0911, PLR0915 # pylint: disable=too-many-branches, too-many-arguments, too-many-positional-arguments, too-many-return-statements, too-many-statements
         self,
         filename: str,
         file_info: dict,
@@ -233,6 +234,19 @@ class ConfigurationSteps:
                             return error_msg
                         logging_warning(error_msg)
                         continue
+
+                if isinstance(result, (int, float)) and not isfinite(result):
+                    error_msg = _(
+                        "In file '{self.configuration_steps_filename}': '{filename}' {parameter_type} "
+                        "parameter '{parameter}' evaluation produced a non-finite value: {result}"
+                    )
+                    error_msg = error_msg.format(**locals())
+                    if parameter_type == "forced":
+                        logging_error(error_msg)
+                        return error_msg
+                    if not ignore_fc_derived_param_warnings:
+                        logging_warning(error_msg)
+                    continue
 
                 if filename not in destination:
                     destination[filename] = ParDict()

--- a/tests/test_backend_filesystem_configuration_steps.py
+++ b/tests/test_backend_filesystem_configuration_steps.py
@@ -523,5 +523,41 @@ def test_safe_log_function_in_expression() -> None:
     assert abs(config_steps.forced_parameters["test_file"]["MOT_THST_EXPO"].value - 0.6) < 0.01
 
 
+def test_compute_forced_parameter_rejects_inf() -> None:
+    """Forced parameter evaluating to inf should return an error and not be stored."""
+    config_steps = ConfigurationSteps("vehicle_dir", "vehicle_type")
+    file_info = {"forced_parameters": {"PARAM1": {"New Value": "1e309", "Change Reason": "Test"}}}
+    variables = {"doc_dict": {"PARAM1": {"values": {}}}}
+
+    result = config_steps.compute_parameters("test_file", file_info, "forced", variables)
+
+    assert "non-finite" in result
+    assert "test_file" not in config_steps.forced_parameters
+
+
+def test_compute_forced_parameter_rejects_negative_inf() -> None:
+    """Forced parameter evaluating to -inf should return an error and not be stored."""
+    config_steps = ConfigurationSteps("vehicle_dir", "vehicle_type")
+    file_info = {"forced_parameters": {"PARAM1": {"New Value": "-1e309", "Change Reason": "Test"}}}
+    variables = {"doc_dict": {"PARAM1": {"values": {}}}}
+
+    result = config_steps.compute_parameters("test_file", file_info, "forced", variables)
+
+    assert "non-finite" in result
+    assert "test_file" not in config_steps.forced_parameters
+
+
+def test_compute_derived_parameter_skips_inf() -> None:
+    """Derived parameter evaluating to inf should be skipped without error."""
+    config_steps = ConfigurationSteps("vehicle_dir", "vehicle_type")
+    file_info = {"derived_parameters": {"PARAM1": {"New Value": "1e309", "Change Reason": "Test"}}}
+    variables = {"doc_dict": {"PARAM1": {"values": {}}}}
+
+    result = config_steps.compute_parameters("test_file", file_info, "derived", variables)
+
+    assert result == ""
+    assert "test_file" not in config_steps.derived_parameters
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`safe_evaluate()` can produce non-finite values (inf, nan) from expressions like `exp(1000)`, `log(0)`, or conditional branches. These values bypass the existing `ZeroDivisionError`/`ValueError` handlers and flow unchecked through `set_forced_or_derived_value()` to the flight controller.

## Changes

Add an `isfinite()` check on the evaluated result in `compute_parameters()` before creating the `Par` object. Non-finite values are rejected with a descriptive error message, consistent with the existing validation pattern for forced vs derived parameters.

This closes a gap where `isfinite()` checks existed for file-loaded parameters and user-entered values, but not for expression-evaluated results.

Closes #1438

Signed-off-by: Yash Goel <yashhzd@users.noreply.github.com>