### PR TITLE
Fix: Resolve ty linter warnings

### DIFF
--- a/ty.toml
+++ b/ty.toml
@@ -4,5 +4,6 @@ unresolved-attribute = "ignore"
 invalid-assignment = "ignore"
 unused-type-ignore-comment = "ignore"
 possibly-missing-attribute = "ignore"
+# These are mostly ty false positives for now. Revisit this at a later date once ty fixes this upstream.
 too-many-positional-arguments = "ignore"
 invalid-return-type = "ignore"


### PR DESCRIPTION
# Description
Fix #1504
Removed the global ignore for `too-many-positional-arguments` in ty.toml.

## Checklist

- [X] Run pre-commit checks locally
- [X] Verified by a human programmer
- [X] All commits are signed off (use `git commit --signoff`)
- [X] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [X] Documentation updated if needed
- [X] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [X] Unit tests pass (all including the edited)
- [] Integration tests pass
- [X] Manual testing performed
- [ ] Tested on flight controller hardware (*Not needed)
