### PR TITLE
refactor(tests): deduplicate capture_safe_write into conftest.py

### DIFF
--- a/ardupilot_methodic_configurator/backend_safe_file_io.py
+++ b/ardupilot_methodic_configurator/backend_safe_file_io.py
@@ -9,10 +9,12 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import io
+import json
 import os
 import tempfile
 from contextlib import suppress
-from typing import IO, Callable
+from typing import IO, Any, Callable
 
 
 def safe_write(filepath: str, write_func: Callable[[IO[str]], object]) -> None:
@@ -73,3 +75,38 @@ def safe_write(filepath: str, write_func: Callable[[IO[str]], object]) -> None:
         if not replaced:
             with suppress(OSError):
                 os.unlink(tmp_path)
+
+
+# ==================== SAFE-WRITE TEST HELPERS ====================
+
+
+def make_capture_safe_write() -> tuple[  # pragma: no cover
+    dict[str, Any], list[bool], Callable[[str, Callable[[IO[str]], object]], None]
+]:
+    """
+    Create a ``safe_write`` side-effect that captures written JSON data.
+
+    Returns a (captured_data, called, side_effect) triple:
+    - ``captured_data``: dict updated with the JSON that the write_func produces.
+    - ``called``: single-element list (``[False]``) flipped to ``True`` on invocation.
+    - ``side_effect``: function to assign to ``mock_safe_write.side_effect``.
+
+    Usage::
+
+        captured_data, called, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
+        ...
+        assert called[0]
+        assert captured_data == expected
+
+    """
+    captured_data: dict[str, Any] = {}
+    called: list[bool] = [False]
+
+    def _capture(_filepath: str, write_func: Callable[[IO[str]], object]) -> None:
+        fake_file = io.StringIO()
+        write_func(fake_file)
+        captured_data.update(json.loads(fake_file.getvalue()))
+        called[0] = True
+
+    return captured_data, called, _capture

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -10,8 +10,6 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import io
-import json as json_mod
 import os.path
 from json.decoder import JSONDecodeError as RealJSONDecodeError
 from unittest.mock import mock_open, patch
@@ -19,6 +17,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
+from ardupilot_methodic_configurator.backend_safe_file_io import make_capture_safe_write
 from ardupilot_methodic_configurator.data_model_template_overview import TemplateOverview
 
 # pylint: disable=too-many-lines,too-many-public-methods,attribute-defined-outside-init
@@ -654,14 +653,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Capture written data via safe_write callback
-        captured_data = {}
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            captured_data.update(json_mod.loads(fake_file.getvalue()))
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, _, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         templates = {"Component1": [{"name": "Test Template", "data": {"param": "value"}, "is_user_modified": True}]}
 
@@ -725,14 +718,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Capture and verify written data
-        captured_data = {}
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            captured_data.update(json_mod.loads(fake_file.getvalue()))
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, _, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
@@ -780,14 +767,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Capture and verify written data
-        captured_data = {}
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            captured_data.update(json_mod.loads(fake_file.getvalue()))
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, _, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
@@ -836,14 +817,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Capture and verify written data
-        captured_data = {}
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            captured_data.update(json_mod.loads(fake_file.getvalue()))
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, _, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         # Call method
         result, msg = self.vehicle_components.save_component_templates(templates)
@@ -977,18 +952,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = {}
 
         # Capture and verify written data
-        captured_data: dict = {}
-        wrote_empty = [False]
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            value = fake_file.getvalue()
-            captured_data.update(json_mod.loads(value))
-            if json_mod.loads(value) == {}:
-                wrote_empty[0] = True
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, called, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         # Call method with empty dictionary
         result, msg = self.vehicle_components.save_component_templates({})
@@ -997,7 +962,8 @@ class TestVehicleComponents:
         assert not result  # False means success
         assert msg == "/templates/user_vehicle_components_template.json"
         # Should save empty dict
-        assert wrote_empty[0], "Expected empty dict to be written"
+        assert called[0], "Expected empty dict to be written"
+        assert not captured_data, f"Expected empty dict, got {captured_data}"
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "_load_user_templates")
@@ -1111,14 +1077,8 @@ class TestVehicleComponents:
         mock_load_user.return_value = existing_user_templates
 
         # Capture the write_func callback passed to safe_write to verify data
-        captured_data = {}
-
-        def capture_safe_write(_filepath, write_func) -> None:
-            fake_file = io.StringIO()
-            write_func(fake_file)
-            captured_data.update(json_mod.loads(fake_file.getvalue()))
-
-        mock_safe_write.side_effect = capture_safe_write
+        captured_data, _, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
 
         # Save a new ESC template (Battery is NOT included in this call)
         templates_to_save = {"ESC": [{"name": "BLHeli32 60A", "data": {"protocol": "DSHOT600"}, "is_user_modified": True}]}


### PR DESCRIPTION
## Summary

- Extracted the `capture_safe_write` helper (defined 6 times in `test_backend_filesystem_vehicle_components.py`) into a single `make_capture_safe_write()` factory function in `conftest.py`
- Removed unused `io` and `json` imports from the test file
- All 132 related tests pass, ruff clean

Follow-up to #1437 as [requested by @amilcarlucas](https://github.com/ArduPilot/MethodicConfigurator/pull/1437#issuecomment-4148405219).