### PR TITLE
fix(progress): use update_idletasks() to avoid reentrant event dispatch

### DIFF
--- a/ardupilot_methodic_configurator/frontend_tkinter_flightcontroller_info.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_flightcontroller_info.py
@@ -153,8 +153,12 @@ class FlightControllerInfoWindow(BaseWindow):
         progress_message = _("Downloaded {} of {} parameters").format(current_value, max_value)
         self.progress_label.config(text=progress_message)
 
-        # Update the display
-        self.progress_bar.update()
+        # Update the display. update_idletasks() repaints the bar/label
+        # without re-entering the event loop; the plain update() variant
+        # would pump the full event queue (including queued user clicks
+        # against other windows) while the caller is still in the middle
+        # of a blocking parameter download.
+        self.progress_bar.update_idletasks()
         self.root.update_idletasks()
 
         # Hide progress bar when complete

--- a/ardupilot_methodic_configurator/frontend_tkinter_progress_window.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_progress_window.py
@@ -75,7 +75,11 @@ class ProgressWindow:
             # Show the window now that it's properly positioned
             self.progress_window.lift()
             self._shown = True
-            self.progress_bar.update()
+            # Use update_idletasks() rather than update(): the latter pumps the
+            # full event queue (including queued mouse clicks against other
+            # windows) and can re-enter user-event handlers while the caller
+            # is still in the middle of a blocking I/O operation.
+            self.progress_bar.update_idletasks()
 
     def _center_progress_window(self) -> None:
         """
@@ -133,7 +137,11 @@ class ProgressWindow:
                 # Update the progress message
                 self.progress_label.config(text=self.message.format(current_value, max_value))
 
-                self.progress_bar.update()
+                # update_idletasks() repaints the bar/label without re-entering
+                # the event loop. The plain update() variant processes pending
+                # user events (clicks, keypresses) which can fire callbacks on
+                # other windows while a blocking upload/download is in flight.
+                self.progress_bar.update_idletasks()
 
                 # Close the progress window when the process is complete
                 if current_value == max_value:

--- a/tests/test_frontend_tkinter_progress_window.py
+++ b/tests/test_frontend_tkinter_progress_window.py
@@ -278,7 +278,7 @@ class TestProgressWindowUserExperience:
         progress_window.update_progress_bar(25, 100)
 
         progress_window.progress_bar.update.assert_not_called()
-        progress_window.progress_bar.update_idletasks.assert_called()
+        progress_window.progress_bar.update_idletasks.assert_called_once()
 
     def test_user_sees_progress_window_handle_lazy_window_relift(self, progress_window) -> None:
         """

--- a/tests/test_frontend_tkinter_progress_window.py
+++ b/tests/test_frontend_tkinter_progress_window.py
@@ -247,8 +247,8 @@ class TestProgressWindowUserExperience:
         WHEN: Progress updates fail due to widget errors
         THEN: Errors are logged but no exceptions are raised
         """
-        # Mock progress_bar.update to raise TclError
-        progress_window.progress_bar.update = MagicMock(side_effect=tk.TclError("Widget destroyed"))
+        # Mock progress_bar.update_idletasks to raise TclError
+        progress_window.progress_bar.update_idletasks = MagicMock(side_effect=tk.TclError("Widget destroyed"))
 
         with patch("ardupilot_methodic_configurator.frontend_tkinter_progress_window.logging_error") as mock_logging:
             # This should not raise an exception
@@ -257,6 +257,28 @@ class TestProgressWindowUserExperience:
             # Verify error was logged
             mock_logging.assert_called_once()
             assert "Updating progress widgets" in mock_logging.call_args[0][0]
+
+    def test_progress_updates_do_not_pump_user_events(self, progress_window) -> None:
+        """
+        Progress updates must use update_idletasks(), not update().
+
+        GIVEN: A blocking I/O operation (param upload, FC connection, etc.) is
+            running on the main thread and periodically calling
+            update_progress_bar to refresh the bar.
+        WHEN: The progress window is initialised and then updated.
+        THEN: Only update_idletasks() is called on the progress bar. The
+            full update() variant pumps the entire event queue and would
+            re-dispatch user clicks that arrived during the blocking call,
+            allowing reentrant button callbacks while the caller is still
+            in the middle of upload/connection logic.
+        """
+        progress_window.progress_bar.update = MagicMock()
+        progress_window.progress_bar.update_idletasks = MagicMock()
+
+        progress_window.update_progress_bar(25, 100)
+
+        progress_window.progress_bar.update.assert_not_called()
+        progress_window.progress_bar.update_idletasks.assert_called()
 
     def test_user_sees_progress_window_handle_lazy_window_relift(self, progress_window) -> None:
         """


### PR DESCRIPTION
## Problem

Two progress bars in the GUI repaint themselves with `progress_bar.update()` while the main thread is mid-operation:

- `ProgressWindow.__init__` (`frontend_tkinter_progress_window.py:78`) — first repaint after the window is shown.
- `ProgressWindow.update_progress_bar` (`frontend_tkinter_progress_window.py:136`) — every progress tick during parameter upload, parameter download, FC connection, IMU temperature calibration, motor reset, etc.
- `FlightControllerInfoWindow.update_progress_bar` (`frontend_tkinter_flightcontroller_info.py:157`) — every progress tick during the FC parameter download performed before the editor opens.

`tkinter.Misc.update()` pumps the **entire** event queue. That includes any user clicks, key presses, or window events that arrived against other Toplevel windows while the long blocking call was holding the main thread (MAVLink I/O is fully synchronous in this codebase). Those queued handlers fire **reentrantly** while the caller is still mid-operation. Concretely this can:

- retrigger an upload/download whose state machine is not yet idle (the user double-clicks "Upload", the second click sits in the queue, the first upload calls `update_progress_bar`, the second click handler now runs from inside the first one).
- close or rebuild widgets the caller still holds references to (the user clicks the close button on a parent window; that handler now runs while the upload is in flight).
- dispatch destructor paths on a window the caller will dereference moments later.

Reentrancy through `update()` is a well-documented tkinter footgun (Python docs explicitly warn: *"This method should be used with care, since it may lead to unexpected events because of recursive calls into update."*).

## Fix

Replace the three `progress_bar.update()` calls with `progress_bar.update_idletasks()`. The idle-task variant flushes geometry and repaint events but does **not** run user-event handlers, which is exactly the semantics needed: the bar and label still repaint, but no other callback fires.

The visible behaviour is unchanged because progress-bar redraw is an idle task — only the unintended event dispatch is removed.

## Tests

- Updated `test_user_sees_progress_window_handle_widget_update_errors` to mock the new method (`update_idletasks` instead of `update`).
- Added `test_progress_updates_do_not_pump_user_events` as a regression guard: it asserts `progress_bar.update` is **not** called and `progress_bar.update_idletasks` **is** called when `update_progress_bar` runs, so a future refactor cannot silently restore the reentrant variant.

All 18 tests in `tests/test_frontend_tkinter_progress_window.py` and all 32 tests in `tests/test_frontend_tkinter_flightcontroller_info.py` pass. Pre-commit (ruff/codespell/reuse/gitleaks) clean.

## Signed-off-by

`Signed-off-by: Yash Goel <yashvardhan664@gmail.com>` is in the commit.