### PR TITLE
Project from bin

### DIFF
--- a/ARCHITECTURE_3_directory_selection.md
+++ b/ARCHITECTURE_3_directory_selection.md
@@ -254,7 +254,38 @@ The data flow follows the layered architecture pattern with clear separation of 
    - Project creation delegated to specialized creator services
    - Success/failure feedback provided through manager interface
 
-4. **Existing Project Opening Flow**
+4. **.bin Log Import Flow**
+   - User clicks *Create a vehicle project from a .bin log file* in VehicleProjectOpenerWindow (option-1 panel, via `BinLogSelectionWidgets`)
+   - Frontend opens a file-picker; user selects a `.bin` ArduPilot log file
+   - Frontend delegates to `project_manager.create_new_vehicle_from_bin_log(bin_file)`
+   - `VehicleProjectManager` orchestrates the following steps via `VehicleProjectCreator`:
+     1. `extract_firmware_version_from_bin_log()` — reads the `VER` (or `MSG`) record from the
+        log to determine vehicle type (e.g. `ArduCopter`) and firmware version (e.g. `4.6.3`);
+        `pymavlink` is imported lazily at call time so it does not slow application startup
+     2. `template_dir_for_bin_import()` — resolves and validates the matching template directory
+        (e.g. `ArduCopter/empty_4.6.x`); raises a user-friendly error if none is installed
+     3. `create_new_vehicle_from_template()` — copies the template with `fc_connected=False`
+        so no live FC values are injected
+     4. `extract_param_files_from_bin_log()` — extracts default and current parameter values
+        from the log's `PARM` messages; also imported lazily
+     5. `LocalFilesystem.fw_version` is set to `"major.minor.patch"` before `re_init()` is
+        called, preventing the template's placeholder version from being used
+     6. `re_init()` — points the filesystem at the new vehicle directory
+     7. `set_fc_fw_version_and_type_in_components_json()` — persists the detected firmware
+        version and type into `vehicle_components.json`
+     8. `write_param_default_values_to_file()` — overwrites `00_default.param` with the
+        log-extracted defaults
+     9. Parameters present in the log but absent/different in the template files are exported
+        to `xx_imported_bin_log_parameters.param`; `re_init()` is called again to pick up
+        the new file
+     10. Manager state (`_settings`, `configuration_template`, recent-dir history) is updated
+         only after `open_vehicle_directory()` succeeds, ensuring manager metadata
+         is committed only on success
+   - Success/failure feedback provided through manager interface; on failure the new directory
+     is not registered in session history and manager in-memory state is not updated,
+     though filesystem changes to the new project directory are not rolled back
+
+5. **Existing Project Opening Flow**
    - User interacts with VehicleProjectOpenerWindow
    - Frontend presents project opening and re-opening options
    - User selects existing directory through DirectorySelectionWidgets with callbacks
@@ -263,14 +294,14 @@ The data flow follows the layered architecture pattern with clear separation of 
    - Project state is reconstructed and validated
    - Error handling managed through consistent interface
 
-5. **Architecture Benefits**
+6. **Architecture Benefits**
    - Frontend never directly accesses backend services
    - All business logic centralized in VehicleProjectManager
    - Easy to test with mock VehicleProjectManager
    - Changes to backend services don't affect frontend code
    - Clean separation between project opening and project creation concerns
 
-6. **Recent Directories History Flow**
+7. **Recent Directories History Flow**
    - On application startup, `ProgramSettings.get_recent_vehicle_dirs()` loads history from settings.json; the history is passed through the manager
    - History is passed to VehicleProjectOpenerWindow to populate the combobox widget
    - User selects a directory from the combobox dropdown

--- a/USECASES.md
+++ b/USECASES.md
@@ -12,6 +12,7 @@ Hence the two main use cases are:
 
 But there are other use cases as well:
 
+- [Create a vehicle project from a .bin log file](#create-a-vehicle-project-from-a-bin-log-file)
 - [Create a vehicle configuration based on a correctly configured vehicle](#create-a-vehicle-configuration-based-on-a-correctly-configured-vehicle)
 - [Review and or edit configuration files without having the vehicle FC](#review-and-or-edit-configuration-files-without-having-the-vehicle-fc)
 - [Use the correct default values](#use-the-correct-default-values)
@@ -75,6 +76,42 @@ Please scroll down and make sure you do not miss a property.
 1. You should now see the *Parameter file editor and uploader* window.
 ![AMC parameter file editor and uploader](images/App_screenshot2.png)
 1. Proceed as explained in [parameter editor workflow overview](USERMANUAL.md#step-4-parameter-file-editor-and-uploader-interface)
+
+If something is not clear, read the [ArduPilot Methodic Configurator user manual](USERMANUAL.md)
+
+## Create a vehicle project from a .bin log file
+
+Use this workflow when you have an ArduPilot `.bin` flight-log file recorded by a vehicle that was already
+running a valid configuration and you want to reconstruct a methodic-configurator project from it —
+no physical flight controller required.
+
+The software reads the `.bin` file to automatically determine:
+
+- **Vehicle type** (e.g. ArduCopter, ArduPlane, Rover) from the log's `VER` or `MSG` record
+- **Firmware version** (major.minor.patch) from the same record — used to select the right
+  parameter-documentation metadata and to populate `vehicle_components.json`
+- **Default parameter values** — the per-build defaults stored in the log (`PARM` messages with `Default` attribute)
+- **Current parameter values** — the values that were actually active when the log was recorded
+
+1. Open the *ArduPilot Methodic Configurator* software.
+1. Select `Skip FC connection, just edit .param files on disk` button.
+![AMC no connection](images/App_screenshot_FC_connection_no_connection.png)
+1. Click the **Create a vehicle project from a .bin log file** button.
+1. In the file-picker that opens, select your `.bin` log file.
+   - The software automatically detects the vehicle type and firmware version.
+   - A matching template directory (e.g. `ArduCopter/empty_4.6.x`) is selected automatically.
+   - The project is named after the log file (without the `.bin` extension) and created in the
+     default vehicles directory.
+   - `00_default.param` is populated with the default values extracted from the log.
+   - A `xx_imported_bin_log_parameters.param` file is created for any current values that differ
+     from the template's parameter files — giving you a clear delta to review and tune.
+   - `vehicle_components.json` is updated with the detected firmware type and version.
+1. Review and edit the vehicle components in the *Vehicle Component Editor* window.
+   The firmware type and version fields will already be pre-filled from the log.
+1. Press *Save data and start configuration*.
+1. You should now see the *Parameter file editor and uploader* window.
+   ![AMC parameter file editor and uploader](images/App_screenshot2.png)
+1. Follow the procedure to [configure the vehicle parameters](USERMANUAL.md#step-4-parameter-file-editor-and-uploader-interface).
 
 If something is not clear, read the [ArduPilot Methodic Configurator user manual](USERMANUAL.md)
 

--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -167,7 +167,7 @@ It provides three main options for selecting a vehicle directory:
 
 #### New
 
-Create a new vehicle configuration directory
+Create a new vehicle configuration directory, either from a template or from a `.bin` log file.
 
 #### Open
 
@@ -200,6 +200,23 @@ It's useful for setting up a new vehicle configuration quickly.
 - Use the "Destination base directory" `...` button to select the existing directory where the new vehicle directory will be created.
 - Enter the name for the new vehicle directory in the "Destination new vehicle name" field.
 - Click the "Create vehicle directory from template" button to create the new vehicle directory on the base directory and copy the template files to it.
+
+### Create a New Vehicle Configuration Directory from a .bin Log File
+
+If you have an ArduPilot `.bin` log file recorded by a correctly running vehicle, the software can
+build a complete project from it — no physical flight controller connection required.
+
+- Click the **Create a vehicle project from a .bin log file** button in the **New** panel.
+- In the file-picker, select your `.bin` log file.
+- The software automatically:
+  - Reads the vehicle type and firmware version from the log's `VER` (or `MSG`) record.
+  - Selects the matching template directory (e.g. `ArduCopter/empty_4.6.x`).
+  - Names the project after the log file (without the `.bin` extension).
+  - Writes the default parameter values extracted from the log into `00_default.param`.
+  - Creates `xx_imported_bin_log_parameters.param` for any current values that differ from the
+    template's parameter files, giving you a clear delta to review.
+  - Sets the firmware type and version in `vehicle_components.json`.
+- You are taken directly to the Vehicle Component Editor with the firmware fields pre-filled.
 
 ### Step 3: Vehicle Component Editor Interface
 

--- a/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_vehicle_components.py
@@ -13,11 +13,11 @@ from json import JSONDecodeError
 from json import dump as json_dump
 from json import load as json_load
 
-# from logging import warning as logging_warning
 # from sys import exit as sys_exit
 from logging import debug as logging_debug
 from logging import error as logging_error
 from logging import info as logging_info
+from logging import warning as logging_warning
 from os import makedirs as os_makedirs
 from os import path as os_path
 from os import walk as os_walk
@@ -337,6 +337,28 @@ class VehicleComponents:
             error_msg = _("FW version string {version_str} on {filename} is invalid")
             logging_error(error_msg.format(version_str=version_str, filename=self.vehicle_components_fs.json_filename))
         return ""
+
+    def set_fc_fw_version_and_type_in_components_json(self, fw_version: str, vehicle_type: str, vehicle_dir: str) -> None:
+        """
+        Update the firmware version and type in the loaded vehicle_components.json and save it to disk.
+
+        This ensures the project's component metadata reflects the actual firmware that was
+        running when the .bin log was recorded, rather than the template's placeholder values.
+
+        Args:
+            fw_version: Full firmware version string in "major.minor.patch" format (e.g. "4.6.3").
+            vehicle_type: Firmware type string (e.g. "ArduCopter").
+            vehicle_dir: Path to the vehicle directory containing vehicle_components.json.
+
+        """
+        data = self.vehicle_components_fs.data
+        if data and "Components" in data:
+            fc_firmware = data["Components"].setdefault("Flight Controller", {}).setdefault("Firmware", {})
+            fc_firmware["Version"] = fw_version
+            fc_firmware["Type"] = vehicle_type
+            error_occurred, msg = self.save_vehicle_components_json_data(data, vehicle_dir)
+            if error_occurred:
+                logging_warning("%s", msg)
 
     @staticmethod
     def supported_vehicles() -> tuple[str, ...]:

--- a/ardupilot_methodic_configurator/data_model_vehicle_project.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import is_within_tolerance
 from ardupilot_methodic_configurator.data_model_vehicle_project_creator import NewVehicleProjectSettings, VehicleProjectCreator
 from ardupilot_methodic_configurator.data_model_vehicle_project_opener import VehicleProjectOpener
 
@@ -154,6 +155,92 @@ class VehicleProjectManager:  # pylint: disable=too-many-public-methods
             # performed consistently for both project creation and opening.
             self.store_recently_used_template_dirs(template_dir, new_base_dir)
             self.open_vehicle_directory(new_path)
+        return new_path
+
+    def create_new_vehicle_from_bin_log(self, bin_file: str) -> str:
+        """
+        Create a new vehicle configuration directory from an ArduPilot .bin log file.
+
+        The vehicle type and firmware version are extracted from the .bin file itself.
+        The project is based on the matching empty_{major}.{minor}.x template, uses the
+        extracted current parameter values for template substitution, replaces the
+        template's 00_default.param with the extracted defaults snapshot, and exports any
+        remaining parameters missing from the AMC files into a final import file.
+
+        Args:
+            bin_file: Path to the ArduPilot .bin log file
+
+        Returns:
+            The created vehicle directory path
+
+        Raises:
+            VehicleProjectCreationError: If creation, extraction, or template lookup fails
+
+        """
+        firmware_info = self._creator.extract_firmware_version_from_bin_log(bin_file)
+        vehicle_type = firmware_info[0]
+        fw_version = f"{firmware_info[1]}.{firmware_info[2]}.{firmware_info[3]}"
+        template_dir = self._creator.template_dir_for_bin_import(vehicle_type, firmware_info[1], firmware_info[2])
+        default_params, current_params = self._creator.extract_param_files_from_bin_log(bin_file)
+        fc_parameters = {name: param.value for name, param in current_params.items()}
+        settings = NewVehicleProjectSettings(
+            blank_change_reason=True,
+            infer_comp_specs_and_conn_from_fc_params=True,
+            use_fc_params=True,
+        )
+
+        new_path = self._creator.create_new_vehicle_from_template(
+            template_dir,
+            str(LocalFilesystem.get_vehicles_default_dir()),
+            self._creator.vehicle_name_from_bin_log(bin_file),
+            settings,
+            fc_connected=False,
+            fc_parameters=fc_parameters,
+        )
+
+        # Point the filesystem at the new vehicle directory before any reads or writes.
+        # write_param_default_values_to_file() and compound_params() rely on vehicle_dir,
+        # so re_init() must be called here to avoid accidentally operating on the previously-open project.
+        # Set fw_version first so re_init() does not override it with the template's placeholder version.
+        self._local_filesystem.fw_version = fw_version
+        self._local_filesystem.re_init(new_path, vehicle_type)
+        # Persist the correct firmware version and type into vehicle_components.json so subsequent
+        # re_init calls (and the user when they inspect the project) see the actual recorded firmware.
+        self._local_filesystem.set_fc_fw_version_and_type_in_components_json(fw_version, vehicle_type, new_path)
+
+        self._local_filesystem.write_param_default_values_to_file(default_params)
+
+        # Build the baseline from log-extracted defaults plus compounded AMC step files.
+        # This avoids exporting params that merely match 00_default.param but are absent
+        # from the numbered step files.
+        compounded_step_params, _first_config_step = self._local_filesystem.compound_params(skip_default=True)
+        baseline_params = default_params.deep_copy()
+        baseline_params.update(compounded_step_params)
+
+        if imported_params := current_params.get_missing_or_different(baseline_params, is_within_tolerance):
+            self._local_filesystem.export_to_param(
+                imported_params,
+                self._creator.next_import_filename(new_path),
+                annotate_doc=False,
+            )
+            self._local_filesystem.re_init(new_path, vehicle_type)
+
+        if self._flight_controller is not None:
+            self._flight_controller.fc_parameters = fc_parameters
+
+        # Open the vehicle directory only after all file modifications are complete and filesystem state is synced.
+        # This ensures the UI/session operates on the authoritative filesystem state, not stale in-memory cache.
+        # Also note: infer_comp_specs_and_conn_from_fc_params and use_fc_params are reused for log-derived params
+        # because the semantics align: we're supplying external parameter values for template substitution.
+        self.open_vehicle_directory(new_path)
+
+        # Update manager state only after the whole import succeeds so that a failure in any preceding step
+        # (including open_vehicle_directory) does not leave the manager in a partially-updated state and
+        # does not pollute the recently-used template history with an incomplete project.
+        self._settings = settings
+        self.configuration_template = self.get_directory_name_from_path(template_dir)
+        self.store_recently_used_template_dirs(template_dir, str(LocalFilesystem.get_vehicles_default_dir()))
+
         return new_path
 
     # Vehicle project opening operations

--- a/ardupilot_methodic_configurator/data_model_vehicle_project_creator.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project_creator.py
@@ -12,10 +12,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 from dataclasses import MISSING, dataclass, fields
+from pathlib import Path
 from typing import ClassVar, NamedTuple, Optional
 
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import ParDict
 
 
 class VehicleProjectCreationError(Exception):
@@ -387,7 +389,7 @@ class NewVehicleProjectSettings:
         return NewVehicleProjectSettings(**adjusted_settings)
 
 
-class VehicleProjectCreator:  # pylint: disable=too-few-public-methods
+class VehicleProjectCreator:
     """Manages vehicle project creation operations."""
 
     def __init__(self, local_filesystem: LocalFilesystem) -> None:
@@ -399,6 +401,88 @@ class VehicleProjectCreator:  # pylint: disable=too-few-public-methods
 
         """
         self.local_filesystem = local_filesystem
+
+    @staticmethod
+    def template_dir_for_bin_import(vehicle_type: str, major: int, minor: int) -> str:
+        """
+        Return the empty template directory for .bin log imports, validated to exist.
+
+        Builds the path as <templates_base>/<vehicle_type>/empty_{major}.{minor}.x and
+        raises VehicleProjectCreationError if the directory does not exist in the
+        installed templates, so unsupported vehicle types are caught as late as possible.
+        """
+        template_name = f"empty_{major}.{minor}.x"
+        template_dir = Path(LocalFilesystem.get_templates_base_dir()) / vehicle_type / template_name
+        if not template_dir.is_dir():
+            msg = _("No template found for {vehicle_type} {template_name}.\nExpected directory: {template_dir}").format(
+                vehicle_type=vehicle_type, template_name=template_name, template_dir=template_dir
+            )
+            raise VehicleProjectCreationError(_(".bin log import"), msg)
+        return str(template_dir)
+
+    @staticmethod
+    def vehicle_name_from_bin_log(bin_file: str) -> str:
+        """Return the default vehicle directory name derived from the .bin filename."""
+        return Path(bin_file).stem
+
+    @staticmethod
+    def next_import_filename(vehicle_dir: str) -> str:
+        """Return the next available numbered parameter filename for imported log parameters."""
+        highest_prefix = 0
+        try:
+            directory_iter = Path(vehicle_dir).iterdir()
+        except OSError as exc:
+            msg = _("Could not scan the vehicle directory for imported parameter files: {vehicle_dir}. {error}").format(
+                vehicle_dir=vehicle_dir, error=str(exc)
+            )
+            raise VehicleProjectCreationError(_("Parameter import"), msg) from exc
+
+        for file_path in directory_iter:
+            if not file_path.is_file() or file_path.suffix != ".param":
+                continue
+            prefix = file_path.name[:2]
+            if prefix.isdigit():
+                highest_prefix = max(highest_prefix, int(prefix))
+
+        next_prefix = highest_prefix + 1
+        if next_prefix > 99:
+            msg = _("Could not create an import parameter file because no numbered slot is available in {vehicle_dir}")
+            raise VehicleProjectCreationError(_("Parameter import"), msg.format(vehicle_dir=vehicle_dir))
+        return f"{next_prefix:02d}_imported_bin_log_parameters.param"
+
+    @staticmethod
+    def extract_firmware_version_from_bin_log(bin_file: str) -> tuple[str, int, int, int]:
+        """
+        Extract vehicle type and firmware version from an ArduPilot .bin log file.
+
+        Returns:
+            (vehicle_type, major, minor, patch) e.g. ("ArduCopter", 4, 6, 3)
+
+        """
+        from ardupilot_methodic_configurator.extract_param_defaults import (  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
+            extract_firmware_version_and_vehicle_type,
+        )
+
+        try:
+            return extract_firmware_version_and_vehicle_type(bin_file)
+        except SystemExit as exc:
+            msg = str(exc) or _("Failed to read firmware version from the selected .bin log file")
+            raise VehicleProjectCreationError(_(".bin log import"), msg) from exc
+
+    @staticmethod
+    def extract_param_files_from_bin_log(bin_file: str) -> tuple[ParDict, ParDict]:
+        """Extract default and current parameter snapshots from an ArduPilot .bin log file."""
+        from ardupilot_methodic_configurator.extract_param_defaults import (  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
+            extract_parameter_values,
+        )
+
+        try:
+            default_params = ParDict.from_float_dict(extract_parameter_values(bin_file, "defaults"))
+            current_params = ParDict.from_float_dict(extract_parameter_values(bin_file, "values"))
+        except SystemExit as exc:
+            msg = str(exc) or _("Failed to extract parameters from the selected .bin log file")
+            raise VehicleProjectCreationError(_(".bin log import"), msg) from exc
+        return default_params, current_params
 
     def create_new_vehicle_from_template(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,

--- a/ardupilot_methodic_configurator/data_model_vehicle_project_creator.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project_creator.py
@@ -430,20 +430,17 @@ class VehicleProjectCreator:
         """Return the next available numbered parameter filename for imported log parameters."""
         highest_prefix = 0
         try:
-            directory_iter = Path(vehicle_dir).iterdir()
+            for file_path in Path(vehicle_dir).iterdir():
+                if not file_path.is_file() or file_path.suffix != ".param":
+                    continue
+                prefix = file_path.name[:2]
+                if prefix.isdigit():
+                    highest_prefix = max(highest_prefix, int(prefix))
         except OSError as exc:
             msg = _("Could not scan the vehicle directory for imported parameter files: {vehicle_dir}. {error}").format(
                 vehicle_dir=vehicle_dir, error=str(exc)
             )
             raise VehicleProjectCreationError(_("Parameter import"), msg) from exc
-
-        for file_path in directory_iter:
-            if not file_path.is_file() or file_path.suffix != ".param":
-                continue
-            prefix = file_path.name[:2]
-            if prefix.isdigit():
-                highest_prefix = max(highest_prefix, int(prefix))
-
         next_prefix = highest_prefix + 1
         if next_prefix > 99:
             msg = _("Could not create an import parameter file because no numbered slot is available in {vehicle_dir}")

--- a/ardupilot_methodic_configurator/extract_param_defaults.py
+++ b/ardupilot_methodic_configurator/extract_param_defaults.py
@@ -175,6 +175,62 @@ def extract_parameter_values(logfile: str, param_type: str = "defaults") -> dict
             raise SystemExit(msg)
 
 
+def extract_firmware_version_and_vehicle_type(logfile: str) -> tuple[str, int, int, int]:
+    """
+    Extract vehicle type and firmware version from an ArduPilot .bin log file.
+
+    Prefers the structured VER message (fields Maj, Min, Pat, FWS) and falls back to
+    scanning MSG messages until one with a parseable "Vx.y" version is found
+    (e.g. "ArduCopter V4.6.3 (hash)").
+
+    Args:
+        logfile: The path to the ArduPilot .bin log file.
+
+    Returns:
+        A tuple of (vehicle_type, major, minor, patch), e.g. ("ArduCopter", 4, 6, 3).
+
+    """
+    try:
+        mlog = mavutil.mavlink_connection(logfile)
+    except Exception as e:
+        msg = f"Error opening the {logfile} logfile: {e!s}"
+        raise SystemExit(msg) from e
+
+    try:
+        msg_fallback_result: Union[tuple[str, int, int, int], None] = None
+        while True:
+            m = mlog.recv_match(type=["VER", "MSG"])
+            if m is None:
+                break
+            if m.get_type() == "VER":
+                fws = str(m.FWS)  # e.g. "ArduCopter V4.6.3 (3fc7011a)"
+                vehicle_type = fws.split(maxsplit=1)[0] if fws else ""
+                maj, min_, pat = m.Maj, m.Min, m.Pat
+                if maj is None or min_ is None or pat is None:
+                    continue
+                return vehicle_type, int(maj), int(min_), int(pat)
+            # Parse each MSG; store the first parseable Vx.y one as fallback and keep scanning for VER
+            if msg_fallback_result is None:
+                parts = str(m.Message).split()
+                if len(parts) >= 2 and parts[1].startswith("V"):
+                    version_parts = parts[1][1:].split(".")  # Remove "V" prefix, split by "."
+                    if len(version_parts) >= 2:
+                        with contextlib.suppress(ValueError):
+                            patch_val = int(version_parts[2]) if len(version_parts) >= 3 else 0
+                            msg_fallback_result = (parts[0], int(version_parts[0]), int(version_parts[1]), patch_val)
+
+        if msg_fallback_result is not None:
+            return msg_fallback_result
+
+        msg = f"No firmware version information found in {logfile}"
+        raise SystemExit(msg)
+    finally:
+        close_method = getattr(mlog, "close", None)
+        if callable(close_method):
+            with contextlib.suppress(Exception):
+                close_method()
+
+
 def missionplanner_sort(item: str) -> tuple[str, ...]:
     """
     Sorts a parameter name according to the rules defined in the Mission Planner software.

--- a/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_directory_selection.py
@@ -14,6 +14,7 @@ from tkinter import filedialog, messagebox, ttk
 from typing import Callable, Optional
 
 from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.data_model_vehicle_project_creator import VehicleProjectCreationError
 from ardupilot_methodic_configurator.data_model_vehicle_project_opener import VehicleProjectOpenError
 from ardupilot_methodic_configurator.frontend_tkinter_base_window import BaseWindow
 from ardupilot_methodic_configurator.frontend_tkinter_show import show_tooltip
@@ -133,6 +134,58 @@ class DirectorySelectionWidgets:
 
     def get_selected_directory(self) -> str:
         return self.directory
+
+
+class BinLogSelectionWidgets:  # pylint: disable=too-few-public-methods
+    """A GUI widget for selecting a .bin log file and invoking a callback."""
+
+    def __init__(
+        self,
+        parent: BaseWindow,
+        parent_frame: ttk.Widget,
+        on_select_file_callback: Callable[[str], None],
+    ) -> None:
+        self.parent = parent
+        self.on_select_file_callback = on_select_file_callback
+
+        self.container_frame = ttk.Frame(parent_frame)
+        self.select_file_button = ttk.Button(
+            self.container_frame,
+            text=_("Create a vehicle project from a .bin log file"),
+            command=self.on_select_file,
+        )
+        self.select_file_button.pack(expand=False, fill=tk.X, padx=20, pady=5, anchor=tk.CENTER)
+        show_tooltip(
+            self.select_file_button,
+            _(
+                "Extract default and current parameters from an ArduPilot .bin log file.\n"
+                "The vehicle type and firmware version are read from the log and the matching\n"
+                "empty template is used. The template's 00_default.param is replaced with the\n"
+                "extracted defaults snapshot. Continue with the normal component editor flow."
+            ),
+        )
+
+    def on_select_file(self) -> bool:
+        selected_file = filedialog.askopenfilename(
+            parent=self.parent.root,
+            title=_("Select an ArduPilot .bin log file"),
+            filetypes=[(_("ArduPilot binary log files"), "*.bin"), (_("All files"), "*.*")],
+        )
+        if not selected_file:
+            return False
+
+        try:
+            self.on_select_file_callback(selected_file)
+            return True
+        except VehicleProjectCreationError as exc:
+            messagebox.showerror(exc.title, exc.message)
+            return False
+        except VehicleProjectOpenError as exc:
+            messagebox.showerror(exc.title, exc.message)
+            return False
+        except OSError as exc:
+            messagebox.showerror(_(".bin log import"), str(exc))
+            return False
 
 
 class VehicleDirectorySelectionWidgets(DirectorySelectionWidgets):

--- a/ardupilot_methodic_configurator/frontend_tkinter_project_opener.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_project_opener.py
@@ -28,6 +28,7 @@ from ardupilot_methodic_configurator.data_model_vehicle_project import VehiclePr
 from ardupilot_methodic_configurator.data_model_vehicle_project_opener import VehicleProjectOpenError
 from ardupilot_methodic_configurator.frontend_tkinter_base_window import BaseWindow
 from ardupilot_methodic_configurator.frontend_tkinter_directory_selection import (
+    BinLogSelectionWidgets,
     VehicleDirectorySelectionWidgets,
 )
 from ardupilot_methodic_configurator.frontend_tkinter_project_creator import VehicleProjectCreatorWindow
@@ -64,7 +65,7 @@ class VehicleProjectOpenerWindow(BaseWindow):
             self.main_frame,
             anchor=tk.CENTER,
             justify=tk.CENTER,
-            text=introduction_text + _("\nChoose one of the following three options:"),
+            text=introduction_text + _("\nChoose one of the following options:"),
         )
         introduction_label.pack(expand=False, fill=tk.X, padx=6, pady=6)
         _template_dir, _new_base_dir, vehicle_dir = self.project_manager.get_recently_used_dirs()
@@ -95,6 +96,17 @@ class VehicleProjectOpenerWindow(BaseWindow):
             create_vehicle_directory_from_template_button,
             _("Create a new vehicle configuration directory, choose this option when using the software for the first time"),
         )
+
+        def on_bin_log_selected(bin_file: str) -> None:
+            self.project_manager.create_new_vehicle_from_bin_log(bin_file)
+            self.root.destroy()
+
+        self.bin_log_selection_widgets = BinLogSelectionWidgets(
+            self,
+            option1_label_frame,
+            on_select_file_callback=on_bin_log_selected,
+        )
+        self.bin_log_selection_widgets.container_frame.pack(expand=False, fill=tk.X, padx=3, pady=(0, 5), anchor=tk.NW)
 
     # pylint: enable=duplicate-code
 

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -1519,3 +1519,205 @@ class TestVehicleComponents:
 
         # Verify empty string is returned
         assert version == ""
+
+
+class TestSetFcFwVersionAndTypeInComponentsJson:
+    """BDD tests for set_fc_fw_version_and_type_in_components_json."""
+
+    @pytest.fixture
+    def vehicle_components_with_data(self) -> VehicleComponents:
+        """Fixture providing a VehicleComponents instance with typical component data."""
+        vc = VehicleComponents()
+        vc.vehicle_components_fs.data = {
+            "Components": {
+                "Flight Controller": {
+                    "Firmware": {"Type": "ArduCopter", "Version": "4.6.0"},
+                    "Product": {"Manufacturer": "Holybro", "Model": "Pixhawk 6C"},
+                }
+            }
+        }
+        return vc
+
+    def test_firmware_version_is_written_into_component_data(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        The firmware version is correctly updated in the in-memory component data.
+
+        GIVEN: Components data that has a placeholder firmware version "4.6.0"
+        WHEN: set_fc_fw_version_and_type_in_components_json is called with "4.6.3"
+        THEN: The Firmware Version field in the component data is updated to "4.6.3"
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        assert vc.vehicle_components_fs.data is not None
+        version = vc.vehicle_components_fs.data["Components"]["Flight Controller"]["Firmware"]["Version"]
+        assert version == "4.6.3"
+
+    def test_firmware_type_is_written_into_component_data(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        The firmware type is correctly updated in the in-memory component data.
+
+        GIVEN: Components data that has firmware Type "ArduCopter"
+        WHEN: set_fc_fw_version_and_type_in_components_json is called with "Rover"
+        THEN: The Firmware Type field is updated to "Rover"
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.5.1", "Rover", "/vehicles/rover_project")
+
+        assert vc.vehicle_components_fs.data is not None
+        fw_type = vc.vehicle_components_fs.data["Components"]["Flight Controller"]["Firmware"]["Type"]
+        assert fw_type == "Rover"
+
+    def test_save_is_called_with_updated_data_and_correct_directory(
+        self, vehicle_components_with_data: VehicleComponents
+    ) -> None:
+        """
+        save_vehicle_components_json_data is called with the updated data and the given vehicle_dir.
+
+        GIVEN: Component data in memory and a known vehicle directory path
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: save_vehicle_components_json_data receives the full data dict and the correct path
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")) as mock_save:
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/my_project")
+
+        mock_save.assert_called_once()
+        saved_data, saved_dir = mock_save.call_args.args
+        assert saved_dir == "/vehicles/my_project"
+        assert saved_data["Components"]["Flight Controller"]["Firmware"]["Version"] == "4.6.3"
+        assert saved_data["Components"]["Flight Controller"]["Firmware"]["Type"] == "ArduCopter"
+
+    def test_other_component_fields_are_not_disturbed(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        Non-firmware component fields remain intact after the firmware update.
+
+        GIVEN: Components data that includes manufacturer and model information
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: Product Manufacturer and Model are unchanged
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        assert vc.vehicle_components_fs.data is not None
+        product = vc.vehicle_components_fs.data["Components"]["Flight Controller"]["Product"]
+        assert product["Manufacturer"] == "Holybro"
+        assert product["Model"] == "Pixhawk 6C"
+
+    def test_creates_firmware_section_when_absent(self) -> None:
+        """
+        The Firmware sub-dict is created if the Flight Controller component lacks it.
+
+        GIVEN: Components data where "Flight Controller" has no "Firmware" key at all
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: A "Firmware" section is created and populated with Version and Type
+        """
+        vc = VehicleComponents()
+        vc.vehicle_components_fs.data = {"Components": {"Flight Controller": {"Product": {"Model": "CubeOrange"}}}}
+
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        firmware = vc.vehicle_components_fs.data["Components"]["Flight Controller"]["Firmware"]
+        assert firmware["Version"] == "4.6.3"
+        assert firmware["Type"] == "ArduCopter"
+
+    def test_creates_flight_controller_section_when_absent(self) -> None:
+        """
+        The Flight Controller section is created if the Components dict lacks it entirely.
+
+        GIVEN: Components data that has no "Flight Controller" key
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: "Flight Controller" → "Firmware" is created with the correct values
+        """
+        vc = VehicleComponents()
+        vc.vehicle_components_fs.data = {"Components": {}}
+
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        firmware = vc.vehicle_components_fs.data["Components"]["Flight Controller"]["Firmware"]
+        assert firmware["Version"] == "4.6.3"
+        assert firmware["Type"] == "ArduCopter"
+
+    def test_does_nothing_when_data_is_none(self) -> None:
+        """
+        No save is attempted when the component data is None.
+
+        GIVEN: vehicle_components_fs.data is None (vehicle_components.json was never loaded)
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: save_vehicle_components_json_data is NOT called and no exception is raised
+        """
+        vc = VehicleComponents()
+        vc.vehicle_components_fs.data = None
+
+        with patch.object(vc, "save_vehicle_components_json_data") as mock_save:
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        mock_save.assert_not_called()
+
+    def test_does_nothing_when_data_has_no_components_key(self) -> None:
+        """
+        No save is attempted when the loaded data lacks the "Components" top-level key.
+
+        GIVEN: vehicle_components_fs.data is a dict without a "Components" key
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: save_vehicle_components_json_data is NOT called
+        """
+        vc = VehicleComponents()
+        vc.vehicle_components_fs.data = {"SomethingElse": {}}
+
+        with patch.object(vc, "save_vehicle_components_json_data") as mock_save:
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        mock_save.assert_not_called()
+
+    def test_version_is_readable_back_via_get_fc_fw_version(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        After setting, get_fc_fw_version_from_vehicle_components_json returns the new version.
+
+        GIVEN: Components data with an old firmware version
+        WHEN: set_fc_fw_version_and_type_in_components_json writes "4.6.3"
+        THEN: get_fc_fw_version_from_vehicle_components_json returns "4.6.3"
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        assert vc.get_fc_fw_version_from_vehicle_components_json() == "4.6.3"
+
+    def test_warning_is_logged_when_save_fails(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        A warning is logged and execution continues when the save operation reports an error.
+
+        GIVEN: Component data is valid but save_vehicle_components_json_data returns an error
+        WHEN: set_fc_fw_version_and_type_in_components_json is called
+        THEN: A warning is logged containing the error message and no exception is raised
+        """
+        vc = vehicle_components_with_data
+        with (
+            patch.object(vc, "save_vehicle_components_json_data", return_value=(True, "disk write error")),
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.logging_warning") as mock_warn,
+        ):
+            vc.set_fc_fw_version_and_type_in_components_json("4.6.3", "ArduCopter", "/vehicles/test")
+
+        mock_warn.assert_called_once()
+        args = mock_warn.call_args.args
+        assert "disk write error" in args[1]
+
+    def test_type_is_readable_back_via_get_fc_fw_type(self, vehicle_components_with_data: VehicleComponents) -> None:
+        """
+        After setting, get_fc_fw_type_from_vehicle_components_json returns the new type.
+
+        GIVEN: Components data with ArduCopter as the firmware type
+        WHEN: set_fc_fw_version_and_type_in_components_json writes "ArduPlane"
+        THEN: get_fc_fw_type_from_vehicle_components_json returns "ArduPlane"
+        """
+        vc = vehicle_components_with_data
+        with patch.object(vc, "save_vehicle_components_json_data", return_value=(False, "")):
+            vc.set_fc_fw_version_and_type_in_components_json("4.5.1", "ArduPlane", "/vehicles/test")
+
+        assert vc.get_fc_fw_type_from_vehicle_components_json() == "ArduPlane"

--- a/tests/test_data_model_vehicle_components_base.py
+++ b/tests/test_data_model_vehicle_components_base.py
@@ -1092,7 +1092,7 @@ class TestComponentDataModelBase(BasicTestMixin, RealisticDataTestMixin):
 
     def test_update_json_structure_adds_arm_and_min_voltages_to_legacy_data(self, basic_model) -> None:
         """
-        Legacy components.json without arm/min voltages gets defaults populated.
+        Legacy vehicle_components.json without arm/min voltages gets defaults populated.
 
         GIVEN: A model whose battery Specifications has Volt per cell max/low/crit but NOT arm or min
         WHEN: update_json_structure() is called

--- a/tests/test_data_model_vehicle_project.py
+++ b/tests/test_data_model_vehicle_project.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import ParDict
 from ardupilot_methodic_configurator.data_model_vehicle_project import VehicleProjectManager
 from ardupilot_methodic_configurator.data_model_vehicle_project_creator import (
     NewVehicleProjectSettings,
@@ -1027,3 +1028,377 @@ class TestIntegrationScenarios:
             assert vehicle_path == "/opened/vehicle/path"
             mock_open.assert_called_once_with("/vehicle/path")
             mock_store.assert_called_once_with("/opened/vehicle/path")
+
+
+class TestCreateNewVehicleFromBinLog:
+    """Test the create_new_vehicle_from_bin_log orchestration method."""
+
+    def _make_manager(self, with_fc: bool = False) -> "VehicleProjectManager":
+        mock_filesystem = MagicMock(spec=LocalFilesystem)
+        mock_flight_controller = MagicMock() if with_fc else None
+        return VehicleProjectManager(mock_filesystem, mock_flight_controller)
+
+    def test_user_can_create_project_from_bin_log_successfully(self) -> None:
+        """
+        User can create a new vehicle project from a valid .bin log file.
+
+        GIVEN: A project manager and a valid .bin log file
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: The vehicle directory is created, defaults replaced, and the path returned
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        fake_defaults = ParDict.from_float_dict({"PARAM_A": 1.0})
+        fake_current = ParDict.from_float_dict({"PARAM_A": 1.0, "PARAM_B": 2.0})
+        empty_compound = ParDict.from_float_dict({})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl/ArduCopter/empty_4.6.x"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="my_flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(fake_defaults, fake_current)),
+            patch.object(
+                manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/my_flight"
+            ) as mock_create,
+            patch.object(manager._creator, "next_import_filename", return_value="02_imported_bin_log_parameters.param"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory") as mock_open,
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file") as mock_write,
+            patch.object(manager._local_filesystem, "compound_params", return_value=(empty_compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param"),
+            patch.object(manager._local_filesystem, "re_init"),
+        ):
+            # Act
+            result = manager.create_new_vehicle_from_bin_log("/logs/my_flight.bin")
+
+        # Assert: correct path returned
+        assert result == "/vehicles/my_flight"
+        # Assert: template creation called with fc_connected=False (key difference from normal flow)
+        _args, kwargs = mock_create.call_args
+        assert kwargs.get("fc_connected") is False
+        # Assert: vehicle directory opened immediately after creation
+        mock_open.assert_called_once_with("/vehicles/my_flight")
+        # Assert: extracted defaults written (replacing the template's 00_default.param)
+        mock_write.assert_called_once_with(fake_defaults)
+
+    def test_bin_log_defaults_are_written_to_vehicle_directory(self) -> None:
+        """
+        The defaults extracted from the .bin log replace the template's 00_default.param.
+
+        GIVEN: A valid .bin log file with a known defaults snapshot
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: write_param_default_values_to_file is called with the extracted defaults ParDict
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        fake_defaults = ParDict.from_float_dict({"BARO_ALT_OFFSET": 0.0})
+        fake_current = ParDict.from_float_dict({"BARO_ALT_OFFSET": 0.5})
+        empty_compound = ParDict.from_float_dict({})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(fake_defaults, fake_current)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(empty_compound, "00_default.param")),
+            patch.object(manager._creator, "next_import_filename", return_value="02_imported_bin_log_parameters.param"),
+            patch.object(manager._local_filesystem, "export_to_param"),
+            patch.object(manager._local_filesystem, "re_init"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file") as mock_write,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: the extracted defaults — not the template's — are written
+        mock_write.assert_called_once_with(fake_defaults)
+
+    def test_missing_params_exported_to_import_file(self) -> None:
+        """
+        Parameters present in the .bin log but absent from the AMC files are exported.
+
+        GIVEN: A .bin log where current params include entries not covered by AMC files
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: export_to_param is called for the difference, and the filesystem is re-initialised
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        fake_defaults = ParDict.from_float_dict({"PARAM_A": 1.0})
+        fake_current = ParDict.from_float_dict({"PARAM_A": 1.0, "EXTRA_PARAM": 99.0})
+        # compound_params covers only PARAM_A — EXTRA_PARAM is missing
+        compound = ParDict.from_float_dict({"PARAM_A": 1.0})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(fake_defaults, fake_current)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(manager._creator, "next_import_filename", return_value="02_imported_bin_log_parameters.param"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param") as mock_export,
+            patch.object(manager._local_filesystem, "re_init") as mock_reinit,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: the import file is created and the filesystem is re-initialised
+        mock_export.assert_called_once()
+        exported_params, export_filename = mock_export.call_args.args[:2]
+        assert export_filename == "02_imported_bin_log_parameters.param"
+        assert "EXTRA_PARAM" in exported_params
+        assert "PARAM_A" not in exported_params
+        assert mock_export.call_args.kwargs.get("annotate_doc") is False
+        # re_init is called once unconditionally (to point filesystem at new_path) and
+        # once more after exporting imported params (to reload the new file).
+        assert mock_reinit.call_count == 2
+
+    def test_no_import_file_when_all_params_covered_by_amc_files(self) -> None:
+        """
+        No extra import file is created when all current params are already in AMC files.
+
+        GIVEN: A .bin log where all current params match the AMC param files
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: export_to_param and re_init are NOT called
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        params = ParDict.from_float_dict({"PARAM_A": 1.0, "PARAM_B": 2.0})
+        compound = ParDict.from_float_dict({"PARAM_A": 1.0, "PARAM_B": 2.0})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(params, params)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param") as mock_export,
+            patch.object(manager._local_filesystem, "re_init") as mock_reinit,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: no extra import file written; re_init called exactly once (the unconditional
+        # initial call to point the filesystem at the new vehicle directory).
+        mock_export.assert_not_called()
+        mock_reinit.assert_called_once_with("/vehicles/flight", "ArduCopter")
+        # Assert: fw_version is set to the full "major.minor.patch" string from the log,
+        # not just "major.minor" or whatever the template's vehicle_components.json contained.
+        assert manager._local_filesystem.fw_version == "4.6.3"
+        # Assert: the correct firmware version and type are written into vehicle_components.json.
+        manager._local_filesystem.set_fc_fw_version_and_type_in_components_json.assert_called_once_with(
+            "4.6.3", "ArduCopter", "/vehicles/flight"
+        )
+
+    def test_no_import_file_for_params_matching_defaults_but_missing_from_step_files(self) -> None:
+        """
+        Params equal to extracted defaults are not exported just because step files omit them.
+
+        GIVEN: Current log params include a value that equals the extracted default
+               and no numbered step file defines that parameter
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: No import file is written for that parameter
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        default_params = ParDict.from_float_dict({"PARAM_A": 10.0})
+        current_params = ParDict.from_float_dict({"PARAM_A": 10.0})
+        empty_step_compound = ParDict.from_float_dict({})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(default_params, current_params)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(empty_step_compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param") as mock_export,
+            patch.object(manager._local_filesystem, "re_init") as mock_reinit,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: nothing to export because current value equals default baseline
+        mock_export.assert_not_called()
+        mock_reinit.assert_called_once_with("/vehicles/flight", "ArduCopter")
+
+    def test_fc_parameters_synced_when_flight_controller_connected(self) -> None:
+        """
+        When a flight controller is connected, its fc_parameters are updated.
+
+        GIVEN: A project manager with an active flight controller
+        WHEN: create_new_vehicle_from_bin_log completes successfully
+        THEN: The flight controller's fc_parameters are set to the current log params
+        """
+        # Arrange
+        manager = self._make_manager(with_fc=True)
+
+        fake_defaults = ParDict.from_float_dict({"PARAM_A": 1.0})
+        fake_current = ParDict.from_float_dict({"PARAM_A": 1.0})
+        compound = ParDict.from_float_dict({"PARAM_A": 1.0})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(fake_defaults, fake_current)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param"),
+            patch.object(manager._local_filesystem, "re_init"),
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: FC parameters updated to the values extracted from the log
+        assert manager._flight_controller.fc_parameters == {"PARAM_A": 1.0}
+
+    def test_creation_error_propagates_to_caller(self) -> None:
+        """
+        VehicleProjectCreationError from param extraction propagates unchanged.
+
+        GIVEN: A .bin log file that cannot have its params extracted
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: VehicleProjectCreationError is raised with the original title/message
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="bad"),
+            patch.object(
+                manager._creator,
+                "extract_param_files_from_bin_log",
+                side_effect=VehicleProjectCreationError(".bin log import", "Corrupt log"),
+            ),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            pytest.raises(VehicleProjectCreationError) as exc_info,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/bad.bin")
+
+        assert exc_info.value.title == ".bin log import"
+        assert exc_info.value.message == "Corrupt log"
+
+    def test_firmware_version_error_propagates_to_caller(self) -> None:
+        """
+        VehicleProjectCreationError from firmware extraction propagates unchanged.
+
+        GIVEN: A .bin log file with no firmware version information
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: VehicleProjectCreationError is raised immediately
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        with (
+            patch.object(
+                manager._creator,
+                "extract_firmware_version_from_bin_log",
+                side_effect=VehicleProjectCreationError(".bin log import", "No VER or MSG found"),
+            ),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            pytest.raises(VehicleProjectCreationError) as exc_info,
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/no_ver.bin")
+
+        assert exc_info.value.title == ".bin log import"
+        assert "No VER or MSG found" in exc_info.value.message
+
+    def test_template_creation_always_called_with_fc_connected_false(self) -> None:
+        """
+        create_new_vehicle_from_template is always called with fc_connected=False.
+
+        This is the key difference from the normal template-creation flow: the vehicle
+        is scaffolded without a live FC connection, using log-extracted params instead.
+
+        GIVEN: A project manager that even has a flight controller connected
+        WHEN: create_new_vehicle_from_bin_log is called
+        THEN: create_new_vehicle_from_template receives fc_connected=False
+        """
+        # Arrange: manager WITH a connected flight controller
+        manager = self._make_manager(with_fc=True)
+
+        params = ParDict.from_float_dict({"PARAM_A": 1.0})
+        compound = ParDict.from_float_dict({"PARAM_A": 1.0})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(params, params)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight") as mock_create,
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param"),
+            patch.object(manager._local_filesystem, "re_init"),
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: regardless of FC connection, fc_connected must be False
+        _args, kwargs = mock_create.call_args
+        assert kwargs.get("fc_connected") is False
+
+    def test_manager_state_updated_after_bin_log_import(self) -> None:
+        """
+        Manager internal state is updated correctly after a successful .bin log import.
+
+        GIVEN: A project manager in its initial state
+        WHEN: create_new_vehicle_from_bin_log completes successfully
+        THEN: _settings carries the bin-log import options and configuration_template
+              is set to the template directory name
+        """
+        # Arrange
+        manager = self._make_manager()
+
+        params = ParDict.from_float_dict({"PARAM_A": 1.0})
+        compound = ParDict.from_float_dict({"PARAM_A": 1.0})
+
+        with (
+            patch.object(manager._creator, "extract_firmware_version_from_bin_log", return_value=("ArduCopter", 4, 6, 3)),
+            patch.object(manager._creator, "template_dir_for_bin_import", return_value="/tpl/ArduCopter/empty_4.6.x"),
+            patch.object(manager._creator, "vehicle_name_from_bin_log", return_value="flight"),
+            patch.object(manager._creator, "extract_param_files_from_bin_log", return_value=(params, params)),
+            patch.object(manager._creator, "create_new_vehicle_from_template", return_value="/vehicles/flight"),
+            patch.object(LocalFilesystem, "get_vehicles_default_dir", return_value="/vehicles"),
+            patch.object(manager, "store_recently_used_template_dirs"),
+            patch.object(manager, "open_vehicle_directory"),
+            patch.object(manager._local_filesystem, "write_param_default_values_to_file"),
+            patch.object(manager._local_filesystem, "compound_params", return_value=(compound, "00_default.param")),
+            patch.object(manager._local_filesystem, "export_to_param"),
+            patch.object(manager._local_filesystem, "re_init"),
+        ):
+            manager.create_new_vehicle_from_bin_log("/logs/flight.bin")
+
+        # Assert: settings reflect the bin-log import defaults
+        assert manager._settings is not None
+        assert manager._settings.blank_change_reason is True
+        assert manager._settings.infer_comp_specs_and_conn_from_fc_params is True
+        assert manager._settings.use_fc_params is True
+        # Assert: configuration_template is the leaf directory name of the template path
+        assert manager.configuration_template == "empty_4.6.x"

--- a/tests/test_data_model_vehicle_project_creator.py
+++ b/tests/test_data_model_vehicle_project_creator.py
@@ -13,11 +13,13 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_par_dict import ParDict
 from ardupilot_methodic_configurator.data_model_vehicle_project_creator import (
     NewVehicleProjectSetting,
     NewVehicleProjectSettings,
@@ -1061,6 +1063,265 @@ class TestGetFCDependentErrorMessageGuardClause:
 
         # Assert
         assert "no flight controller connected" in error_message
+
+
+class TestBinLogImportHelpers:
+    """Test static helper methods on VehicleProjectCreator used for .bin log imports."""
+
+    def test_template_dir_for_bin_import_returns_correct_path(self, tmp_path) -> None:
+        """
+        template_dir_for_bin_import returns the empty_{major}.{minor}.x path for a given vehicle type.
+
+        GIVEN: A user wants to create a project from a .bin log file for ArduCopter 4.6
+        WHEN: They request the template directory with the extracted vehicle_type and version
+        THEN: The path ends with ArduCopter/empty_4.6.x and points to an existing directory
+        """
+        # Arrange: create the expected directory structure so the existence check passes
+        template_dir = tmp_path / "ArduCopter" / "empty_4.6.x"
+        template_dir.mkdir(parents=True)
+
+        with patch.object(LocalFilesystem, "get_templates_base_dir", return_value=str(tmp_path)):
+            result = VehicleProjectCreator.template_dir_for_bin_import("ArduCopter", 4, 6)
+
+        # Assert: returned path ends with the correct vehicle/version subdirectory
+        assert result.endswith(("ArduCopter/empty_4.6.x", "ArduCopter\\empty_4.6.x"))
+
+    def test_template_dir_for_bin_import_uses_major_minor_for_template_name(self, tmp_path) -> None:
+        """
+        template_dir_for_bin_import uses the extracted major.minor version numbers.
+
+        GIVEN: A .bin log from a Rover running firmware 4.5
+        WHEN: They request the template directory with vehicle_type="Rover", major=4, minor=5
+        THEN: The path contains Rover and empty_4.5.x
+        """
+        # Arrange: create expected directory structure
+        template_dir = tmp_path / "Rover" / "empty_4.5.x"
+        template_dir.mkdir(parents=True)
+
+        with patch.object(LocalFilesystem, "get_templates_base_dir", return_value=str(tmp_path)):
+            result = VehicleProjectCreator.template_dir_for_bin_import("Rover", 4, 5)
+
+        assert "Rover" in result
+        assert "empty_4.5.x" in result
+
+    def test_template_dir_for_bin_import_raises_when_template_directory_missing(self, tmp_path) -> None:
+        """
+        template_dir_for_bin_import raises VehicleProjectCreationError for unsupported vehicle/version.
+
+        GIVEN: A .bin log whose vehicle type has no matching template directory
+        WHEN: template_dir_for_bin_import is called with that vehicle_type and version
+        THEN: VehicleProjectCreationError is raised with the .bin log import title
+        """
+        # Arrange: directory does NOT exist (no mkdir)
+        with (
+            patch.object(LocalFilesystem, "get_templates_base_dir", return_value=str(tmp_path)),
+            pytest.raises(VehicleProjectCreationError) as exc_info,
+        ):
+            VehicleProjectCreator.template_dir_for_bin_import("UnknownVehicle", 9, 9)
+
+        assert exc_info.value.title == ".bin log import"
+        assert "UnknownVehicle" in exc_info.value.message
+        assert "empty_9.9.x" in exc_info.value.message
+
+    def test_extract_firmware_version_from_bin_log_returns_vehicle_type_and_version(self) -> None:
+        """
+        extract_firmware_version_from_bin_log returns (vehicle_type, major, minor, patch).
+
+        GIVEN: A .bin log file whose VER message reports ArduCopter 4.6.3
+        WHEN: extract_firmware_version_from_bin_log is called
+        THEN: Returns ("ArduCopter", 4, 6, 3)
+        """
+        with patch(
+            "ardupilot_methodic_configurator.extract_param_defaults.extract_firmware_version_and_vehicle_type",
+            return_value=("ArduCopter", 4, 6, 3),
+        ):
+            result = VehicleProjectCreator.extract_firmware_version_from_bin_log("any.bin")
+
+        assert result == ("ArduCopter", 4, 6, 3)
+
+    def test_extract_firmware_version_from_bin_log_raises_creation_error_on_failure(self) -> None:
+        """
+        extract_firmware_version_from_bin_log converts SystemExit to VehicleProjectCreationError.
+
+        GIVEN: A .bin log file with no firmware version information
+        WHEN: extract_firmware_version_from_bin_log is called
+        THEN: VehicleProjectCreationError is raised with the .bin log import title
+        """
+        with (
+            patch(
+                "ardupilot_methodic_configurator.extract_param_defaults.extract_firmware_version_and_vehicle_type",
+                side_effect=SystemExit("No VER or MSG message found"),
+            ),
+            pytest.raises(VehicleProjectCreationError) as exc_info,
+        ):
+            VehicleProjectCreator.extract_firmware_version_from_bin_log("no_ver.bin")
+
+        assert ".bin log import" in exc_info.value.title
+        assert "No VER or MSG message found" in exc_info.value.message
+
+    def test_vehicle_name_from_bin_log_uses_file_stem(self, project_creator) -> None:
+        """
+        vehicle_name_from_bin_log returns just the filename stem.
+
+        GIVEN: A user selects a .bin log file with a known name
+        WHEN: The helper derives the vehicle name
+        THEN: Only the filename without extension or directory is returned
+        """
+        # Arrange
+        bin_file = "/logs/2024-04-24/my_flight.bin"
+
+        # Act
+        result = VehicleProjectCreator.vehicle_name_from_bin_log(bin_file)
+
+        # Assert
+        assert result == "my_flight"
+
+    def test_next_import_filename_starts_at_one_when_no_param_files_exist(self, tmp_path) -> None:
+        """
+        next_import_filename returns 01_… when there are no .param files.
+
+        GIVEN: A newly created vehicle directory with no .param files
+        WHEN: The next import filename is requested
+        THEN: The filename should start with "01_"
+        """
+        # Arrange: empty directory (no .param files)
+        vehicle_dir = str(tmp_path)
+
+        # Act
+        result = VehicleProjectCreator.next_import_filename(vehicle_dir)
+
+        # Assert: the canonical import filename is returned verbatim
+        assert result == "01_imported_bin_log_parameters.param"
+
+    def test_next_import_filename_increments_beyond_highest_numbered_file(self, tmp_path) -> None:
+        """
+        next_import_filename returns one higher than the highest existing prefix.
+
+        GIVEN: A vehicle directory containing numbered .param files up to prefix 05
+        WHEN: The next import filename is requested
+        THEN: The filename should start with "06_"
+        """
+        # Arrange: create some numbered .param files
+        for name in ("01_setup.param", "03_tuning.param", "05_final.param"):
+            (tmp_path / name).write_text("")
+
+        # Act
+        result = VehicleProjectCreator.next_import_filename(str(tmp_path))
+
+        # Assert
+        assert result == "06_imported_bin_log_parameters.param"
+
+    def test_next_import_filename_ignores_non_param_files(self, tmp_path) -> None:
+        """
+        next_import_filename ignores files that are not .param files.
+
+        GIVEN: A vehicle directory containing a mix of file types
+        WHEN: The next import filename is requested
+        THEN: Non-.param files are not counted and do not affect the prefix
+        """
+        # Arrange: one .param file and one unrelated file with a high numeric name
+        (tmp_path / "03_setup.param").write_text("")
+        (tmp_path / "99_readme.txt").write_text("")
+
+        # Act
+        result = VehicleProjectCreator.next_import_filename(str(tmp_path))
+
+        # Assert: txt file must not have inflated the counter
+        assert result == "04_imported_bin_log_parameters.param"
+
+    def test_next_import_filename_converts_os_error_to_creation_error(self, tmp_path, monkeypatch) -> None:
+        """
+        next_import_filename converts filesystem errors into VehicleProjectCreationError.
+
+        GIVEN: The vehicle directory cannot be scanned due to an OSError
+        WHEN: next_import_filename is called
+        THEN: VehicleProjectCreationError is raised with a Parameter import title
+        """
+        vehicle_dir = str(tmp_path)
+
+        def raise_os_error(_: Path) -> None:
+            msg = "permission denied"
+            raise OSError(msg)
+
+        monkeypatch.setattr(Path, "iterdir", raise_os_error)
+
+        with pytest.raises(VehicleProjectCreationError) as exc_info:
+            VehicleProjectCreator.next_import_filename(vehicle_dir)
+
+        assert exc_info.value.title == "Parameter import"
+        assert "permission denied" in exc_info.value.message
+        assert vehicle_dir in exc_info.value.message
+
+    def test_next_import_filename_raises_when_all_slots_used(self, tmp_path) -> None:
+        """
+        next_import_filename raises VehicleProjectCreationError when slot 99 is taken.
+
+        GIVEN: A vehicle directory where a .param file already uses prefix 99
+        WHEN: The next import filename is requested
+        THEN: VehicleProjectCreationError is raised
+        """
+        # Arrange: prefix 99 is occupied
+        (tmp_path / "99_last.param").write_text("")
+
+        # Act & Assert
+        with pytest.raises(VehicleProjectCreationError) as exc_info:
+            VehicleProjectCreator.next_import_filename(str(tmp_path))
+
+        assert exc_info.value.title == "Parameter import"
+        assert str(tmp_path) in exc_info.value.message
+
+    def test_extract_param_files_from_bin_log_returns_two_par_dicts(self) -> None:
+        """
+        extract_param_files_from_bin_log returns (defaults, current) ParDict pair.
+
+        GIVEN: A valid .bin log file that extract_parameter_values can parse
+        WHEN: extract_param_files_from_bin_log is called
+        THEN: Two non-empty ParDict objects are returned (defaults first, current second)
+        """
+        # Arrange
+        fake_defaults = {"PARAM_A": 1.0, "PARAM_B": 2.0}
+        fake_current = {"PARAM_A": 1.5, "PARAM_B": 2.0, "PARAM_C": 3.0}
+
+        with patch(
+            "ardupilot_methodic_configurator.extract_param_defaults.extract_parameter_values",
+            side_effect=[fake_defaults, fake_current],
+        ):
+            # Act
+            result_defaults, result_current = VehicleProjectCreator.extract_param_files_from_bin_log("any.bin")
+
+        # Assert: both results are ParDict instances with correct keys and values
+        assert isinstance(result_defaults, ParDict)
+        assert isinstance(result_current, ParDict)
+        assert set(result_defaults.keys()) == {"PARAM_A", "PARAM_B"}
+        assert result_defaults["PARAM_A"].value == pytest.approx(1.0)
+        assert result_defaults["PARAM_B"].value == pytest.approx(2.0)
+        assert set(result_current.keys()) == {"PARAM_A", "PARAM_B", "PARAM_C"}
+        assert result_current["PARAM_A"].value == pytest.approx(1.5)
+        assert result_current["PARAM_C"].value == pytest.approx(3.0)
+
+    def test_extract_param_files_raises_creation_error_when_extraction_fails(self) -> None:
+        """
+        extract_param_files_from_bin_log converts SystemExit into VehicleProjectCreationError.
+
+        GIVEN: A .bin log file that extract_parameter_values cannot parse
+        WHEN: extract_param_files_from_bin_log is called
+        THEN: VehicleProjectCreationError is raised with the .bin log import title
+        """
+        with (
+            patch(
+                "ardupilot_methodic_configurator.extract_param_defaults.extract_parameter_values",
+                side_effect=SystemExit("bad log"),
+            ),
+            pytest.raises(VehicleProjectCreationError) as exc_info,
+        ):
+            VehicleProjectCreator.extract_param_files_from_bin_log("corrupt.bin")
+
+        assert ".bin log import" in exc_info.value.title
+        assert "bad log" in exc_info.value.message
+
+
+class TestGetFCDependentErrorMessageWorksForParams:
+    """Test the non-guard-clause cases of get_fc_dependent_error_message."""
 
     def test_get_fc_dependent_error_message_works_for_param_dependent(self) -> None:
         """

--- a/tests/test_extract_param_defaults.py
+++ b/tests/test_extract_param_defaults.py
@@ -21,6 +21,7 @@ from ardupilot_methodic_configurator.extract_param_defaults import (
     MAVLINK_SYSID_MAX,
     NO_DEFAULT_VALUES_MESSAGE,
     create_argument_parser,
+    extract_firmware_version_and_vehicle_type,
     extract_parameter_values,
     mavproxy_sort,
     missionplanner_sort,
@@ -469,7 +470,7 @@ class TestCreateArgumentParser:  # pylint: disable=too-few-public-methods
         assert args.bin_file == "dummy.bin"
 
 
-class TestSortParams:
+class TestSortParams:  # pylint: disable=too-few-public-methods
     """Tests for the sort_params function."""
 
     def test_sort_params_none(self) -> None:
@@ -478,6 +479,239 @@ class TestSortParams:
 
         # With sort_type "none", the order should be preserved
         assert list(sorted_params.keys()) == ["B_PARAM", "A_PARAM", "C_PARAM"]
+
+
+class TestExtractFirmwareVersionAndVehicleType:
+    """BDD tests for extract_firmware_version_and_vehicle_type."""
+
+    def _make_mlog(self, messages: list) -> MagicMock:
+        """Build a mock mavlink connection that yields the given messages then None."""
+        mlog = MagicMock()
+        mlog.recv_match.side_effect = [*messages, None]
+        return mlog
+
+    def _make_ver_msg(self, fws: str, maj: int, min_: int, pat: int) -> MagicMock:
+        msg = MagicMock()
+        msg.get_type.return_value = "VER"
+        msg.FWS = fws
+        msg.Maj = maj
+        msg.Min = min_
+        msg.Pat = pat
+        return msg
+
+    def _make_msg_msg(self, text: str) -> MagicMock:
+        msg = MagicMock()
+        msg.get_type.return_value = "MSG"
+        msg.Message = text
+        return msg
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_ver_message_returns_full_four_tuple(self, mock_conn: MagicMock) -> None:
+        """
+        VER message produces a complete (vehicle_type, major, minor, patch) 4-tuple.
+
+        GIVEN: A .bin log whose first relevant message is a VER record for ArduCopter 4.6.3
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Returns ("ArduCopter", 4, 6, 3) with all four components correct
+        """
+        ver = self._make_ver_msg("ArduCopter V4.6.3 (3fc7011a)", 4, 6, 3)
+        mock_conn.return_value = self._make_mlog([ver])
+
+        result = extract_firmware_version_and_vehicle_type("flight.bin")
+
+        assert result == ("ArduCopter", 4, 6, 3)
+        vehicle_type, major, minor, patchv = result
+        assert vehicle_type == "ArduCopter"
+        assert major == 4
+        assert minor == 6
+        assert patchv == 3
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_ver_message_extracts_correct_vehicle_type_from_fws_field(self, mock_conn: MagicMock) -> None:
+        """
+        Vehicle type comes from the first word of the FWS field, not from a separate field.
+
+        GIVEN: A VER message where FWS is "ArduPlane V4.5.1 (abcdef01)"
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: vehicle_type is "ArduPlane" and version components are (4, 5, 1)
+        """
+        ver = self._make_ver_msg("ArduPlane V4.5.1 (abcdef01)", 4, 5, 1)
+        mock_conn.return_value = self._make_mlog([ver])
+
+        vehicle_type, major, minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "ArduPlane"
+        assert major == 4
+        assert minor == 5
+        assert patchv == 1
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_ver_message_with_patch_zero(self, mock_conn: MagicMock) -> None:
+        """
+        VER message with Pat=0 correctly returns patch=0 rather than a default or absent value.
+
+        GIVEN: A VER message where Pat field is 0
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: The returned patch component is exactly 0
+        """
+        ver = self._make_ver_msg("Rover V4.4.0 (deadbeef)", 4, 4, 0)
+        mock_conn.return_value = self._make_mlog([ver])
+
+        vehicle_type, major, minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "Rover"
+        assert major == 4
+        assert minor == 4
+        assert patchv == 0
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_ver_message_takes_priority_over_msg_message(self, mock_conn: MagicMock) -> None:
+        """
+        VER message is preferred and MSG fallback is ignored when VER is present.
+
+        GIVEN: A log containing a MSG message followed by a VER message
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Data comes from VER, not MSG; the MSG data is completely ignored
+        """
+        msg_first = self._make_msg_msg("ArduPlane V3.9.9 (stale-hash)")
+        ver_second = self._make_ver_msg("ArduCopter V4.6.3 (correct)", 4, 6, 3)
+        mock_conn.return_value = self._make_mlog([msg_first, ver_second])
+
+        vehicle_type, major, minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "ArduCopter"
+        assert major == 4
+        assert minor == 6
+        assert patchv == 3
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_msg_fallback_used_when_no_ver_message(self, mock_conn: MagicMock) -> None:
+        """
+        MSG message is used as fallback when VER message is absent.
+
+        GIVEN: A .bin log that contains only a MSG record for ArduCopter V4.6.3
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Returns ("ArduCopter", 4, 6, 3) parsed from the MSG text
+        """
+        msg = self._make_msg_msg("ArduCopter V4.6.3 (3fc7011a)")
+        mock_conn.return_value = self._make_mlog([msg])
+
+        vehicle_type, major, minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "ArduCopter"
+        assert major == 4
+        assert minor == 6
+        assert patchv == 3
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_msg_fallback_without_patch_defaults_to_zero(self, mock_conn: MagicMock) -> None:
+        """
+        MSG fallback with only major.minor (no patch) returns patch=0.
+
+        GIVEN: A MSG record that reads "ArduCopter V4.6 (hash)" (no patch component)
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Returns ("ArduCopter", 4, 6, 0) with patch defaulted to 0
+        """
+        msg = self._make_msg_msg("ArduCopter V4.6 (3fc7011a)")
+        mock_conn.return_value = self._make_mlog([msg])
+
+        vehicle_type, major, minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "ArduCopter"
+        assert major == 4
+        assert minor == 6
+        assert patchv == 0
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_first_parseable_msg_message_is_used_as_fallback(self, mock_conn: MagicMock) -> None:
+        """
+        The first MSG record with a parseable Vx.y version is used; unparsable ones are skipped.
+
+        GIVEN: Two MSG messages - first is a boot log line without a version, second is ArduCopter 4.6.3
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Data is from the second (parseable) MSG message
+        """
+        msg1 = self._make_msg_msg("Boot started")
+        msg2 = self._make_msg_msg("ArduCopter V4.6.3 (hash1)")
+        mock_conn.return_value = self._make_mlog([msg1, msg2])
+
+        vehicle_type, _major, _minor, patchv = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert vehicle_type == "ArduCopter"
+        assert patchv == 3
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_raises_system_exit_when_logfile_cannot_be_opened(self, mock_conn: MagicMock) -> None:
+        """
+        A SystemExit is raised with an informative message when the logfile cannot be opened.
+
+        GIVEN: A logfile path that causes mavlink_connection to raise an exception
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: SystemExit is raised with a message mentioning the logfile path
+        """
+        mock_conn.side_effect = Exception("file not found")
+
+        with pytest.raises(SystemExit) as exc_info:
+            extract_firmware_version_and_vehicle_type("missing.bin")
+
+        assert "missing.bin" in str(exc_info.value)
+        assert "Error opening" in str(exc_info.value)
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_raises_system_exit_when_no_version_information_found(self, mock_conn: MagicMock) -> None:
+        """
+        A SystemExit is raised when neither VER nor parseable MSG is found.
+
+        GIVEN: A .bin log that contains no VER or MSG messages
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: SystemExit is raised with a message mentioning the logfile and "No firmware version"
+        """
+        mock_conn.return_value = self._make_mlog([])  # No messages at all
+
+        with pytest.raises(SystemExit) as exc_info:
+            extract_firmware_version_and_vehicle_type("empty.bin")
+
+        assert "empty.bin" in str(exc_info.value)
+        assert "No firmware version" in str(exc_info.value)
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_raises_system_exit_when_msg_version_format_is_unparseable(self, mock_conn: MagicMock) -> None:
+        """
+        A SystemExit is raised when the MSG version string cannot be parsed.
+
+        GIVEN: A MSG record whose text contains no recognisable "Vx.y" pattern
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: SystemExit is raised
+        """
+        msg = self._make_msg_msg("Boot started")
+        mock_conn.return_value = self._make_mlog([msg])
+
+        with pytest.raises(SystemExit) as exc_info:
+            extract_firmware_version_and_vehicle_type("bad.bin")
+
+        assert "bad.bin" in str(exc_info.value)
+
+    @patch("ardupilot_methodic_configurator.extract_param_defaults.mavutil.mavlink_connection")
+    def test_return_type_is_tuple_of_str_int_int_int(self, mock_conn: MagicMock) -> None:
+        """
+        The return value has the correct types for all four components.
+
+        GIVEN: A valid VER message
+        WHEN: extract_firmware_version_and_vehicle_type is called
+        THEN: Returns a 4-tuple of (str, int, int, int) — not floats or strings for version numbers
+        """
+        ver = self._make_ver_msg("Heli V4.5.2 (cafebabe)", 4, 5, 2)
+        mock_conn.return_value = self._make_mlog([ver])
+
+        result = extract_firmware_version_and_vehicle_type("log.bin")
+
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+        vehicle_type, major, minor, patchv = result
+        assert isinstance(vehicle_type, str)
+        assert isinstance(major, int)
+        assert isinstance(minor, int)
+        assert isinstance(patchv, int)
 
     def test_sort_params_qgcs(self) -> None:
         params = {"ZZZ_PARAM": 3.0, "AAA_PARAM": 1.0, "MMM_PARAM": 2.0}


### PR DESCRIPTION
# Description

Add a "Create a vehicle project from a .bin log file" button to the
New Vehicle panel in the project-opener window.

Business logic additions in data_model_vehicle_project_creator.py:
- extract_param_files_from_bin_log(): calls extract_parameter_values()
  for both "defaults" and "values" snapshots; wraps results as ParDict
- template_dir_for_bin_import(): returns the empty_4.6.x template path
- vehicle_name_from_bin_log(): derives the new vehicle name from the
  .bin file stem
- next_import_filename(): finds the next available numbered slot for the
  imported parameter file

Orchestration in data_model_vehicle_project.py
(create_new_vehicle_from_bin_log):
- Scaffolds the project from empty_4.6.x with current FC params used for
  template substitution
- Replaces the template's 00_default.param with the .bin-extracted
  defaults snapshot (key deviation from normal template-based creation)
- Exports remaining current parameters into a numbered
  *_imported_bin_log_parameters.param file

GUI additions:
- BinLogSelectionWidgets reusable widget added to
  frontend_tkinter_directory_selection.py
- Widget wired into VehicleProjectOpenerWindow.create_option1_widgets()

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Tested on flight controller hardware
