### PR TITLE
fix(connection): address Copilot review comments on PR #1527

### DIFF
--- a/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_connection.py
@@ -638,7 +638,7 @@ class FlightControllerConnection:  # pylint: disable=too-many-instance-attribute
                 hash_len = min(hash_len1, hash_len2)
                 if os_custom_version[:hash_len] != self.info.os_custom_version[:hash_len]:
                     logging_warning(
-                        _("ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"),
+                        _("ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"),
                         os_custom_version,
                         self.info.os_custom_version,
                     )

--- a/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/de/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -976,7 +976,7 @@ msgstr ""
 "Melden Sie sich danach ab und wieder an, damit die Änderungen wirksam werden."
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:640
-msgid "ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"
+msgid "ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 msgstr "ChibiOS Versionskonflikt: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:706

--- a/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/it/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -989,7 +989,7 @@ msgstr ""
 "effetto."
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:640
-msgid "ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"
+msgid "ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 msgstr ""
 "Incompatibilità versione ChibiOS: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 

--- a/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/ja/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -965,7 +965,7 @@ msgstr ""
 "その後、ログアウトして再度ログインすると変更が有効になります。"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:640
-msgid "ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"
+msgid "ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 msgstr "ChibiOSバージョンの不一致: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:706

--- a/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/pt/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -982,7 +982,7 @@ msgstr ""
 "tenham efeito."
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:640
-msgid "ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"
+msgid "ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 msgstr ""
 "Incompatibilidade de versão ChibiOS: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 

--- a/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
+++ b/ardupilot_methodic_configurator/locale/zh_CN/LC_MESSAGES/ardupilot_methodic_configurator.po
@@ -908,7 +908,7 @@ msgstr ""
 "然后注销并重新登录以使更改生效。"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:640
-msgid "ChibiOS version mismatch: %s (BANNER) != % s (AUTOPILOT_VERSION)"
+msgid "ChibiOS version mismatch: %s (BANNER) != %s (AUTOPILOT_VERSION)"
 msgstr "ChibiOS版本不匹配：%s (BANNER) != %s (AUTOPILOT_VERSION)"
 
 #: ardupilot_methodic_configurator/backend_flightcontroller_connection.py:706

--- a/tests/test_backend_flightcontroller_connection.py
+++ b/tests/test_backend_flightcontroller_connection.py
@@ -1518,11 +1518,11 @@ class TestFlightControllerConnectionBannerParsing:
         assert os_ver == ""
         assert index is None
 
-    def test_extract_chibios_version_handles_banner_without_trailing_space(self) -> None:
+    def test_extract_chibios_version_handles_banner_truncated_after_prefix(self) -> None:
         """
-        _extract_chibios_version_from_banner tolerates a malformed banner line with no space after the prefix.
+        _extract_chibios_version_from_banner tolerates a banner truncated immediately after the ChibiOS prefix.
 
-        GIVEN: Banner messages where the ChibiOS line has no space between the prefix and the version
+        GIVEN: Banner messages where the ChibiOS line has no hash and no separator after the prefix
         WHEN: _extract_chibios_version_from_banner is called
         THEN: An empty version string should be returned
         AND: The index of the ChibiOS line should still be recorded
@@ -1547,6 +1547,23 @@ class TestFlightControllerConnectionBannerParsing:
         """
         connection = FlightControllerConnection(info=FlightControllerInfo())
         banner_msgs = ["ChibiOS:"]
+
+        os_ver, index = connection._extract_chibios_version_from_banner(banner_msgs)
+
+        assert os_ver == ""
+        assert index == 0
+
+    def test_extract_chibios_version_handles_hash_packed_without_space(self) -> None:
+        """
+        _extract_chibios_version_from_banner tolerates a banner where the hash is packed directly after the prefix.
+
+        GIVEN: A banner line where the version hash follows the 'ChibiOS:' prefix without a separating space
+        WHEN: _extract_chibios_version_from_banner is called
+        THEN: An empty version string should be returned (rather than crashing with IndexError)
+        AND: The index of the ChibiOS line should still be recorded
+        """
+        connection = FlightControllerConnection(info=FlightControllerInfo())
+        banner_msgs = ["ChibiOS:abc1234567"]
 
         os_ver, index = connection._extract_chibios_version_from_banner(banner_msgs)
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1527 addressing three review comments from the Copilot bot.

## Changes

1. **Fix `% s` printf placeholder typo** (`backend_flightcontroller_connection.py:641`)
   The ChibiOS version mismatch warning used `% s` (with a space) in the format string, which is not a valid printf placeholder. On a mismatch, `logging.warning` would silently fail to format the second argument. My banner fix in #1527 made this path more reachable because malformed banners now yield an empty `os_custom_version` that compares unequal to `self.info.os_custom_version`.

2. **Tighten docstring of truncated-banner test**
   The docstring of `test_extract_chibios_version_handles_banner_without_trailing_space` said 'no space between the prefix and the version', but the fixture `\"ChibiOS:\"` has no version at all. Renamed to `test_extract_chibios_version_handles_banner_truncated_after_prefix` with a docstring that matches the fixture ('truncated immediately after the ChibiOS prefix').

3. **Add regression test for `ChibiOS:abc1234` variant**
   PR #1527's description listed two malformed-input shapes, but only `\"ChibiOS:\"` had explicit coverage. Added `test_extract_chibios_version_handles_hash_packed_without_space` exercising the version-packed-after-prefix form to lock in that it returns an empty version instead of raising IndexError.

## Translation files

The `% s` string appears as a `msgid` in five `.po` files (de, it, ja, pt, zh_CN). All five already had the correct `%s` in their `msgstr` — only the `msgid` side carried the typo. Updated the `msgid` in all five so existing translations stay bound to the new source string.

## Tests

`tests/test_backend_flightcontroller_connection.py::TestFlightControllerConnectionBannerParsing` — 10 passed locally. Full file suite (102 tests) passes.

## Lint / type checks

* `ruff check ardupilot_methodic_configurator/backend_flightcontroller_connection.py tests/test_backend_flightcontroller_connection.py` — clean.
* `mypy ardupilot_methodic_configurator/backend_flightcontroller_connection.py` — clean.
* `pylint ardupilot_methodic_configurator/backend_flightcontroller_connection.py tests/test_backend_flightcontroller_connection.py` — 10.00/10.

DCO: commit is signed off.