### PR TITLE
fix(connection): release flight controller on connection window close

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_connection_selection.py
@@ -319,6 +319,7 @@ class ConnectionSelectionWindow(BaseWindow):
         self.root.geometry(self.calculate_scaled_geometry(520, 380))
         self.center_window_on_screen(self.root)
         self.default_baudrate = default_baudrate
+        self.flight_controller = flight_controller
 
         # Explain why we are here
         if flight_controller.comport is None:
@@ -413,6 +414,8 @@ class ConnectionSelectionWindow(BaseWindow):
         # Stop periodic refresh when window is closing
         if hasattr(self, "connection_selection_widgets"):
             self.connection_selection_widgets.stop_periodic_refresh()
+        # Release the flight controller connection so the serial port is not left locked
+        self.flight_controller.disconnect()
         sys_exit(0)
 
     def fc_autoconnect(self) -> None:

--- a/tests/test_frontend_tkinter_connection_selection.py
+++ b/tests/test_frontend_tkinter_connection_selection.py
@@ -425,6 +425,22 @@ class TestConnectionSelectionWindow:
             window.close_and_quit()
         mock_widgets.stop_periodic_refresh.assert_called_once()
 
+    def test_close_and_quit_disconnects_flight_controller(
+        self, connection_window: tuple[ConnectionSelectionWindow, MagicMock], mock_fc: MagicMock
+    ) -> None:
+        """
+        The flight controller connection is released when the user closes the connection window.
+
+        GIVEN: The connection window is open and bound to a flight controller instance
+        WHEN: The user closes the window via the window manager (X button)
+        THEN: disconnect should be called on the flight controller before the process exits
+        AND: The underlying serial port is not left locked for the next launch
+        """
+        window, _ = connection_window
+        with patch(f"{_MOD}.sys_exit"):
+            window.close_and_quit()
+        mock_fc.disconnect.assert_called_once()
+
     def test_fc_autoconnect(self, connection_window: tuple[ConnectionSelectionWindow, MagicMock]) -> None:
         """Test fc_autoconnect method calls reconnect."""
         window, _ = connection_window


### PR DESCRIPTION
Fixes #1525.

## Summary

`ConnectionSelectionWindow.close_and_quit()` called `sys_exit(0)` without first calling `flight_controller.disconnect()`. When the user closed the window via the window manager (X button, Cmd-Q, Alt-F4) instead of using one of the in-window buttons, the MAVLink link and the underlying serial port were left open until the OS reclaimed the file descriptor.

On Windows this left the COM port locked long enough that relaunching AMC, or running `mavproxy` / Mission Planner against the same port, hit a `PermissionError` on open. `skip_fc_connection()` on the same class already calls `flight_controller.disconnect()` before destroying the window, so `close_and_quit` was the inconsistent path.

## Fix

Store the `flight_controller` reference on the window in `__init__` and call `disconnect()` from `close_and_quit`, mirroring the skip path.

## Tests

New regression test `test_close_and_quit_disconnects_flight_controller` patches `sys_exit` and asserts the mock flight controller's `disconnect()` is called when `close_and_quit` fires, sibling to the existing `test_skip_fc_connection` that checks the same invariant on the other exit path.

`tests/test_frontend_tkinter_connection_selection.py` — 51 passed locally.

## Lint / type checks

* `ruff check` on the changed files — clean.
* `pylint` on the changed files — 10.00/10.

DCO: commit is signed off.