### PR TITLE
fix(connection): prevent IndexError on malformed ChibiOS banner line

### DIFF
--- a/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
@@ -631,7 +631,8 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
 
         for i, msg in enumerate(banner_msgs):
             if "ChibiOS:" in msg:
-                os_custom_version = msg.split(" ")[1].strip()
+                parts = msg.split(" ", 1)
+                os_custom_version = parts[1].strip() if len(parts) > 1 else ""
                 hash_len1 = max(7, len(os_custom_version) - 1)
                 hash_len2 = max(7, len(self.info.os_custom_version) - 1)
                 hash_len = min(hash_len1, hash_len2)

--- a/tests/test_backend_flightcontroller_connection.py
+++ b/tests/test_backend_flightcontroller_connection.py
@@ -1518,6 +1518,41 @@ class TestFlightControllerConnectionBannerParsing:
         assert os_ver == ""
         assert index is None
 
+    def test_extract_chibios_version_handles_banner_without_trailing_space(self) -> None:
+        """
+        _extract_chibios_version_from_banner tolerates a malformed banner line with no space after the prefix.
+
+        GIVEN: Banner messages where the ChibiOS line has no space between the prefix and the version
+        WHEN: _extract_chibios_version_from_banner is called
+        THEN: An empty version string should be returned
+        AND: The index of the ChibiOS line should still be recorded
+        AND: No IndexError should be raised
+        """
+        connection = FlightControllerConnection(info=FlightControllerInfo())
+        banner_msgs = ["ArduCopter V4.5.0", "ChibiOS:"]
+
+        os_ver, index = connection._extract_chibios_version_from_banner(banner_msgs)
+
+        assert os_ver == ""
+        assert index == 1
+
+    def test_extract_chibios_version_handles_banner_with_only_prefix(self) -> None:
+        """
+        _extract_chibios_version_from_banner tolerates a banner line that is exactly the ChibiOS prefix.
+
+        GIVEN: A banner line consisting only of the 'ChibiOS:' prefix with no hash at all
+        WHEN: _extract_chibios_version_from_banner is called
+        THEN: An empty version string should be returned
+        AND: No IndexError should be raised
+        """
+        connection = FlightControllerConnection(info=FlightControllerInfo())
+        banner_msgs = ["ChibiOS:"]
+
+        os_ver, index = connection._extract_chibios_version_from_banner(banner_msgs)
+
+        assert os_ver == ""
+        assert index == 0
+
     def test_extract_firmware_type_from_message_after_chibios(self) -> None:
         """
         _extract_firmware_type_from_banner extracts type from message after ChibiOS line.


### PR DESCRIPTION
## Summary

`FlightControllerConnection._extract_chibios_version_from_banner` crashes with `IndexError: list index out of range` when a banner line starting with `ChibiOS:` does not contain a space followed by a version hash. This can happen with a truncated banner (`ChibiOS:`) or a non-standard banner that packs the hash directly after the prefix without a space (`ChibiOS:abc1234`). In both cases `msg.split(" ")[1]` indexes past the end of the split result, the IndexError propagates out of `get_fc_version_and_type`, and the whole flight-controller connection setup aborts.

## Reproduction

```python
>>> "ChibiOS:".split(" ")[1]
Traceback (most recent call last):
IndexError: list index out of range
```

Any autopilot firmware that emits a malformed banner (or a banner that gets truncated at the point where AMC stops collecting STATUSTEXT frames) triggers this code path.

## Fix

Use `split(\" \", 1)` and guard the length before indexing, falling back to an empty version string. The surrounding code already handles an empty `os_custom_version` correctly: it logs a mismatch warning against `self.info.os_custom_version`, sets the `os_custom_version_index`, and continues.

Diff in the affected file:

```python
# before
os_custom_version = msg.split(\" \")[1].strip()

# after
parts = msg.split(\" \", 1)
os_custom_version = parts[1].strip() if len(parts) > 1 else \"\"
```

## Tests

Added two BDD-named tests alongside the existing `TestFlightControllerConnectionBannerParsing` class:

* `test_extract_chibios_version_handles_banner_without_trailing_space` — banner ends with the `ChibiOS:` prefix and no hash; expects empty version, recorded index, no IndexError.
* `test_extract_chibios_version_handles_banner_with_only_prefix` — single-message banner consisting only of the `ChibiOS:` prefix; same expectations.

Both tests fail on master and pass with this change. Full `tests/test_backend_flightcontroller_connection.py` suite: 102 passed locally.

## Lint / type checks

* `ruff check ardupilot_methodic_configurator/backend_flightcontroller_connection.py tests/test_backend_flightcontroller_connection.py` — clean.
* `mypy ardupilot_methodic_configurator/backend_flightcontroller_connection.py` — clean.
* `pylint ardupilot_methodic_configurator/backend_flightcontroller_connection.py tests/test_backend_flightcontroller_connection.py` — 10.00/10.

DCO: commit is signed off.