### PR TITLE
Use Ubuntu 22.04 because Ubuntu 20.04 has been deprecated by github.com

### DIFF
--- a/.github/workflows/build_windows_macos.yml
+++ b/.github/workflows/build_windows_macos.yml
@@ -252,7 +252,7 @@ jobs:
           retention-days: 7
 
   build_linux:
-    runs-on: 'ubuntu-20.04'  # Use a consistent Linux environment for building the AppImage
+    runs-on: 'ubuntu-22.04'  # Use a consistent Linux environment for building the AppImage
     strategy:
       matrix:
         python-version: ['3.14']


### PR DESCRIPTION
# Description

Use Ubuntu 22.04 because Ubuntu 20.04 has been deprecated by github.com

## Checklist

- [ ] Run pre-commit checks locally
- [ ] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [ ] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [ ] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
