### PR TITLE
fix: correct error message in directory removal

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -685,11 +685,11 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                         param.value = new_value
 
     def remove_created_files_and_vehicle_dir(self) -> str:
-        # Remove the created files in the new vehicle directory
+        # Remove the created files and the vehicle directory itself
         try:
             if not os_path.exists(self.vehicle_dir):
                 # Use the actual vehicle_dir value to avoid KeyError from missing format keys
-                error_msg = _("New vehicle directory does not exist: {vehicle_dir}")
+                error_msg = _("Vehicle directory to remove does not exist: {vehicle_dir}")
                 error_msg = error_msg.format(vehicle_dir=self.vehicle_dir)
                 logging_error(error_msg)
                 return error_msg

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -158,9 +158,9 @@ class TestLocalFilesystem(unittest.TestCase):  # pylint: disable=too-many-public
             patch("ardupilot_methodic_configurator.backend_filesystem.os_listdir") as mock_listdir,
         ):
             ret = filesystem.remove_created_files_and_vehicle_dir()
-            # Should return a non-empty error message mentioning the new vehicle directory
+            # Should return a non-empty error message mentioning the removed vehicle directory
             assert isinstance(ret, str)
-            assert "New vehicle directory does not exist" in ret
+            assert "Vehicle directory to remove does not exist" in ret
             # listdir must not have been called when directory doesn't exist
             assert not mock_listdir.called
             mock_exists.assert_called()


### PR DESCRIPTION
Fixes an incorrect error message in `remove_created_files_and_vehicle_dir`.

The previous message was a bit misleading in the context of directory removal.