### PR TITLE
Auto import params

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -421,6 +421,10 @@ These files are crucial for the tool's operation and are organized in a specific
   The `configuration_steps_ArduCopter.json` documentation file is first searched in the selected vehicle-specific directory,
   and if not found, in the directory where the script is located.
 
+- **Configuration Steps File**: The `configuration_steps_*.json` files (like `configuration_steps_ArduCopter.json`) define the workflow,
+ for each intermediate parameter file. They provide the documentation links, explanations("why" and "why now"), mandatory/optional percentages,
+ and advanced logic rules like `autoimport_nondefault_regexp` to automatically pull specific non-default parameters from the live flight controller into the GUI.
+
 - **Default Parameter Values File**: The `00_defaults.param` file is located in the vehicle-specific directory.
   If the file does not exist or is invalid, use this command to regenerate it
 

--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -567,16 +567,16 @@ def process_component_editor_results(
 
     """
     # Get existing FC parameters for reference
-    fc_param_names: dict[str, float] = {}
+    fc_parameters: dict[str, float] = {}
     if flight_controller.fc_parameters:
-        fc_param_names = flight_controller.fc_parameters
+        fc_parameters = flight_controller.fc_parameters
     elif local_filesystem.param_default_dict:
         # Extract the float values from the ParDict objects
-        fc_param_names = {k: v.value for k, v in local_filesystem.param_default_dict.items()}
+        fc_parameters = {k: v.value for k, v in local_filesystem.param_default_dict.items()}
 
     try:
         component_dependent_param_changes = local_filesystem.calculate_derived_and_forced_param_changes(
-            fc_param_names=fc_param_names,
+            fc_parameters=fc_parameters,
         )
     except ValueError as e:
         error_msg = str(e)

--- a/ardupilot_methodic_configurator/__main__.py
+++ b/ardupilot_methodic_configurator/__main__.py
@@ -567,11 +567,12 @@ def process_component_editor_results(
 
     """
     # Get existing FC parameters for reference
-    fc_param_names: list[str] = []
+    fc_param_names: dict[str, float] = {}
     if flight_controller.fc_parameters:
-        fc_param_names = list(flight_controller.fc_parameters.keys())
+        fc_param_names = flight_controller.fc_parameters
     elif local_filesystem.param_default_dict:
-        fc_param_names = list(local_filesystem.param_default_dict.keys())
+        # Extract the float values from the ParDict objects
+        fc_param_names = {k: v.value for k, v in local_filesystem.param_default_dict.items()}
 
     try:
         component_dependent_param_changes = local_filesystem.calculate_derived_and_forced_param_changes(

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -10,7 +10,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 # from sys import exit as sys_exit
-import re
 from argparse import ArgumentParser
 from logging import debug as logging_debug
 from logging import error as logging_error
@@ -836,26 +835,9 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
             variables["doc_dict"] = self.doc_dict
         return variables
 
-    def _auto_import_params(
-        self, step_dict: dict[str, Any], fc_param_names: Union[list[str], dict[str, float]], working: ParDict
-    ) -> None:
-        # Only run if the dict of values was passed, and the regex rule exists
-        if "autoimport_nondefault_regexp" not in step_dict or not isinstance(fc_param_names, dict):
-            return
-
-        regex_rules = step_dict["autoimport_nondefault_regexp"]
-        for live_key, live_value in fc_param_names.items():
-            if live_key in working:
-                continue
-
-            if any(re.match(pattern, live_key) for pattern in regex_rules) and live_key in self.param_default_dict:
-                default_value = self.param_default_dict[live_key].value
-                if not is_within_tolerance(live_value, default_value):
-                    working[live_key] = Par(float(live_value), "")
-
     def calculate_derived_and_forced_param_changes(
         self,
-        fc_param_names: Union[list[str], dict[str, float]],
+        fc_parameters: Union[list[str], dict[str, float]],
     ) -> dict[str, ParDict]:
         """
         Compute updated parameter values without mutating the in-memory data model.
@@ -872,7 +854,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         disk call :meth:`save_vehicle_params_to_files` afterwards.
 
         Args:
-            fc_param_names: List of parameter names or dictionary of parameter values from the FC.
+            fc_parameters: List of parameter names or dictionary of parameter values from the FC.
                             If empty or None all parameters are assumed to exist.
 
         Returns:
@@ -886,7 +868,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
 
         Example:
             computed_changes = fs.calculate_derived_and_forced_param_changes(
-                fc_param_names=["PARAM1"],
+                fc_parameters=["PARAM1"],
             )
             if computed_changes:
                 if user_confirms:
@@ -915,7 +897,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 if error_msg:
                     msg = f"Error computing forced parameters for {param_filename}: {error_msg}"
                     raise ValueError(msg)
-                self.merge_forced_or_derived_parameters(param_filename, self.forced_parameters, fc_param_names, target=working)
+                self.merge_forced_or_derived_parameters(param_filename, self.forced_parameters, fc_parameters, target=working)
 
                 error_msg = self.compute_parameters(
                     param_filename, step_dict, "derived", eval_variables, ignore_fc_derived_param_warnings=True
@@ -923,11 +905,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 if error_msg:
                     msg = f"Error computing derived parameters for {param_filename}: {error_msg}"
                     raise ValueError(msg)
-                self.merge_forced_or_derived_parameters(
-                    param_filename, self.derived_parameters, fc_param_names, target=working
-                )
-
-                self._auto_import_params(step_dict, fc_param_names, working)
+                self.merge_forced_or_derived_parameters(param_filename, self.derived_parameters, fc_parameters, target=working)
 
             # Include in computed_changes if the working copy differs from the loaded in-memory state
             if working.differs_from(param_dict):
@@ -962,7 +940,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         self,
         filename: str,
         new_parameters: dict[str, ParDict],
-        fc_param_names: Optional[Union[list[str], dict[str, float]]],
+        fc_parameters: Optional[Union[list[str], dict[str, float]]],
         target: Optional[ParDict] = None,
     ) -> bool:
         """
@@ -971,7 +949,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         Args:
             filename: The name of the parameter file.
             new_parameters: Dictionary of new parameters to potentially merge.
-            fc_param_names: Optional list of flight controller parameter names.
+            fc_parameters: Optional list of flight controller parameter names.
             target: ParDict to merge into.  When *None* (default), merges into
                     ``self.file_parameters[filename]`` (legacy behaviour used by the
                     parameter-editor upload path).  Pass the working copy from
@@ -988,7 +966,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
 
         at_least_one_param_changed = False
         for param_name, param in new_parameters[filename].items():
-            if fc_param_names is None or not fc_param_names or param_name in fc_param_names:
+            if fc_parameters is None or not fc_parameters or param_name in fc_parameters:
                 if param_name in dest:
                     if not is_within_tolerance(dest[param_name].value, param.value):
                         at_least_one_param_changed = True

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 # from sys import exit as sys_exit
+import re
 from argparse import ArgumentParser
 from logging import debug as logging_debug
 from logging import error as logging_error
@@ -835,9 +836,26 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
             variables["doc_dict"] = self.doc_dict
         return variables
 
+    def _auto_import_params(
+        self, step_dict: dict[str, Any], fc_param_names: Union[list[str], dict[str, float]], working: ParDict
+    ) -> None:
+        # Only run if the dict of values was passed, and the regex rule exists
+        if "autoimport_nondefault_regexp" not in step_dict or not isinstance(fc_param_names, dict):
+            return
+
+        regex_rules = step_dict["autoimport_nondefault_regexp"]
+        for live_key, live_value in fc_param_names.items():
+            if live_key in working:
+                continue
+
+            if any(re.match(pattern, live_key) for pattern in regex_rules) and live_key in self.param_default_dict:
+                default_value = self.param_default_dict[live_key].value
+                if not is_within_tolerance(live_value, default_value):
+                    working[live_key] = Par(float(live_value), "")
+
     def calculate_derived_and_forced_param_changes(
         self,
-        fc_param_names: list[str],
+        fc_param_names: Union[list[str], dict[str, float]],
     ) -> dict[str, ParDict]:
         """
         Compute updated parameter values without mutating the in-memory data model.
@@ -854,7 +872,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         disk call :meth:`save_vehicle_params_to_files` afterwards.
 
         Args:
-            fc_param_names: List of parameter names that exist in the FC.
+            fc_param_names: List of parameter names or dictionary of parameter values from the FC.
                             If empty or None all parameters are assumed to exist.
 
         Returns:
@@ -909,6 +927,8 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                     param_filename, self.derived_parameters, fc_param_names, target=working
                 )
 
+                self._auto_import_params(step_dict, fc_param_names, working)
+
             # Include in computed_changes if the working copy differs from the loaded in-memory state
             if working.differs_from(param_dict):
                 computed_changes[param_filename] = working
@@ -942,7 +962,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         self,
         filename: str,
         new_parameters: dict[str, ParDict],
-        fc_param_names: Optional[list[str]],
+        fc_param_names: Optional[Union[list[str], dict[str, float]]],
         target: Optional[ParDict] = None,
     ) -> bool:
         """

--- a/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
+++ b/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
@@ -124,6 +124,7 @@
             "external_tool_url": "",
             "mandatory_text": "100% mandatory (0% optional)",
             "auto_changed_by": "",
+            "autoimport_nondefault_regexp": ["BATT.*"],
             "forced_parameters": {
                 "BATT_FS_CRT_ACT": { "New Value": 1, "Change Reason": "Land ASAP" },
                 "BATT_FS_LOW_ACT": { "New Value": 2, "Change Reason": "Return and land at home or rally point" }
@@ -169,6 +170,7 @@
             "external_tool_url": "",
             "mandatory_text": "100% mandatory (0% optional)",
             "auto_changed_by": "",
+            "autoimport_nondefault_regexp": ["GPS.*", "GNSS.*"],
             "derived_parameters": {
                 "GPS_TYPE": { "New Value": "vehicle_components['GNSS Receiver']['FC Connection']['Protocol']", "Change Reason": "Defined in component editor" },
                 "GPS1_TYPE": { "New Value": "vehicle_components['GNSS Receiver']['FC Connection']['Protocol']", "Change Reason": "Defined in component editor" }

--- a/ardupilot_methodic_configurator/configuration_steps_schema.json
+++ b/ardupilot_methodic_configurator/configuration_steps_schema.json
@@ -23,6 +23,13 @@
               "type": "string",
               "description": "Explanation of why this step is needed"
             },
+            "autoimport_nondefault_regexp": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of regular expressions to match parameters for automatic import if they have non-default values."
+            },
             "why_now": {
               "type": "string",
               "description": "Explanation of why this step needs to be done at this point"

--- a/ardupilot_methodic_configurator/configuration_steps_strings.py
+++ b/ardupilot_methodic_configurator/configuration_steps_strings.py
@@ -344,6 +344,9 @@ def configuration_steps_descriptions() -> None:
 
     For pygettext to extract them, they have no other function
     """
+    _config_steps_descriptions = _(
+        "A list of regular expressions to match parameters for automatic import if they have non-default values."
+    )
     _config_steps_descriptions = _("Description of the phase")
     _config_steps_descriptions = _("Explanation of why this step is needed")
     _config_steps_descriptions = _("Explanation of why this step needs to be done at this point")

--- a/ardupilot_methodic_configurator/data_model_configuration_step.py
+++ b/ardupilot_methodic_configurator/data_model_configuration_step.py
@@ -11,13 +11,14 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import re
 from logging import info as logging_info
 from typing import Any, Optional
 
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
 from ardupilot_methodic_configurator.data_model_ardupilot_parameter import ArduPilotParameter
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict
+from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict, is_within_tolerance
 from ardupilot_methodic_configurator.data_model_safe_evaluator import safe_evaluate
 
 
@@ -100,10 +101,10 @@ class ConfigurationStepProcessor:
             # Collect derived parameter values to apply later in domain model
             elif selected_file in self.local_filesystem.derived_parameters:
                 # Filter derived parameters that exist in FC (if fc_parameters provided)
-                fc_param_names = set(fc_parameters.keys()) if fc_parameters else set()
+                fc_param_keys = set(fc_parameters.keys()) if fc_parameters else set()
                 for param_name, param in self.local_filesystem.derived_parameters[selected_file].items():
                     # Only include if no FC filter OR parameter exists in FC
-                    if not fc_param_names or param_name in fc_param_names:
+                    if not fc_param_keys or param_name in fc_param_keys:
                         derived_params_to_apply[param_name] = param
 
             # Populate new_connection_prefix from rename_connection configuration step (per-step scope)
@@ -123,6 +124,9 @@ class ConfigurationStepProcessor:
         # Create domain model parameters
         current_step_parameters = self._create_domain_model_parameters(selected_file, fc_parameters)
 
+        # Call the _apply_auto_imports import
+        self._apply_auto_imports(selected_file, fc_parameters, current_step_parameters)
+
         # Check for ExpressLRS and add FLTMODE_CH warning
         if current_step_parameters.get("RC_OPTIONS") is not None or current_step_parameters.get("FLTMODE_CH") is not None:
             rc_options = int(fc_parameters.get("RC_OPTIONS", 32))
@@ -141,6 +145,34 @@ class ConfigurationStepProcessor:
                     )
 
         return current_step_parameters, ui_errors, ui_infos, duplicates_to_remove, renames_to_apply, derived_params_to_apply
+
+    def _apply_auto_imports(
+        self,
+        selected_file: str,
+        fc_parameters: dict[str, float],
+        current_step_parameters: dict[str, ArduPilotParameter],
+    ) -> None:
+        """Automatically import non-default FC parameters matching regex rules into the domain model."""
+        step_dict = self.local_filesystem.configuration_steps.get(selected_file, {})
+        if "autoimport_nondefault_regexp" not in step_dict or not fc_parameters:
+            return
+
+        regex_rules = step_dict["autoimport_nondefault_regexp"]
+        for live_key, live_value in fc_parameters.items():
+            if live_key in current_step_parameters:
+                continue
+
+            is_matching_regex = any(re.match(pattern, live_key) for pattern in regex_rules)
+            is_in_defaults = live_key in self.local_filesystem.param_default_dict
+
+            if is_matching_regex and is_in_defaults:
+                default_value = self.local_filesystem.param_default_dict[live_key].value
+                if not is_within_tolerance(live_value, default_value):
+                    # Create the parameter with a blank reason and inject it into the UI domain model
+                    param = Par(float(live_value), "")
+                    current_step_parameters[live_key] = self.create_ardupilot_parameter(
+                        live_key, param, selected_file, fc_parameters
+                    )
 
     def _handle_connection_renaming(
         self, selected_file: str, variables: dict

--- a/tests/acceptance_template_import_from_params.py
+++ b/tests/acceptance_template_import_from_params.py
@@ -225,9 +225,9 @@ def perform_component_inference(
     local_filesystem.load_vehicle_components_json_data(new_vehicle_dir)
 
     # Regenerate parameter files from the inferred component data
-    fc_param_names = list(fc_parameters.keys())
+    fc_parameters = list(fc_parameters.keys())
     try:
-        pending = local_filesystem.calculate_derived_and_forced_param_changes(fc_param_names=fc_param_names)
+        pending = local_filesystem.calculate_derived_and_forced_param_changes(fc_parameters=fc_parameters)
     except ValueError as e:
         return False, f"Failed to update and export parameters: {e}"
     local_filesystem.apply_computed_changes(pending)

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1259,7 +1259,7 @@ class TestComponentEditorHelperFunctions:
         # Assert: FC parameter names used as existing-parameter reference
         mock_filesystem.calculate_derived_and_forced_param_changes.assert_called_once()
         call_args = mock_filesystem.calculate_derived_and_forced_param_changes.call_args
-        assert call_args.kwargs["fc_param_names"] == {"PARAM1": 1.0, "PARAM2": 2.0}
+        assert call_args.kwargs["fc_parameters"] == {"PARAM1": 1.0, "PARAM2": 2.0}
 
         # Assert: No disk write - in-memory model already matches disk when pending list is empty
         mock_filesystem.save_vehicle_params_to_files.assert_not_called()

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1259,7 +1259,7 @@ class TestComponentEditorHelperFunctions:
         # Assert: FC parameter names used as existing-parameter reference
         mock_filesystem.calculate_derived_and_forced_param_changes.assert_called_once()
         call_args = mock_filesystem.calculate_derived_and_forced_param_changes.call_args
-        assert call_args.kwargs["fc_param_names"] == ["PARAM1", "PARAM2"]
+        assert call_args.kwargs["fc_param_names"] == {"PARAM1": 1.0, "PARAM2": 2.0}
 
         # Assert: No disk write - in-memory model already matches disk when pending list is empty
         mock_filesystem.save_vehicle_params_to_files.assert_not_called()

--- a/tests/test_data_model_configuration_step.py
+++ b/tests/test_data_model_configuration_step.py
@@ -190,6 +190,56 @@ class TestConfigurationStepProcessorWorkflows:
         # Should have info messages about parameter renaming since configuration includes rename_connection
         assert len(ui_infos) > 0
 
+    def test_user_can_auto_import_nondefault_parameters_matching_regex(self, processor) -> None:
+        """
+        User can automatically import non-default flight controller parameters that match regex rules.
+
+        GIVEN: A configuration step with auto-import regex rules
+        WHEN: The step is processed with live FC parameters
+        THEN: Non-default matching parameters are added to the domain model with a blank reason
+        AND: Parameters already in the file or matching firmware defaults are not overridden
+        """
+        # Arrange: Set up configuration with regex rules and mixed FC states
+        selected_file = "test_file.param"
+        processor.local_filesystem.configuration_steps = {selected_file: {"autoimport_nondefault_regexp": ["BATT.*", "GPS.*"]}}
+        processor.local_filesystem.param_default_dict = {
+            "BATT_OPTIONS": Par(value=0.0, comment="Default option"),
+            "BATT_MONITOR": Par(value=0.0, comment="Default monitor"),
+            "GPS_TYPE": Par(value=0.0, comment="Default type"),
+        }
+        processor.local_filesystem.file_parameters = {
+            selected_file: {
+                "BATT_MONITOR": Par(value=4.0, comment="User comment")  # Already exists in file
+            }
+        }
+        test_fc_parameters = {
+            "BATT_OPTIONS": 5.0,  # Non-default, matching regex -> MUST IMPORT
+            "BATT_MONITOR": 4.0,  # Already in file -> MUST SKIP
+            "GPS_TYPE": 0.0,  # Default value -> MUST SKIP
+            "SERIAL1_BAUD": 115200.0,  # Doesn't match regex -> MUST SKIP
+        }
+
+        # Act: Process configuration step
+        parameters, ui_errors, _, _, _, _ = processor.process_configuration_step(selected_file, test_fc_parameters)
+
+        # Assert: No errors
+        assert ui_errors == []
+
+        # BATT_OPTIONS should be auto-imported with a blank reason
+        assert "BATT_OPTIONS" in parameters
+        assert parameters["BATT_OPTIONS"]._value_on_file == 5.0
+        assert parameters["BATT_OPTIONS"].change_reason == ""
+
+        # BATT_MONITOR should remain untouched (protecting the user comment)
+        assert "BATT_MONITOR" in parameters
+        assert parameters["BATT_MONITOR"].change_reason == "User comment"
+
+        # GPS_TYPE should NOT be imported (it is at default value)
+        assert "GPS_TYPE" not in parameters
+
+        # SERIAL1_BAUD should NOT be imported (does not match regex)
+        assert "SERIAL1_BAUD" not in parameters
+
 
 class TestConfigurationStepProcessorConnectionRenaming:
     """Test connection renaming workflows and edge cases."""

--- a/tests/test_derived_parameter_confirmation.py
+++ b/tests/test_derived_parameter_confirmation.py
@@ -85,7 +85,7 @@ class TestParameterSafetyChecks:
 
         # WHEN: Call update without permission (commit_derived_changes=False)
         pending_changes = fs.calculate_derived_and_forced_param_changes(
-            fc_param_names=[],
+            fc_parameters=[],
         )
 
         # THEN: The changed file is reported as pending
@@ -114,7 +114,7 @@ class TestParameterSafetyChecks:
 
         # WHEN: Call update to detect changes, then save with permission
         pending_changes = fs.calculate_derived_and_forced_param_changes(
-            fc_param_names=[],
+            fc_parameters=[],
         )
 
         # Changes detected - simulate user saying Yes: apply then save
@@ -154,7 +154,7 @@ class TestParameterSafetyChecks:
 
         # WHEN
         pending_changes = fs.calculate_derived_and_forced_param_changes(
-            fc_param_names=[],
+            fc_parameters=[],
         )
 
         # THEN: Comment change alone triggers the pending flag
@@ -189,7 +189,7 @@ class TestParameterSafetyChecks:
 
         # WHEN: Call update
         pending_changes = fs.calculate_derived_and_forced_param_changes(
-            fc_param_names=[],
+            fc_parameters=[],
         )
 
         # THEN: Derived value (11.75) differs from loaded value (15.7) → detected

--- a/update_vehicle_templates.py
+++ b/update_vehicle_templates.py
@@ -126,11 +126,11 @@ def process_template_directory(template_dir: Path) -> None:
 
         local_fs.save_vehicle_components_json_data(local_fs.vehicle_components_fs.data, str(template_dir))
 
-        fc_param_names = list(local_fs.param_default_dict.keys()) if local_fs.param_default_dict else []
+        fc_parameters = list(local_fs.param_default_dict.keys()) if local_fs.param_default_dict else []
 
         # Test parameter derivation (passing None means only forced/derived params are computed)
         try:
-            computed_changes = local_fs.calculate_derived_and_forced_param_changes(fc_param_names=fc_param_names)
+            computed_changes = local_fs.calculate_derived_and_forced_param_changes(fc_parameters=fc_parameters)
             local_fs.apply_computed_changes(computed_changes)
             local_fs.save_vehicle_params_to_files(list(local_fs.file_parameters))
         except ValueError as e:


### PR DESCRIPTION
# Description

Completed #1551 

Allows specific configuration steps to define a regex pattern. Any live parameter matching the pattern that differs from the firmware default is automatically appended to the step's .param file and displayed in the GUI.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [X] Manual testing performed
- [x] Tested on SITL
