### PR TITLE
Fix macos tooltips final clean

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_show.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_show.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # https://wiki.tcl-lang.org/page/Changing+Widget+Colors
 
+import contextlib
 import tkinter as tk
 from platform import system as platform_system
 from tkinter import messagebox, ttk
@@ -508,7 +509,8 @@ class Tooltip:
     def _cancel_show(self) -> None:
         """Cancel any pending show timer."""
         if self.show_timer:
-            self.widget.after_cancel(self.show_timer)
+            with contextlib.suppress(tk.TclError):
+                self.widget.after_cancel(self.show_timer)
             self.show_timer = None
 
     def show(self, event: Optional[tk.Event] = None) -> None:  # noqa: ARG002 # pylint: disable=unused-argument
@@ -523,13 +525,16 @@ class Tooltip:
     def _cancel_hide(self, event: Optional[tk.Event] = None) -> None:  # noqa: ARG002 # pylint: disable=unused-argument
         """Cancel the hide timer."""
         if self.hide_timer:
-            self.widget.after_cancel(self.hide_timer)
+            with contextlib.suppress(tk.TclError):
+                self.widget.after_cancel(self.hide_timer)
             self.hide_timer = None
 
     def _hide_active_tooltip(self) -> None:
         """Hide another active tooltip before showing this one."""
         if Tooltip._active_tooltip and Tooltip._active_tooltip is not self:
-            Tooltip._active_tooltip.force_hide()
+            with contextlib.suppress(tk.TclError):
+                Tooltip._active_tooltip.force_hide()
+            Tooltip._active_tooltip = None
 
     def schedule_show(self, event: Optional[tk.Event] = None) -> None:  # noqa: ARG002 # pylint: disable=unused-argument
         """Delay tooltip creation slightly to avoid flicker during pointer movement."""
@@ -568,6 +573,9 @@ class Tooltip:
         )
         tooltip_label.pack()
         self.position_tooltip()
+
+        self.tooltip.update_idletasks()  # Force macOS to finish rendering text
+
         self.tooltip.deiconify()
         Tooltip._active_tooltip = self
 

--- a/tests/bdd_frontend_tkinter_show.py
+++ b/tests/bdd_frontend_tkinter_show.py
@@ -899,12 +899,12 @@ class TestTooltipFunctionality:  # pylint: disable=too-many-public-methods
         """
         with patch("ardupilot_methodic_configurator.frontend_tkinter_show.platform_system", return_value="Darwin"):
             tooltip = Tooltip(mock_widget, "Test text")
-        tooltip.tooltip = mock_toplevel
+            tooltip.tooltip = mock_toplevel  # Set the mock window while in "Mac mode"
 
-        tooltip.destroy_hide()
+            tooltip.destroy_hide()
 
-        mock_toplevel.destroy.assert_called_once()
-        assert tooltip.tooltip is None
+            mock_toplevel.destroy.assert_called_once()
+            assert tooltip.tooltip is None
 
     def test_tooltip_schedule_show_on_macos(self, mock_widget: MagicMock) -> None:
         """
@@ -916,10 +916,9 @@ class TestTooltipFunctionality:  # pylint: disable=too-many-public-methods
         """
         with patch("ardupilot_methodic_configurator.frontend_tkinter_show.platform_system", return_value="Darwin"):
             tooltip = Tooltip(mock_widget, "Test text")
+            tooltip.schedule_show()
 
-        tooltip.schedule_show()
-
-        mock_widget.after.assert_called_once_with(TOOLTIP_SHOW_DELAY_MS, tooltip.create_show)
+            mock_widget.after.assert_called_once_with(TOOLTIP_SHOW_DELAY_MS, tooltip.create_show)
 
     def test_tooltip_create_show_hides_previous_active_tooltip(self, mock_widget: MagicMock, mock_toplevel: MagicMock) -> None:
         """


### PR DESCRIPTION
continuing #1434

Adressed the copilot comments: The tooltips were not visible when hovering.

Fixed the test to pass the CI.


