### PR TITLE
fix(filesystem): guard get_start_file against IndexError on small file lists

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -774,7 +774,7 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
             return files[start_file_index]
 
         # In the no-tcal branch the historical behaviour is files[2], i.e. skip
-        # the first two files (typically 00_default.param + 01_tcal.param). Fall
+        # the first two files (typically 02_imu_temperature_calibration_setup.param + 03_imu_temperature_calibration_results.param). Fall
         # back to the last available file when fewer than 3 files are present
         # so we never crash on a small or non-standard file set.
         if tcal_available:

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -758,10 +758,10 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         # Get the list of intermediate parameter files files that will be processed sequentially
         files = list(self.file_parameters.keys())
 
-        if explicit_index >= 0:
-            if not files:
-                return ""
+        if not files:
+            return ""
 
+        if explicit_index >= 0:
             # Determine the starting file based on the --n command line argument
             start_file_index = explicit_index  # Ensure the index is within the range of available files
             if start_file_index >= len(files):
@@ -777,7 +777,10 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
             start_file = files[0]
             info_msg = _("Starting with the first file.")
         else:
-            start_file = files[2]
+            # files[2] skips 00_default.param + 01_tcal.param when tcal is not
+            # available; fall back to the last file if fewer than 3 are present
+            # so we never crash on a small or non-standard file set.
+            start_file = files[2] if len(files) >= 3 else files[-1]
             info_msg = _("Starting with the first non-tcal file.")
 
         last_uploaded_filename = self.__read_last_uploaded_filename()

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -773,15 +773,19 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 )
             return files[start_file_index]
 
+        # In the no-tcal branch the historical behaviour is files[2], i.e. skip
+        # the first two files (typically 00_default.param + 01_tcal.param). Fall
+        # back to the last available file when fewer than 3 files are present
+        # so we never crash on a small or non-standard file set.
         if tcal_available:
             start_file = files[0]
             info_msg = _("Starting with the first file.")
-        else:
-            # files[2] skips 00_default.param + 01_tcal.param when tcal is not
-            # available; fall back to the last file if fewer than 3 are present
-            # so we never crash on a small or non-standard file set.
-            start_file = files[2] if len(files) >= 3 else files[-1]
+        elif len(files) >= 3:
+            start_file = files[2]
             info_msg = _("Starting with the first non-tcal file.")
+        else:
+            start_file = files[-1]
+            info_msg = _("Fewer than three files available; starting with the last file.")
 
         last_uploaded_filename = self.__read_last_uploaded_filename()
         if last_uploaded_filename:

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -773,9 +773,9 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 )
             return files[start_file_index]
 
-        # In the no-tcal branch the historical behaviour is files[2], i.e. skip
-        # the first two files (typically 02_imu_temperature_calibration_setup.param + 03_imu_temperature_calibration_results.param). Fall
-        # back to the last available file when fewer than 3 files are present
+        # In the no-tcal branch the historical behaviour is files[2], i.e. skip the first two files,
+        # typically 02_imu_temperature_calibration_setup.param + 03_imu_temperature_calibration_results.param.
+        # Fall back to the last available file when fewer than 3 files are present
         # so we never crash on a small or non-standard file set.
         if tcal_available:
             start_file = files[0]

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -504,6 +504,44 @@ class TestLocalFilesystem(unittest.TestCase):  # pylint: disable=too-many-public
         result = lfs.get_start_file(1, tcal_available=True)
         assert result == ""
 
+    def test_get_start_file_empty_files_no_explicit_index(self) -> None:
+        """
+        Regression: get_start_file must not crash with an empty file list.
+
+        GIVEN: A vehicle directory with no intermediate parameter files
+        WHEN: get_start_file is called with the implicit (-1) index
+        THEN: An empty string is returned for both tcal branches instead of an
+              IndexError on files[0] / files[2].
+        """
+        lfs = LocalFilesystem(
+            "vehicle_dir", "vehicle_type", None, allow_editing_template_files=False, save_component_to_system_templates=False
+        )
+        lfs.file_parameters = {}
+
+        assert lfs.get_start_file(-1, tcal_available=True) == ""
+        assert lfs.get_start_file(-1, tcal_available=False) == ""
+
+    def test_get_start_file_fewer_than_three_files_no_tcal(self) -> None:
+        """
+        Regression: get_start_file must not raise IndexError on files[2].
+
+        It must not raise when fewer than three intermediate parameter files
+        exist and IMU temperature calibration is not available.
+
+        GIVEN: A vehicle directory with one or two parameter files
+        WHEN: get_start_file is called with implicit index and tcal_available=False
+        THEN: A valid filename is returned (the last file) rather than crashing.
+        """
+        lfs = LocalFilesystem(
+            "vehicle_dir", "vehicle_type", None, allow_editing_template_files=False, save_component_to_system_templates=False
+        )
+
+        lfs.file_parameters = {"01_only.param": {}}
+        assert lfs.get_start_file(-1, tcal_available=False) == "01_only.param"
+
+        lfs.file_parameters = {"01_a.param": {}, "02_b.param": {}}
+        assert lfs.get_start_file(-1, tcal_available=False) == "02_b.param"
+
     def test_get_eval_variables_with_none(self) -> None:
         """Test get_eval_variables with None values."""
         lfs = LocalFilesystem(


### PR DESCRIPTION
## Problem

`LocalFilesystem.get_start_file()` unconditionally accessed `files[0]` / `files[2]` in the implicit-index branch (`backend_filesystem.py:776-781`), which raised `IndexError` and crashed the application before any window appeared in two real scenarios:

1. **Empty vehicle directory** — no intermediate parameter files were loaded (e.g. user pointed the tool at the wrong folder, or `os_listdir` filtering produced no matches). The empty-list guard at the top of the function only covered the `explicit_index >= 0` branch, so the implicit `-1` path crashed on `files[0]` (tcal available) or `files[2]` (tcal not available).
2. **Fewer than three parameter files + tcal not available** — `files[2]` is positionally meant to skip `00_default.param` and `01_tcal.param`. Any non-standard or pared-down vehicle directory with one or two files crashed when the user was on a flight controller without IMU temperature calibration (or in simple-GUI mode where tcal is forced off via `imu_tcal_available and not simple_gui` in `__main__.py`).

Both crashes are surfaced before the main editor window opens, with no recovery path other than re-launching the tool against a different directory.

## Fix

- Move the `if not files: return ""` guard above both branches so the implicit-index path is also protected.
- In the no-tcal branch, fall back to `files[-1]` when `len(files) < 3` instead of indexing `[2]` blindly. The `files[2]` semantics (skip the two read-only setup files) is preserved for the standard 3-or-more-file case that all existing tests cover.

## Tests

Added two regression tests:

- `test_get_start_file_empty_files_no_explicit_index` — exercises the implicit-index branch with an empty file list for both tcal flags.
- `test_get_start_file_fewer_than_three_files_no_tcal` — covers 1-file and 2-file directories with `tcal_available=False`.

All 74 tests in `tests/test_backend_filesystem.py` pass. Pre-commit (ruff/codespell/reuse/gitleaks) clean.

## Signed-off-by

`Signed-off-by: Yash Goel <yashvardhan664@gmail.com>` is in the commit.