### PR TITLE
Add unit branch coverage for FC commands/params and split safe_write test helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ test.xml
 sitl/arducopter
 sitl/firmware-version.txt
 sitl/git-version.txt
+
+tuning_report.csv

--- a/ardupilot_methodic_configurator/backend_safe_file_io.py
+++ b/ardupilot_methodic_configurator/backend_safe_file_io.py
@@ -9,12 +9,10 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import io
-import json
 import os
 import tempfile
 from contextlib import suppress
-from typing import IO, Any, Callable
+from typing import IO, Callable
 
 
 def safe_write(filepath: str, write_func: Callable[[IO[str]], object]) -> None:
@@ -75,38 +73,3 @@ def safe_write(filepath: str, write_func: Callable[[IO[str]], object]) -> None:
         if not replaced:
             with suppress(OSError):
                 os.unlink(tmp_path)
-
-
-# ==================== SAFE-WRITE TEST HELPERS ====================
-
-
-def make_capture_safe_write() -> tuple[  # pragma: no cover
-    dict[str, Any], list[bool], Callable[[str, Callable[[IO[str]], object]], None]
-]:
-    """
-    Create a ``safe_write`` side-effect that captures written JSON data.
-
-    Returns a (captured_data, called, side_effect) triple:
-    - ``captured_data``: dict updated with the JSON that the write_func produces.
-    - ``called``: single-element list (``[False]``) flipped to ``True`` on invocation.
-    - ``side_effect``: function to assign to ``mock_safe_write.side_effect``.
-
-    Usage::
-
-        captured_data, called, side_effect = make_capture_safe_write()
-        mock_safe_write.side_effect = side_effect
-        ...
-        assert called[0]
-        assert captured_data == expected
-
-    """
-    captured_data: dict[str, Any] = {}
-    called: list[bool] = [False]
-
-    def _capture(_filepath: str, write_func: Callable[[IO[str]], object]) -> None:
-        fake_file = io.StringIO()
-        write_func(fake_file)
-        captured_data.update(json.loads(fake_file.getvalue()))
-        called[0] = True
-
-    return captured_data, called, _capture

--- a/tests/bdd_backend_safe_file_io.py
+++ b/tests/bdd_backend_safe_file_io.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+
+"""
+BDD-style tests for the backend_safe_file_io.py file.
+
+Tests for crash-safe atomic file writing utilities.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ardupilot_methodic_configurator.backend_safe_file_io import safe_write
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def tmp_file(tmp_path: Path) -> Path:
+    """Fixture providing a temporary file path."""
+    return tmp_path / "test_output.json"
+
+
+class TestSafeWriteBasicBehavior:
+    """Tests for basic safe_write behavior."""
+
+    def test_user_can_write_content_to_new_file(self, tmp_file: Path) -> None:
+        """
+        User can write content to a new file atomically.
+
+        GIVEN: A target file path that does not yet exist
+        WHEN: User calls safe_write with a write function
+        THEN: File should be created with the correct content
+        AND: No temporary files should remain
+        """
+        content = "Hello, World!\n"
+
+        safe_write(str(tmp_file), lambda f: f.write(content))
+
+        assert tmp_file.exists()
+        assert tmp_file.read_text(encoding="utf-8") == content
+
+    def test_user_can_overwrite_existing_file(self, tmp_file: Path) -> None:
+        """
+        User can atomically overwrite an existing file.
+
+        GIVEN: A target file already containing some content
+        WHEN: User calls safe_write with new content
+        THEN: File should contain only the new content
+        AND: Original content should be replaced
+        """
+        tmp_file.write_text("old content\n", encoding="utf-8")
+
+        safe_write(str(tmp_file), lambda f: f.write("new content\n"))
+
+        assert tmp_file.read_text(encoding="utf-8") == "new content\n"
+
+    def test_file_is_fully_written_before_target_is_replaced(self, tmp_file: Path) -> None:
+        """
+        File is fully written to a temp location before replacing the target.
+
+        GIVEN: A target file with existing content
+        WHEN: safe_write is called with large content
+        THEN: Target should contain the complete new content
+        AND: File should be readable immediately after write
+        """
+        large_content = "x" * 100000 + "\n"
+
+        safe_write(str(tmp_file), lambda f: f.write(large_content))
+
+        result = tmp_file.read_text(encoding="utf-8")
+        assert result == large_content
+
+    def test_user_can_write_json_content(self, tmp_file: Path) -> None:
+        """
+        User can write JSON content to a file using safe_write.
+
+        GIVEN: A dictionary of data to persist
+        WHEN: User writes JSON data via safe_write
+        THEN: File should contain valid JSON with the expected data
+        """
+        data = {"key": "value", "number": 42, "nested": {"list": [1, 2, 3]}}
+
+        safe_write(str(tmp_file), lambda f: json.dump(data, f, indent=2))
+
+        written = json.loads(tmp_file.read_text(encoding="utf-8"))
+        assert written == data
+
+    def test_user_can_write_unicode_content(self, tmp_file: Path) -> None:
+        """
+        User can write Unicode content to a file using safe_write.
+
+        GIVEN: Text content containing non-ASCII Unicode characters
+        WHEN: User writes the content via safe_write
+        THEN: File should be readable with the correct Unicode content preserved
+        """
+        unicode_content = "Héllo Wörld — 日本語テスト\n"
+
+        safe_write(str(tmp_file), lambda f: f.write(unicode_content))
+
+        assert tmp_file.read_text(encoding="utf-8") == unicode_content
+
+    def test_no_temporary_files_remain_after_successful_write(self, tmp_path: Path) -> None:
+        """
+        No temporary files remain after a successful write operation.
+
+        GIVEN: A target file path
+        WHEN: safe_write completes successfully
+        THEN: No .tmp files should remain in the directory
+        """
+        tmp_file = tmp_path / "output.json"
+
+        safe_write(str(tmp_file), lambda f: f.write("content"))
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert not tmp_files, f"Found leftover temp files: {tmp_files}"
+
+
+class TestSafeWriteFilePermissions:
+    """Tests for safe_write file permission handling."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits are not meaningful on Windows")
+    def test_new_file_gets_default_permissions(self, tmp_file: Path) -> None:
+        """
+        New file created by safe_write gets reasonable default permissions.
+
+        GIVEN: A target file path that does not exist
+        WHEN: safe_write creates the file
+        THEN: File should have readable permissions
+        """
+        safe_write(str(tmp_file), lambda f: f.write("content"))
+
+        assert os.access(str(tmp_file), os.R_OK)
+        assert os.access(str(tmp_file), os.W_OK)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits are not meaningful on Windows")
+    def test_file_permissions_are_preserved_on_overwrite(self, tmp_file: Path) -> None:
+        """
+        Existing file permissions are preserved when safe_write overwrites the file.
+
+        GIVEN: An existing file with specific permissions
+        WHEN: safe_write overwrites it
+        THEN: The file permissions should be preserved (or close to original)
+        """
+        tmp_file.write_text("original content", encoding="utf-8")
+        original_mode = os.stat(str(tmp_file)).st_mode
+
+        safe_write(str(tmp_file), lambda f: f.write("new content"))
+
+        new_mode = os.stat(str(tmp_file)).st_mode
+        # Permissions should be preserved (same mode bits for owner/group/other read+write)
+        assert (new_mode & 0o666) == (original_mode & 0o666)
+
+    def test_safe_write_handles_file_not_found_for_stat(self, tmp_path: Path) -> None:
+        """
+        safe_write handles the case where the target doesn't exist (for stat).
+
+        GIVEN: A target file path that does not exist
+        WHEN: safe_write tries to stat the target to preserve permissions
+        THEN: FileNotFoundError should be handled gracefully
+        AND: The write should still succeed with default permissions
+        """
+        new_file = tmp_path / "nonexistent_parent" / "output.txt"
+        new_file.parent.mkdir(parents=True)
+
+        safe_write(str(new_file), lambda f: f.write("content"))
+
+        assert new_file.exists()
+        assert new_file.read_text(encoding="utf-8") == "content"
+
+
+class TestSafeWriteErrorHandling:
+    """Tests for safe_write error handling behavior."""
+
+    def test_cleanup_happens_when_write_fails(self, tmp_path: Path) -> None:
+        """
+        Temporary file is cleaned up when write function raises an exception.
+
+        GIVEN: A write function that raises an exception
+        WHEN: safe_write is called and the write fails
+        THEN: No temporary files should remain in the directory
+        AND: An exception should be raised to the caller
+        """
+
+        def failing_write(_f: io.TextIOWrapper) -> None:
+            msg = "Simulated disk full"
+            raise OSError(msg)
+
+        tmp_file = tmp_path / "output.txt"
+
+        with pytest.raises(OSError, match="Simulated disk full"):
+            safe_write(str(tmp_file), failing_write)
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert not tmp_files, f"Temp files not cleaned up: {tmp_files}"
+
+        # Target should not have been created
+        assert not tmp_file.exists()
+
+    def test_directory_fsync_failure_does_not_break_write(self, tmp_file: Path) -> None:
+        """
+        Directory fsync failure does not break the write operation.
+
+        GIVEN: A system where directory fsync fails
+        WHEN: safe_write is called
+        THEN: The file write should still succeed
+        AND: The error from fsync should be silently ignored
+        """
+        with patch(
+            "ardupilot_methodic_configurator.backend_safe_file_io.os.fsync",
+            side_effect=[None, OSError("fsync failed")],
+        ):
+            safe_write(str(tmp_file), lambda f: f.write("test content"))
+
+        assert tmp_file.exists()
+        assert tmp_file.read_text(encoding="utf-8") == "test content"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import tkinter as tk
 from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pyautogui
 import pytest
@@ -35,6 +35,26 @@ from ardupilot_methodic_configurator.backend_flightcontroller import FlightContr
 from ardupilot_methodic_configurator.data_model_parameter_editor import ParameterEditor
 from ardupilot_methodic_configurator.frontend_tkinter_base_window import BaseWindow
 from ardupilot_methodic_configurator.frontend_tkinter_parameter_editor_table import NEW_VALUE_DIFFERENT_STR
+
+# ==================== SHARED FLIGHT CONTROLLER FIXTURES ====================
+
+
+@pytest.fixture
+def mock_connected_master() -> tuple[MagicMock, Mock]:
+    """
+    Provide a connected mock master and connection manager for flight controller tests.
+
+    Returns (mock_master, mock_conn_mgr) where mock_master has target_system=1 and
+    target_component=1 pre-configured. Tests that require different system/component IDs
+    should override those attributes directly after unpacking.
+    """
+    mock_master = MagicMock()
+    mock_master.target_system = 1
+    mock_master.target_component = 1
+    mock_conn_mgr = Mock()
+    mock_conn_mgr.master = mock_master
+    return mock_master, mock_conn_mgr
+
 
 # ==================== SHARED TKINTER TESTING CONFIGURATION ====================
 

--- a/tests/test_backend_filesystem_vehicle_components.py
+++ b/tests/test_backend_filesystem_vehicle_components.py
@@ -15,9 +15,9 @@ from json.decoder import JSONDecodeError as RealJSONDecodeError
 from unittest.mock import mock_open, patch
 
 import pytest
+from test_backend_safe_file_io_write_capture import make_capture_safe_write
 
 from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
-from ardupilot_methodic_configurator.backend_safe_file_io import make_capture_safe_write
 from ardupilot_methodic_configurator.data_model_template_overview import TemplateOverview
 
 # pylint: disable=too-many-lines,too-many-public-methods,attribute-defined-outside-init

--- a/tests/test_backend_flightcontroller_commands.py
+++ b/tests/test_backend_flightcontroller_commands.py
@@ -67,7 +67,7 @@ class TestFlightControllerCommandsInitialization:
 class TestFlightControllerCommandsMotorTest:
     """Test motor testing command functionality."""
 
-    def test_user_can_test_individual_motor(self) -> None:
+    def test_user_can_test_individual_motor(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can test individual motor at specified throttle.
 
@@ -77,17 +77,13 @@ class TestFlightControllerCommandsMotorTest:
         AND: Command acknowledgment should be received
         """
         # Given: Connected FC with ACK response
-        mock_master = MagicMock()
-        mock_master.target_system = 1
-        mock_master.target_component = 1
+        mock_master, mock_conn_mgr = mock_connected_master
 
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -129,7 +125,7 @@ class TestFlightControllerCommandsMotorTest:
 class TestFlightControllerCommandsBatteryStatus:
     """Test battery status request functionality."""
 
-    def test_user_can_request_battery_status(self) -> None:
+    def test_user_can_request_battery_status(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can request periodic battery status updates.
 
@@ -139,14 +135,12 @@ class TestFlightControllerCommandsBatteryStatus:
         AND: Command should be acknowledged
         """
         # Given: Connected FC
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -160,7 +154,7 @@ class TestFlightControllerCommandsBatteryStatus:
         assert success is True
         assert error == ""
 
-    def test_user_can_get_battery_status(self) -> None:
+    def test_user_can_get_battery_status(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can get current battery status from flight controller.
 
@@ -170,14 +164,12 @@ class TestFlightControllerCommandsBatteryStatus:
         AND: Values should be in expected ranges
         """
         # Given: FC with battery data
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_battery_msg = MagicMock()
         mock_battery_msg.voltages = [4200, 4180, 4190]  # mV
         mock_battery_msg.current_battery = 2500  # centi-amps
         mock_master.recv_match.return_value = mock_battery_msg
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
         mock_params_mgr.fc_parameters = {"BATT_MONITOR": 4.0}
 
@@ -189,16 +181,15 @@ class TestFlightControllerCommandsBatteryStatus:
         # Then: Status retrieved
         assert battery_data is not None
         assert message == ""
-        if battery_data:
-            voltage, current = battery_data
-            assert voltage > 0
-            assert current >= 0
+        voltage, current = battery_data
+        assert voltage > 0
+        assert current >= 0
 
 
 class TestFlightControllerCommandsParameterReset:  # pylint: disable=too-few-public-methods
     """Test parameter reset command functionality."""
 
-    def test_user_can_reset_all_parameters_to_defaults(self) -> None:
+    def test_user_can_reset_all_parameters_to_defaults(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can reset all parameters to factory defaults.
 
@@ -208,14 +199,12 @@ class TestFlightControllerCommandsParameterReset:  # pylint: disable=too-few-pub
         AND: Command should be acknowledged
         """
         # Given: Connected FC
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_PREFLIGHT_STORAGE
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -231,7 +220,7 @@ class TestFlightControllerCommandsParameterReset:  # pylint: disable=too-few-pub
 class TestFlightControllerCommandsSendCommandAndWaitAck:
     """Test low-level command sending with ACK waiting."""
 
-    def test_command_waits_for_acknowledgment(self) -> None:
+    def test_command_waits_for_acknowledgment(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         Command sending waits for proper acknowledgment.
 
@@ -241,14 +230,12 @@ class TestFlightControllerCommandsSendCommandAndWaitAck:
         AND: Return success when ACK received
         """
         # Given: FC that sends ACK
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_ack = MagicMock()
         mock_ack.command = 123
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -262,7 +249,7 @@ class TestFlightControllerCommandsSendCommandAndWaitAck:
         assert success is True
         assert error == ""
 
-    def test_command_timeout_returns_error(self) -> None:
+    def test_command_timeout_returns_error(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         Command timeout returns appropriate error.
 
@@ -272,11 +259,9 @@ class TestFlightControllerCommandsSendCommandAndWaitAck:
         AND: Error message should indicate timeout
         """
         # Given: FC that doesn't respond
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_master.recv_match.return_value = None
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -294,7 +279,7 @@ class TestFlightControllerCommandsSendCommandAndWaitAck:
 class TestFlightControllerCommandsPropertyDelegation:  # pylint: disable=too-few-public-methods
     """Test property delegation to connection manager."""
 
-    def test_master_property_delegates_to_connection_manager(self) -> None:
+    def test_master_property_delegates_to_connection_manager(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         Master property correctly delegates to connection manager.
 
@@ -303,9 +288,7 @@ class TestFlightControllerCommandsPropertyDelegation:  # pylint: disable=too-few
         THEN: Connection manager's master should be returned
         """
         # Given: Connection with master
-        mock_master = MagicMock()
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -320,16 +303,14 @@ class TestFlightControllerCommandsPropertyDelegation:  # pylint: disable=too-few
 class TestFlightControllerCommandsEdgeCases:
     """Additional edge-case tests for battery and command handling."""
 
-    def test_request_periodic_battery_status_denied(self) -> None:
+    def test_request_periodic_battery_status_denied(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """Battery status request should propagate NACK/denied responses."""
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL
         mock_ack.result = mavutil.mavlink.MAV_RESULT_DENIED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -339,14 +320,12 @@ class TestFlightControllerCommandsEdgeCases:
         assert success is False
         assert "denied" in error.lower() or "failed" in error.lower()
 
-    def test_get_battery_status_returns_recent_cache(self) -> None:
+    def test_get_battery_status_returns_recent_cache(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """Return cached battery data when no new telemetry is available but a recent value exists."""
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         # Simulate no new telemetry
         mock_master.recv_match.return_value = None
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
         mock_params_mgr.fc_parameters = {"BATT_MONITOR": 4.0}
 
@@ -360,16 +339,14 @@ class TestFlightControllerCommandsEdgeCases:
 
         assert data == (11.1, 2.2)
 
-    def test_get_battery_status_handles_invalid_readings(self) -> None:
+    def test_get_battery_status_handles_invalid_readings(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """BATTERY_STATUS messages with invalid sentinel values (-1) should be converted to zeros."""
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_battery_msg = MagicMock()
         mock_battery_msg.voltages = [-1]
         mock_battery_msg.current_battery = -1
         mock_master.recv_match.return_value = mock_battery_msg
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
         mock_params_mgr.fc_parameters = {"BATT_MONITOR": 4.0}
 
@@ -378,24 +355,19 @@ class TestFlightControllerCommandsEdgeCases:
         battery_data, _ = commands_mgr.get_battery_status()
 
         assert battery_data is not None
-        if battery_data:
-            voltage, current = battery_data
-            assert voltage == 0.0
-            assert current == 0.0
+        voltage, current = battery_data
+        assert voltage == 0.0
+        assert current == 0.0
 
-    def test_motor_test_denied_ack(self) -> None:
+    def test_motor_test_denied_ack(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """Motor test should fail when FC returns a DENIED acknowledgment."""
-        mock_master = MagicMock()
-        mock_master.target_system = 1
-        mock_master.target_component = 1
+        mock_master, mock_conn_mgr = mock_connected_master
 
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST
         mock_ack.result = mavutil.mavlink.MAV_RESULT_DENIED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -405,16 +377,14 @@ class TestFlightControllerCommandsEdgeCases:
         assert success is False
         assert "denied" in error.lower() or "failed" in error.lower()
 
-    def test_send_command_unknown_result(self) -> None:
+    def test_send_command_unknown_result(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """send_command_and_wait_ack should return an error for unknown result codes."""
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_ack = MagicMock()
         mock_ack.command = 999
         mock_ack.result = 9999  # unknown result
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -424,9 +394,9 @@ class TestFlightControllerCommandsEdgeCases:
         assert success is False
         assert "unknown result" in error.lower()
 
-    def test_send_command_in_progress_then_accepted(self) -> None:
+    def test_send_command_in_progress_then_accepted(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """send_command_and_wait_ack should handle IN_PROGRESS followed by ACCEPTED."""
-        mock_master = MagicMock()
+        mock_master, mock_conn_mgr = mock_connected_master
 
         in_progress = MagicMock()
         in_progress.command = 555
@@ -440,8 +410,6 @@ class TestFlightControllerCommandsEdgeCases:
         # First return in-progress, then accepted
         mock_master.recv_match.side_effect = [in_progress, accepted]
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -455,7 +423,7 @@ class TestFlightControllerCommandsEdgeCases:
 class TestFlightControllerCommandsAllMotors:
     """Test test_all_motors functionality."""
 
-    def test_user_can_test_all_motors(self) -> None:
+    def test_user_can_test_all_motors(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can test all motors simultaneously.
 
@@ -465,12 +433,7 @@ class TestFlightControllerCommandsAllMotors:
         AND: Method should return success
         """
         # Given: Connected FC
-        mock_master = MagicMock()
-        mock_master.target_system = 1
-        mock_master.target_component = 1
-
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
+        mock_master, mock_conn_mgr = mock_connected_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -509,7 +472,7 @@ class TestFlightControllerCommandsAllMotors:
 class TestFlightControllerCommandsSequencedMotors:
     """Test test_motors_in_sequence functionality."""
 
-    def test_user_can_test_motors_in_sequence(self) -> None:
+    def test_user_can_test_motors_in_sequence(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can test motors in sequence.
 
@@ -519,17 +482,13 @@ class TestFlightControllerCommandsSequencedMotors:
         AND: Method should return success
         """
         # Given: Connected FC with ACK response
-        mock_master = MagicMock()
-        mock_master.target_system = 1
-        mock_master.target_component = 1
+        mock_master, mock_conn_mgr = mock_connected_master
 
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
@@ -571,7 +530,7 @@ class TestFlightControllerCommandsSequencedMotors:
 class TestFlightControllerCommandsStopMotors:  # pylint: disable=too-few-public-methods
     """Test stop_all_motors functionality."""
 
-    def test_user_can_stop_all_motors(self) -> None:
+    def test_user_can_stop_all_motors(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
         """
         User can stop all motors with emergency stop command.
 
@@ -581,17 +540,13 @@ class TestFlightControllerCommandsStopMotors:  # pylint: disable=too-few-public-
         AND: Command should be acknowledged
         """
         # Given: Connected FC with ACK response
-        mock_master = MagicMock()
-        mock_master.target_system = 1
-        mock_master.target_component = 1
+        mock_master, mock_conn_mgr = mock_connected_master
 
         mock_ack = MagicMock()
         mock_ack.command = mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST
         mock_ack.result = mavutil.mavlink.MAV_RESULT_ACCEPTED
         mock_master.recv_match.return_value = mock_ack
 
-        mock_conn_mgr = Mock()
-        mock_conn_mgr.master = mock_master
         mock_params_mgr = Mock()
 
         commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)

--- a/tests/test_backend_safe_file_io_write_capture.py
+++ b/tests/test_backend_safe_file_io_write_capture.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+"""
+Capture helper for mocking safe_write in backend_safe_file_io tests.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import io
+import json
+from typing import IO, Any, Callable
+
+
+def make_capture_safe_write() -> tuple[dict[str, Any], list[bool], Callable[[str, Callable[[IO[str]], object]], None]]:
+    """
+    Create a ``safe_write`` side-effect that captures written JSON data.
+
+    Returns a (captured_data, called, side_effect) triple:
+    - ``captured_data``: dict updated with the JSON that the write_func produces.
+    - ``called``: single-element list (``[False]``) flipped to ``True`` on invocation.
+    - ``side_effect``: function to assign to ``mock_safe_write.side_effect``.
+
+    Usage::
+
+        captured_data, called, side_effect = make_capture_safe_write()
+        mock_safe_write.side_effect = side_effect
+        ...
+        assert called[0]
+        assert captured_data == expected
+
+    """
+    captured_data: dict[str, Any] = {}
+    called: list[bool] = [False]
+
+    def _capture(_filepath: str, write_func: Callable[[IO[str]], object]) -> None:
+        fake_file = io.StringIO()
+        write_func(fake_file)
+        captured_data.update(json.loads(fake_file.getvalue()))
+        called[0] = True
+
+    return captured_data, called, _capture

--- a/tests/unit_backend_filesystem_vehicle_components.py
+++ b/tests/unit_backend_filesystem_vehicle_components.py
@@ -13,8 +13,9 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+from importlib.resources import files as importlib_files
 from json.decoder import JSONDecodeError as RealJSONDecodeError
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -34,7 +35,9 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     @patch("builtins.open", new_callable=mock_open)
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
-    def test_load_system_templates_json_decode_error(self, mock_json_load, mock_file, mock_get_base_dir) -> None:
+    def test_load_system_templates_json_decode_error(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
         """
         Test internal error handling for JSONDecodeError in system templates.
 
@@ -52,7 +55,9 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     @patch("builtins.open", new_callable=mock_open)
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
-    def test_load_user_templates_json_decode_error(self, mock_json_load, mock_file, mock_get_base_dir) -> None:
+    def test_load_user_templates_json_decode_error(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
         """
         Test internal error handling for JSONDecodeError in user templates.
 
@@ -69,7 +74,9 @@ class TestVehicleComponentsInternals:
 
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
-    def test_save_component_templates_to_file_makedirs_error(self, mock_get_base_dir, mock_makedirs) -> None:
+    def test_save_component_templates_to_file_makedirs_error(
+        self, mock_get_base_dir: MagicMock, mock_makedirs: MagicMock
+    ) -> None:
         """
         Test internal error handling when directory creation fails.
 
@@ -91,7 +98,7 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_to_file_generic_exception(  # type: ignore[misc]
-        self, mock_get_base_dir, mock_makedirs, mock_safe_write
+        self, mock_get_base_dir: MagicMock, mock_makedirs: MagicMock, mock_safe_write: MagicMock
     ) -> None:
         """
         Test internal error handling for unexpected exceptions.
@@ -115,7 +122,7 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_to_file_permission_error(  # type: ignore[misc]
-        self, mock_get_base_dir, mock_makedirs, mock_safe_write
+        self, mock_get_base_dir: MagicMock, mock_makedirs: MagicMock, mock_safe_write: MagicMock
     ) -> None:
         """
         Test internal error handling for PermissionError.
@@ -138,7 +145,9 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
-    def test_save_component_templates_to_file_os_error(self, mock_get_base_dir, mock_makedirs, mock_safe_write) -> None:
+    def test_save_component_templates_to_file_os_error(
+        self, mock_get_base_dir: MagicMock, mock_makedirs: MagicMock, mock_safe_write: MagicMock
+    ) -> None:
         """
         Test internal error handling for OSError during file write.
 
@@ -163,7 +172,12 @@ class TestVehicleComponentsInternals:
     @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write")
     @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
     def test_save_component_templates_to_file_uses_local_dir_when_local_file_exists(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        self, mock_get_base_dir, mock_safe_write, mock_makedirs, mock_file, mock_exists
+        self,
+        mock_get_base_dir: MagicMock,
+        mock_safe_write: MagicMock,
+        mock_makedirs: MagicMock,
+        mock_file: MagicMock,
+        mock_exists: MagicMock,
     ) -> None:
         """
         Test that system templates use local directory when local file exists.
@@ -183,13 +197,16 @@ class TestVehicleComponentsInternals:
         error, msg = vehicle_components_system.save_component_templates_to_file(templates_to_save)
 
         assert error is False
-        # Should use local dir, which contains system template filename (path may vary by environment)
-        assert "system_vehicle_components_template.json" in msg
-        assert "/system/templates" in msg or "ardupilot_methodic_configurator/vehicle_templates" in msg
+        # Normalise path separators before comparison to remain platform-independent
+        msg_normalized = msg.replace("\\", "/")
+        assert "system_vehicle_components_template.json" in msg_normalized
+        assert "/system/templates" in msg_normalized or "ardupilot_methodic_configurator/vehicle_templates" in msg_normalized
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "save_component_templates_to_file")
-    def test_save_component_templates_template_without_name(self, mock_save_to_file, mock_load_system) -> None:
+    def test_save_component_templates_template_without_name(
+        self, mock_save_to_file: MagicMock, mock_load_system: MagicMock
+    ) -> None:
         """
         Test internal handling of templates without name field.
 
@@ -225,7 +242,9 @@ class TestVehicleComponentsInternals:
 
     @patch.object(VehicleComponents, "_load_system_templates")
     @patch.object(VehicleComponents, "save_component_templates_to_file")
-    def test_save_component_templates_to_system_removes_user_modified_flag(self, mock_save_to_file, mock_load_system) -> None:
+    def test_save_component_templates_to_system_removes_user_modified_flag(
+        self, mock_save_to_file: MagicMock, mock_load_system: MagicMock
+    ) -> None:
         """
         Test internal flag removal when saving to system templates.
 
@@ -335,3 +354,302 @@ class TestVehicleComponentsInternals:
         none_input = None
         self.vehicle_components._recursively_clear_dict(none_input)
         assert none_input is None
+
+
+class TestVehicleComponentsTemplateLoadingErrors:
+    """Unit tests for VehicleComponents template loading error handling."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        """Set up test fixtures."""
+        self.vehicle_components = VehicleComponents()
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_system_templates_file_not_found(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        System template loading is skipped gracefully when the templates file does not exist.
+
+        GIVEN: System templates file doesn't exist
+        WHEN: Loading system templates
+        THEN: Should return empty dict without crashing
+        """
+        mock_get_base_dir.return_value = "/app/path"
+        mock_file.side_effect = FileNotFoundError("File not found")
+
+        result = self.vehicle_components._load_system_templates()
+
+        assert result == {}
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_system_templates_os_error(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        System template loading is skipped gracefully when an OS error prevents file access.
+
+        GIVEN: OS error occurs while reading system templates file
+        WHEN: Loading system templates
+        THEN: Should return empty dict without crashing
+        """
+        mock_get_base_dir.return_value = "/app/path"
+        mock_file.side_effect = OSError("Permission denied")
+
+        result = self.vehicle_components._load_system_templates()
+
+        assert result == {}
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_system_templates_unexpected_exception(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        System template loading is skipped gracefully when an unexpected exception occurs.
+
+        GIVEN: An unexpected exception occurs while reading system templates
+        WHEN: Loading system templates
+        THEN: Should return empty dict without crashing
+        """
+        mock_get_base_dir.return_value = "/app/path"
+        mock_file.side_effect = RuntimeError("Unexpected error")
+
+        result = self.vehicle_components._load_system_templates()
+
+        assert result == {}
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_user_templates_file_not_found(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        User template loading is skipped gracefully when the templates file does not exist.
+
+        GIVEN: User templates file doesn't exist
+        WHEN: Loading user templates
+        THEN: Should return empty dict without crashing (debug message only)
+        """
+        mock_get_base_dir.return_value = "/user/templates"
+        mock_file.side_effect = FileNotFoundError("File not found")
+
+        result = self.vehicle_components._load_user_templates()
+
+        assert result == {}
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_user_templates_os_error(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        User template loading is skipped gracefully when an OS error prevents file access.
+
+        GIVEN: OS error occurs while reading user templates file
+        WHEN: Loading user templates
+        THEN: Should return empty dict without crashing
+        """
+        mock_get_base_dir.return_value = "/user/templates"
+        mock_file.side_effect = OSError("Disk I/O error")
+
+        result = self.vehicle_components._load_user_templates()
+
+        assert result == {}
+
+    @patch("ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.json_load")
+    def test_load_user_templates_unexpected_exception(
+        self, mock_json_load: MagicMock, mock_file: MagicMock, mock_get_base_dir: MagicMock
+    ) -> None:
+        """
+        User template loading is skipped gracefully when an unexpected exception occurs.
+
+        GIVEN: An unexpected exception occurs while reading user templates
+        WHEN: Loading user templates
+        THEN: Should return empty dict without crashing
+        """
+        mock_get_base_dir.return_value = "/user/templates"
+        mock_file.side_effect = RuntimeError("Unexpected error")
+
+        result = self.vehicle_components._load_user_templates()
+
+        assert result == {}
+
+
+class TestVehicleComponentsTemplateMerging:
+    """Unit tests for template merging and filtering during load."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        """Set up test fixtures."""
+        self.vehicle_components = VehicleComponents()
+
+    def test_load_component_templates_handles_user_template_without_name(self) -> None:
+        """
+        load_component_templates skips user templates without a name.
+
+        GIVEN: User templates containing entries without a 'name' field
+        WHEN: Loading component templates
+        THEN: Templates without names should be skipped silently
+        AND: Named templates should still be loaded correctly
+        """
+        system_templates = {"Motor": [{"name": "Standard 2205", "data": {"kv": 2300}}]}
+        user_templates = {
+            "Motor": [
+                {"data": {"kv": 1500}},  # No 'name' field - should be skipped
+                {"name": "", "data": {"kv": 1800}},  # Empty name - should be skipped
+                {"name": "Custom Motor", "data": {"kv": 2000}},  # Valid - should be added
+            ]
+        }
+
+        with (
+            patch.object(self.vehicle_components, "_load_system_templates", return_value=system_templates),
+            patch.object(self.vehicle_components, "_load_user_templates", return_value=user_templates),
+        ):
+            result = self.vehicle_components.load_component_templates()
+
+        # Valid user template should be present
+        assert "Motor" in result
+        motor_names = [t.get("name") for t in result["Motor"]]
+        assert "Custom Motor" in motor_names
+        # Unnamed templates should NOT be present
+        assert None not in motor_names
+        assert "" not in motor_names
+
+
+class TestVehicleComponentsSystemTemplateSaving:
+    """Unit tests for system-template path selection and error handling in save operations."""
+
+    def test_save_component_templates_to_file_fallback_when_system_file_not_found(self) -> None:
+        """
+        save_component_templates_to_file uses package path when system path doesn't exist.
+
+        GIVEN: Saving to system templates and system path doesn't exist on filesystem
+        WHEN: save_component_templates_to_file is called
+        THEN: Should fall back to package path
+        AND: Should not raise an exception
+        """
+        vehicle_components_system = VehicleComponents(save_component_to_system_templates=True)
+        templates_to_save = {"Component1": [{"name": "Test", "data": {}}]}
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir"
+            ) as mock_get_base_dir,
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_path.exists") as mock_exists,
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs"),
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write") as mock_safe_write,
+        ):
+            mock_get_base_dir.return_value = "/nonexistent/path"
+            mock_exists.return_value = False  # System file does NOT exist at primary location
+
+            error, msg = vehicle_components_system.save_component_templates_to_file(templates_to_save)
+
+        expected_fallback = str(
+            importlib_files("ardupilot_methodic_configurator")
+            / "vehicle_templates"
+            / "system_vehicle_components_template.json"
+        ).replace("\\", "/")
+
+        assert error is False
+        assert msg == expected_fallback
+        assert mock_safe_write.call_count == 1
+        safe_write_path = mock_safe_write.call_args.args[0].replace("\\", "/")
+        assert safe_write_path == expected_fallback
+
+    def test_save_component_templates_to_file_handles_oserror_in_makedirs_for_system_path(self) -> None:
+        """
+        save_component_templates_to_file handles OSError when checking system path.
+
+        GIVEN: An OSError occurs when checking for the system template path
+        WHEN: save_component_templates_to_file is called for system templates
+        THEN: Should handle the error gracefully and continue
+        AND: Should fall back to default templates_dir
+        """
+        vehicle_components_system = VehicleComponents(save_component_to_system_templates=True)
+        templates_to_save = {"Component1": [{"name": "Test", "data": {}}]}
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir"
+            ) as mock_get_base_dir,
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_path.exists") as mock_exists,
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs") as mock_makedirs,
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write") as mock_safe_write,
+        ):
+            mock_get_base_dir.return_value = "/test/templates"
+            mock_exists.side_effect = OSError("Permission denied")
+            mock_makedirs.return_value = None
+
+            error, msg = vehicle_components_system.save_component_templates_to_file(templates_to_save)
+
+        expected_path = "/test/templates/system_vehicle_components_template.json"
+        assert error is False
+        assert msg == expected_path
+        assert mock_safe_write.call_count == 1
+        safe_write_path = mock_safe_write.call_args.args[0].replace("\\", "/")
+        assert safe_write_path == expected_path
+
+
+class TestVehicleComponentsWipeInfo:
+    """Tests for wipe_component_info behavior."""
+
+    def test_wipe_component_info_handles_none_data(self) -> None:
+        """
+        wipe_component_info does nothing when vehicle_components_fs.data is None.
+
+        GIVEN: vehicle_components_fs has no data (data is None)
+        WHEN: wipe_component_info is called
+        THEN: No exception should be raised
+        AND: Nothing should be modified
+        """
+        vehicle_components = VehicleComponents()
+        vehicle_components.vehicle_components_fs.data = None
+
+        # Should not raise any exception
+        vehicle_components.wipe_component_info()
+
+        assert vehicle_components.vehicle_components_fs.data is None
+
+    def test_merge_defaults_applies_default_when_key_missing(self) -> None:
+        """
+        merge_defaults sets default when key is not in target.
+
+        GIVEN: A target dict missing a key that has a default value
+        WHEN: wipe_component_info is called to reset to defaults
+        THEN: The missing key should be set to its default value
+        """
+        vehicle_components = VehicleComponents()
+        # Provide minimal data structure that wipe_component_info can work with
+        data = {
+            "Components": {
+                "RC Receiver": {},  # Missing FC Connection
+                "Battery": {
+                    "Specifications": {}  # Missing Chemistry and other defaults
+                },
+                "Motors": {
+                    "Specifications": {}  # Missing Poles
+                },
+                "GNSS Receiver": {},
+                "Telemetry": {},
+                "Battery Monitor": {},
+                "ESC": {},
+            }
+        }
+        vehicle_components.vehicle_components_fs.data = data
+
+        vehicle_components.wipe_component_info()
+
+        # After wipe, defaults should have been applied
+        components = vehicle_components.vehicle_components_fs.data["Components"]
+        assert "FC Connection" in components["RC Receiver"]
+        assert "FC Connection" in components["GNSS Receiver"]

--- a/tests/unit_backend_flightcontroller_commands.py
+++ b/tests/unit_backend_flightcontroller_commands.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for backend_flightcontroller_commands.py.
+
+These tests target specific implementation branches and internal code paths for
+coverage purposes. For behavior-driven tests of flight controller command functionality,
+see test_backend_flightcontroller_commands.py.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from pymavlink import mavutil
+
+from ardupilot_methodic_configurator.backend_flightcontroller_commands import FlightControllerCommands
+
+
+class TestSendCommandAndWaitAckBranches:
+    """Unit tests for the internal branch logic of send_command_and_wait_ack."""
+
+    def test_in_progress_ack_with_zero_progress_does_not_log_percentage(self) -> None:
+        """
+        Branch: MAV_RESULT_IN_PROGRESS with progress=0 skips the debug log call.
+
+        The source code contains:
+            if msg.progress is not None and msg.progress > 0:
+                logging_debug(...)
+
+        This test exercises the else path (progress <= 0) and verifies that
+        logging_debug is not called with the percentage format string, then
+        confirms the command eventually times out.
+        """
+        mock_master = MagicMock()
+        mock_master.target_system = 1
+        mock_master.target_component = 1
+
+        mock_ack = MagicMock()
+        mock_ack.command = 999
+        mock_ack.result = mavutil.mavlink.MAV_RESULT_IN_PROGRESS
+        mock_ack.progress = 0  # <= 0 means logging_debug is NOT called for percentage
+
+        call_count = [0]
+
+        def side_effect_recv_match(*_args, **_kwargs) -> object:
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return mock_ack
+            return None  # Stop returning ACK so the loop times out
+
+        mock_master.recv_match.side_effect = side_effect_recv_match
+
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = mock_master
+
+        commands_mgr = FlightControllerCommands(params_manager=Mock(), connection_manager=mock_conn_mgr)
+
+        with patch("ardupilot_methodic_configurator.backend_flightcontroller_commands.logging_debug") as mock_debug:
+            success, error = commands_mgr.send_command_and_wait_ack(command=999, timeout=0.3)
+
+        assert success is False
+        assert "timeout" in error.lower()
+        # logging_debug should NOT have been called with the progress format string
+        progress_log_calls = [c for c in mock_debug.call_args_list if c.args and "progress" in str(c.args[0]).lower()]
+        assert progress_log_calls == [], "logging_debug should not have logged progress when progress=0"
+
+    def test_in_progress_ack_with_positive_progress_logs_percentage(self) -> None:
+        """
+        Branch: MAV_RESULT_IN_PROGRESS with progress>0 triggers the debug log call.
+
+        Exercises the complementary path to the test above: when progress is
+        positive, logging_debug IS called with the percentage format string.
+        After logging, the loop continues and eventually times out.
+        """
+        mock_master = MagicMock()
+        mock_master.target_system = 1
+        mock_master.target_component = 1
+
+        mock_ack = MagicMock()
+        mock_ack.command = 888
+        mock_ack.result = mavutil.mavlink.MAV_RESULT_IN_PROGRESS
+        mock_ack.progress = 50  # > 0 → should trigger the debug log
+
+        call_count = [0]
+
+        def side_effect_recv_match(*_args, **_kwargs) -> object:
+            call_count[0] += 1
+            if call_count[0] <= 1:
+                return mock_ack
+            return None  # Time out after one in-progress message
+
+        mock_master.recv_match.side_effect = side_effect_recv_match
+
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = mock_master
+
+        commands_mgr = FlightControllerCommands(params_manager=Mock(), connection_manager=mock_conn_mgr)
+
+        with patch("ardupilot_methodic_configurator.backend_flightcontroller_commands.logging_debug") as mock_debug:
+            success, _ = commands_mgr.send_command_and_wait_ack(command=888, timeout=0.3)
+
+        assert success is False  # Timed out
+        # logging_debug SHOULD have been called with a progress-related message
+        progress_log_calls = [c for c in mock_debug.call_args_list if c.args and "progress" in str(c.args[0]).lower()]
+        assert progress_log_calls != [], "logging_debug should have logged progress when progress=50"
+
+    @pytest.mark.parametrize(
+        ("result_code", "expected_keyword"),
+        [
+            (mavutil.mavlink.MAV_RESULT_TEMPORARILY_REJECTED, "rejected"),
+            (mavutil.mavlink.MAV_RESULT_DENIED, "denied"),
+            (mavutil.mavlink.MAV_RESULT_UNSUPPORTED, "unsupported"),
+            (mavutil.mavlink.MAV_RESULT_FAILED, "failed"),
+        ],
+    )
+    def test_known_failure_result_codes_map_to_correct_error_messages(self, result_code: int, expected_keyword: str) -> None:
+        """
+        Branch: each known non-ACCEPTED result code maps to a specific error string.
+
+        Exercises the result_messages dict lookup for every non-success, non-progress
+        result code defined by the protocol.
+        """
+        mock_master = MagicMock()
+        mock_master.target_system = 1
+        mock_master.target_component = 1
+
+        mock_ack = MagicMock()
+        mock_ack.command = 777
+        mock_ack.result = result_code
+        mock_master.recv_match.return_value = mock_ack
+
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = mock_master
+
+        commands_mgr = FlightControllerCommands(params_manager=Mock(), connection_manager=mock_conn_mgr)
+
+        success, error = commands_mgr.send_command_and_wait_ack(command=777, timeout=1.0)
+
+        assert success is False
+        assert expected_keyword in error.lower(), f"Expected '{expected_keyword}' in error: {error!r}"
+
+
+class TestFlightControllerCommandsMissingConnectionBranches:
+    """Branch tests for commands when master is None (no active connection)."""
+
+    @pytest.fixture
+    def disconnected_commands_mgr(self) -> FlightControllerCommands:
+        """Provide a FlightControllerCommands instance with no active connection."""
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = None
+        return FlightControllerCommands(params_manager=Mock(), connection_manager=mock_conn_mgr)
+
+    def test_send_command_and_wait_ack_fails_without_connection(
+        self, disconnected_commands_mgr: FlightControllerCommands
+    ) -> None:
+        """
+        send_command_and_wait_ack returns (False, error) when master is None.
+
+        GIVEN: No flight controller connection (master is None)
+        WHEN: send_command_and_wait_ack is called
+        THEN: False should be returned with an error mentioning the missing connection
+        AND: No exceptions should be raised
+        """
+        success, error = disconnected_commands_mgr.send_command_and_wait_ack(command=999, timeout=0.5)
+
+        assert success is False
+        assert error != ""
+        assert "connection" in error.lower()
+
+    def test_stop_all_motors_fails_without_connection(self, disconnected_commands_mgr: FlightControllerCommands) -> None:
+        """
+        stop_all_motors returns (False, error) when master is None.
+
+        GIVEN: No flight controller connection
+        WHEN: stop_all_motors is called
+        THEN: False should be returned with an error mentioning the missing connection
+        AND: No exceptions should be raised
+        """
+        success, error = disconnected_commands_mgr.stop_all_motors()
+
+        assert success is False
+        assert error != ""
+        assert "connection" in error.lower()
+
+    def test_request_periodic_battery_status_fails_without_connection(
+        self, disconnected_commands_mgr: FlightControllerCommands
+    ) -> None:
+        """
+        request_periodic_battery_status returns (False, error) when master is None.
+
+        GIVEN: No flight controller connection
+        WHEN: request_periodic_battery_status is called
+        THEN: False should be returned with an error mentioning the missing connection
+        AND: No exceptions should be raised
+        """
+        success, error = disconnected_commands_mgr.request_periodic_battery_status()
+
+        assert success is False
+        assert error != ""
+        assert "connection" in error.lower()
+
+
+class TestFlightControllerCommandsFailureBranches:
+    """Branch tests for failure result codes returned by the flight controller."""
+
+    @pytest.fixture
+    def commands_mgr_motor_ack(self) -> Callable[[int], FlightControllerCommands]:
+        """Factory fixture: returns a callable that builds a commands manager with a given MAV_CMD_DO_MOTOR_TEST ACK."""
+
+        def _make(result_code: int) -> FlightControllerCommands:
+            mock_master = MagicMock()
+            mock_master.target_system = 1
+            mock_master.target_component = 1
+
+            mock_ack = MagicMock()
+            mock_ack.command = mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST
+            mock_ack.result = result_code
+
+            mock_master.recv_match.return_value = mock_ack
+            mock_conn_mgr = Mock()
+            mock_conn_mgr.master = mock_master
+            mock_params_mgr = Mock()
+            mock_params_mgr.fc_parameters = {}
+
+            return FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
+
+        return _make  # type: ignore[return-value]
+
+    def test_reset_all_parameters_handles_command_failure(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
+        """
+        reset_all_parameters_to_default returns (False, error) when the FC denies the command.
+
+        GIVEN: Connected flight controller that denies the parameter reset command
+        WHEN: reset_all_parameters_to_default is called
+        THEN: False should be returned with "denied" in the error message
+        AND: fc_parameters should NOT be cleared on failure
+        """
+        mock_master, mock_conn_mgr = mock_connected_master
+
+        mock_ack = MagicMock()
+        mock_ack.command = mavutil.mavlink.MAV_CMD_PREFLIGHT_STORAGE
+        mock_ack.result = mavutil.mavlink.MAV_RESULT_DENIED
+        mock_master.recv_match.return_value = mock_ack
+
+        mock_params_mgr = Mock()
+        mock_params_mgr.fc_parameters = {"PARAM1": 1.0}
+
+        commands_mgr = FlightControllerCommands(params_manager=mock_params_mgr, connection_manager=mock_conn_mgr)
+
+        success, error = commands_mgr.reset_all_parameters_to_default()
+
+        assert success is False
+        assert "denied" in error.lower()
+        assert len(mock_params_mgr.fc_parameters) > 0, "fc_parameters must NOT be cleared on failure"
+
+    def test_test_motors_in_sequence_handles_command_failure(
+        self, commands_mgr_motor_ack: Callable[[int], FlightControllerCommands]
+    ) -> None:
+        """
+        test_motors_in_sequence returns (False, error) when the FC reports FAILED.
+
+        GIVEN: Connected flight controller that rejects the sequential motor test command
+        WHEN: test_motors_in_sequence is called
+        THEN: False should be returned with "failed" in the error message
+        """
+        commands_mgr = commands_mgr_motor_ack(mavutil.mavlink.MAV_RESULT_FAILED)
+
+        success, error = commands_mgr.test_motors_in_sequence(
+            start_motor=1, motor_count=4, throttle_percent=10, timeout_seconds=2
+        )
+
+        assert success is False
+        assert error != ""
+        assert "failed" in error.lower()
+
+    def test_stop_all_motors_handles_command_failure(
+        self, commands_mgr_motor_ack: Callable[[int], FlightControllerCommands]
+    ) -> None:
+        """
+        stop_all_motors returns (False, error) when the FC reports UNSUPPORTED.
+
+        GIVEN: Connected flight controller that reports the motor stop command as unsupported
+        WHEN: stop_all_motors is called
+        THEN: False should be returned with "unsupported" in the error message
+        """
+        commands_mgr = commands_mgr_motor_ack(mavutil.mavlink.MAV_RESULT_UNSUPPORTED)
+
+        success, error = commands_mgr.stop_all_motors()
+
+        assert success is False
+        assert error != ""
+        assert "unsupported" in error.lower()

--- a/tests/unit_backend_flightcontroller_params.py
+++ b/tests/unit_backend_flightcontroller_params.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for backend_flightcontroller_params.py.
+
+These tests target specific implementation branches and private methods for
+coverage purposes. For behavior-driven tests of flight controller parameter
+functionality, see test_backend_flightcontroller_params.py.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from ardupilot_methodic_configurator.backend_flightcontroller_params import FlightControllerParams
+from ardupilot_methodic_configurator.data_model_flightcontroller_info import FlightControllerInfo
+
+# pylint: disable=protected-access
+
+
+class TestDownloadParamsViaMavlink:
+    """Unit tests for the _download_params_via_mavlink private method."""
+
+    @pytest.fixture
+    def connected_params_mgr(self, mock_connected_master: tuple[MagicMock, Mock]) -> tuple[MagicMock, FlightControllerParams]:
+        """Provide a FlightControllerParams instance connected to a mock master."""
+        mock_master, mock_conn_mgr = mock_connected_master
+        mock_conn_mgr.info = FlightControllerInfo()
+        mock_conn_mgr.comport_device = "COM1"
+        return mock_master, FlightControllerParams(connection_manager=mock_conn_mgr)
+
+    @pytest.fixture
+    def disconnected_params_mgr(self) -> FlightControllerParams:
+        """Provide a FlightControllerParams instance with no active connection."""
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = None
+        mock_conn_mgr.info = FlightControllerInfo()
+        mock_conn_mgr.comport_device = ""
+        return FlightControllerParams(connection_manager=mock_conn_mgr)
+
+    def test_download_params_returns_empty_when_master_is_none(self, disconnected_params_mgr: FlightControllerParams) -> None:
+        """
+        _download_params_via_mavlink returns {} when master is None.
+
+        GIVEN: No flight controller connection (master is None)
+        WHEN: _download_params_via_mavlink is called
+        THEN: An empty dictionary should be returned
+        AND: No exceptions should be raised
+        """
+        result = disconnected_params_mgr._download_params_via_mavlink()
+
+        assert result == {}
+
+    def test_download_params_handles_none_message(
+        self, connected_params_mgr: tuple[MagicMock, FlightControllerParams]
+    ) -> None:
+        """
+        _download_params_via_mavlink returns {} when recv_match times out (returns None).
+
+        GIVEN: Connected FC but recv_match returns None immediately (timeout)
+        WHEN: _download_params_via_mavlink is called
+        THEN: An empty dictionary should be returned
+        AND: No exceptions should be raised
+        """
+        mock_master, params_mgr = connected_params_mgr
+        mock_master.recv_match.return_value = None  # Simulate timeout
+
+        result = params_mgr._download_params_via_mavlink()
+
+        assert result == {}
+
+    def test_download_params_receives_parameters_with_progress_callback(
+        self, connected_params_mgr: tuple[MagicMock, FlightControllerParams]
+    ) -> None:
+        """
+        _download_params_via_mavlink calls progress callback while receiving parameters.
+
+        GIVEN: Connected FC that returns two parameter messages then None
+        WHEN: _download_params_via_mavlink is called with a progress callback
+        THEN: The callback should be called with (1, 2) then (2, 2) as (received, total) pairs
+        AND: Both parameters should be present in the result dict with correct values
+        """
+        mock_master, params_mgr = connected_params_mgr
+
+        param1_msg = MagicMock()
+        param1_msg.to_dict.return_value = {"param_id": "PARAM1", "param_value": 1.0}
+        param1_msg.param_count = 2
+
+        param2_msg = MagicMock()
+        param2_msg.to_dict.return_value = {"param_id": "PARAM2", "param_value": 2.0}
+        param2_msg.param_count = 2
+
+        mock_master.recv_match.side_effect = [param1_msg, param2_msg, None]
+
+        progress_calls: list[tuple[int, int]] = []
+
+        def progress_callback(current: int, total: int) -> None:
+            progress_calls.append((current, total))
+
+        result = params_mgr._download_params_via_mavlink(progress_callback=progress_callback)
+
+        assert "PARAM1" in result
+        assert "PARAM2" in result
+        assert result["PARAM1"] == 1.0
+        assert result["PARAM2"] == 2.0
+        assert (1, 2) in progress_calls
+        assert (2, 2) in progress_calls
+
+    def test_download_params_handles_exception_from_recv_match(
+        self, connected_params_mgr: tuple[MagicMock, FlightControllerParams]
+    ) -> None:
+        """
+        _download_params_via_mavlink handles exceptions from recv_match gracefully.
+
+        GIVEN: Connected FC where recv_match raises an exception on the first call
+        WHEN: _download_params_via_mavlink is called
+        THEN: The exception should be caught without propagating
+        AND: An empty dict should be returned (no parameters received before the error)
+        """
+        mock_master, params_mgr = connected_params_mgr
+        mock_master.recv_match.side_effect = Exception("Serial port disconnected")
+
+        result = params_mgr._download_params_via_mavlink()
+
+        assert result == {}
+
+
+class TestDownloadParamsViaMavftp:
+    """Unit tests for the _download_params_via_mavftp private method."""
+
+    @pytest.fixture
+    def disconnected_params_mgr(self) -> FlightControllerParams:
+        """Provide a FlightControllerParams instance with no active connection."""
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = None
+        mock_conn_mgr.info = FlightControllerInfo()
+        mock_conn_mgr.comport_device = ""
+        return FlightControllerParams(connection_manager=mock_conn_mgr)
+
+    def test_download_via_mavftp_returns_empty_when_master_is_none(
+        self, disconnected_params_mgr: FlightControllerParams
+    ) -> None:
+        """
+        _download_params_via_mavftp returns empty dicts when master is None.
+
+        GIVEN: No flight controller connection (master is None)
+        WHEN: _download_params_via_mavftp is called
+        THEN: An empty param dict and an empty ParDict should be returned
+        AND: No exceptions should be raised
+        """
+        result_params, result_defaults = disconnected_params_mgr._download_params_via_mavftp()
+
+        assert result_params == {}
+        assert len(result_defaults) == 0
+
+    def test_download_via_mavftp_calls_progress_callback(self, mock_connected_master: tuple[MagicMock, Mock]) -> None:
+        """
+        _download_params_via_mavftp wires a progress callback through to cmd_getparams.
+
+        GIVEN: Connected FC with MAVFTP support
+        WHEN: _download_params_via_mavftp is called with a progress_callback
+        THEN: cmd_getparams must be invoked with a callable progress_callback kwarg
+        AND: When that inner callback is called with 0.5, the outer callback receives (50, 100)
+        """
+        _mock_master, mock_conn_mgr = mock_connected_master
+        mock_conn_mgr.info = FlightControllerInfo()
+        mock_conn_mgr.comport_device = "COM1"
+        params_mgr = FlightControllerParams(connection_manager=mock_conn_mgr)
+
+        progress_calls: list[tuple[int, int]] = []
+
+        def progress_callback(current: int, total: int) -> None:
+            progress_calls.append((current, total))
+
+        with patch("ardupilot_methodic_configurator.backend_flightcontroller_params.create_mavftp") as mock_mavftp_factory:
+            mock_mavftp = MagicMock()
+            mock_ftp_reply = MagicMock()
+            mock_ftp_reply.error_code = 1  # Simulate failure so no file I/O is needed
+            mock_mavftp.process_ftp_reply.return_value = mock_ftp_reply
+            mock_mavftp_factory.return_value = mock_mavftp
+
+            params_mgr._download_params_via_mavftp(progress_callback=progress_callback)
+
+        call_args = mock_mavftp.cmd_getparams.call_args
+        assert call_args is not None, "cmd_getparams should have been called"
+        inner_callback = call_args.kwargs.get("progress_callback")
+        assert callable(inner_callback), "cmd_getparams must receive a callable progress_callback keyword argument"
+
+        inner_callback(0.5)  # 50 % completion → progress_callback(50, 100)
+        assert (50, 100) in progress_calls
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_backend_safe_file_io.py
+++ b/tests/unit_backend_safe_file_io.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for the make_capture_safe_write test helper in test_helpers.py.
+
+These tests verify the contract of the capture helper that is used across
+many test files to assert JSON data written through safe_write mocks.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import io
+import json
+from unittest.mock import patch
+
+from test_backend_safe_file_io_write_capture import make_capture_safe_write
+
+from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
+
+
+class TestMakeCapturesSafeWrite:
+    """Unit tests for the make_capture_safe_write test helper."""
+
+    def test_capture_helper_records_written_json_data(self) -> None:
+        """
+        make_capture_safe_write records JSON written through its side_effect.
+
+        GIVEN: A freshly created capture helper with empty state
+        WHEN: The side_effect is called with a write function that emits JSON
+        THEN: captured_data should contain the written JSON
+        AND: called[0] should flip to True
+        """
+        captured_data, called, side_effect = make_capture_safe_write()
+
+        assert called[0] is False
+        assert not captured_data
+
+        test_data = {"key": "value", "number": 42}
+
+        def write_json(f: io.TextIOWrapper) -> None:
+            json.dump(test_data, f)
+
+        side_effect("/fake/path", write_json)
+
+        assert called[0] is True
+        assert captured_data == test_data
+
+    def test_capture_helper_can_be_used_as_mock_side_effect(self) -> None:
+        """
+        make_capture_safe_write integrates correctly when patching a real caller's safe_write.
+
+        GIVEN: A real caller (VehicleComponents) that writes JSON via safe_write internally
+        WHEN: safe_write in that module is replaced with the capture side_effect
+        THEN: The JSON data the caller would have written is captured for assertion
+        AND: called[0] should be True after the caller runs
+        """
+        captured_data, called, side_effect = make_capture_safe_write()
+
+        with (
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.safe_write") as mock_safe_write,
+            patch(
+                "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.get_templates_base_dir",
+                return_value="/fake",
+            ),
+            patch("ardupilot_methodic_configurator.backend_filesystem_vehicle_components.os_makedirs"),
+        ):
+            mock_safe_write.side_effect = side_effect
+            templates = {"Motor": [{"name": "Test Motor", "data": {"kv": 2300}}]}
+            VehicleComponents().save_component_templates_to_file(templates)
+
+        assert called[0] is True
+        assert "Motor" in captured_data


### PR DESCRIPTION
- Add unit branch tests for FlightControllerCommands failure/missing-connection paths
- Add unit tests for parameter download edge cases (MAVLink/MAVFTP timeout, exception, progress callback)
- Add shared fixture for connected mock master in conftest
- Move make_capture_safe_write test helper out of production code into tests
- Add bdd safe_write behavior tests and helper-focused unit tests
- Update vehicle components tests to import helper from tests module
- Ignore tuning_report.csv in gitignore

Agent-Logs-Url: https://github.com/ArduPilot/MethodicConfigurator/sessions/20139120-bd7b-4efe-8256-126ef58e373b

# Description

Describe what this PR is trying to achieve. Please read our [Contributing Guide](../CONTRIBUTING.md) for detailed guidelines.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
