### PR TITLE
Add BDD tests for about popup, bin log selection, derived params, and connection renaming

### DIFF
--- a/tests/test_data_model_configuration_step.py
+++ b/tests/test_data_model_configuration_step.py
@@ -1006,3 +1006,182 @@ class TestConfigurationStepProcessorErrorHandling:
         assert len(ui_infos) == 1
         assert ui_infos[0][0] == "ExpressLRS Configuration Warning"
         assert ui_errors == []
+
+
+class TestDerivedParametersFiltering:
+    """Tests for derived parameters filtering logic."""
+
+    def test_derived_parameters_filtered_by_fc_keys_when_fc_provided(self, processor, mock_local_filesystem) -> None:
+        """
+        Derived parameters are filtered by FC keys when fc_parameters is provided.
+
+        GIVEN: A configuration step with derived parameters and FC parameters
+        WHEN: Processing produces derived parameters, some existing in FC and some not
+        THEN: Only derived parameters that exist in FC should be collected for application
+        AND: Parameters not in FC keys should be excluded from derived_params_to_apply
+        """
+        selected_file = "test_file.param"
+        # Set up derived parameters that will be returned
+        derived_params = {
+            "SERIAL1_PROTOCOL": Par(value=5.0, comment="derived"),  # in file AND in FC
+            "CAN_P1_DRIVER": Par(value=2.0, comment="derived"),  # in file, NOT in FC
+        }
+        mock_local_filesystem.configuration_steps = {selected_file: {"derived": {}}}
+        mock_local_filesystem.compute_parameters.return_value = None
+        mock_local_filesystem.derived_parameters = {selected_file: derived_params}
+        mock_local_filesystem.file_parameters = {
+            selected_file: {
+                "SERIAL1_PROTOCOL": Par(value=4.0, comment="original"),
+                "CAN_P1_DRIVER": Par(value=1.0, comment="original"),
+            }
+        }
+
+        # FC only has SERIAL1_PROTOCOL (not CAN_P1_DRIVER)
+        limited_fc_params = {"SERIAL1_PROTOCOL": 4.0}
+
+        _params, ui_errors, _ui_infos, _duplicates, _renames, derived_to_apply = processor.process_configuration_step(
+            selected_file, limited_fc_params
+        )
+
+        assert ui_errors == []
+        # SERIAL1_PROTOCOL is in both file and FC, so it should be in derived_to_apply
+        assert "SERIAL1_PROTOCOL" in derived_to_apply
+        assert derived_to_apply["SERIAL1_PROTOCOL"].value == 5.0
+        assert derived_to_apply["SERIAL1_PROTOCOL"].comment == "derived"
+        # CAN_P1_DRIVER is in file but NOT in FC, so it should be excluded
+        assert "CAN_P1_DRIVER" not in derived_to_apply
+        # Should have exactly 1 parameter (only the one in FC)
+        assert len(derived_to_apply) == 1
+
+    def test_derived_parameters_not_in_file_are_excluded(self, processor, mock_local_filesystem) -> None:
+        """
+        Derived parameters not currently in the file are excluded from derived_params_to_apply.
+
+        GIVEN: A configuration step with derived parameters where some are add-from-FC shorthands
+        WHEN: Processing produces derived parameters
+        THEN: Parameters that don't yet exist in the file should be excluded
+        AND: Only parameters already in the file should be in derived_params_to_apply
+        """
+        selected_file = "test_file.param"
+        derived_params = {
+            "SERIAL1_PROTOCOL": Par(value=5.0, comment="derived"),  # in file
+            "NEW_PARAM": Par(value=99.0, comment="derived"),  # NOT in file (add-from-FC shorthand)
+        }
+        mock_local_filesystem.configuration_steps = {selected_file: {"derived": {}}}
+        mock_local_filesystem.compute_parameters.return_value = None
+        mock_local_filesystem.derived_parameters = {selected_file: derived_params}
+        mock_local_filesystem.file_parameters = {
+            selected_file: {
+                "SERIAL1_PROTOCOL": Par(value=4.0, comment="original"),
+                # NEW_PARAM not in file
+            }
+        }
+
+        fc_params = {"SERIAL1_PROTOCOL": 4.0, "NEW_PARAM": 99.0}
+
+        _params, ui_errors, _ui_infos, _duplicates, _renames, derived_to_apply = processor.process_configuration_step(
+            selected_file, fc_params
+        )
+
+        assert ui_errors == []
+        # Only parameters already in the file should be included
+        assert "SERIAL1_PROTOCOL" in derived_to_apply
+        assert derived_to_apply["SERIAL1_PROTOCOL"].value == 5.0
+        # NEW_PARAM not in file, so should be excluded even though it's in FC and derived_params
+        assert "NEW_PARAM" not in derived_to_apply
+        # Should have exactly 1 parameter (only the one in file)
+        assert len(derived_to_apply) == 1
+
+    def test_derived_parameters_all_included_when_no_fc_parameters(self, processor, mock_local_filesystem) -> None:
+        """
+        All file-matching derived parameters are included when no FC parameters provided.
+
+        GIVEN: A configuration step with derived parameters but no FC connection
+        WHEN: Processing produces derived parameters with empty fc_parameters
+        THEN: All derived parameters that exist in the file should be in derived_params_to_apply
+        """
+        selected_file = "test_file.param"
+        derived_params = {
+            "SERIAL1_PROTOCOL": Par(value=5.0, comment="derived"),
+            "CAN_P1_DRIVER": Par(value=2.0, comment="derived"),
+        }
+        mock_local_filesystem.configuration_steps = {selected_file: {"derived": {}}}
+        mock_local_filesystem.compute_parameters.return_value = None
+        mock_local_filesystem.derived_parameters = {selected_file: derived_params}
+        mock_local_filesystem.file_parameters = {
+            selected_file: {
+                "SERIAL1_PROTOCOL": Par(value=4.0, comment="original"),
+                "CAN_P1_DRIVER": Par(value=1.0, comment="original"),
+            }
+        }
+
+        # No FC parameters (empty dict simulates offline mode)
+        _params, ui_errors, _ui_infos, _duplicates, _renames, derived_to_apply = processor.process_configuration_step(
+            selected_file, {}
+        )
+
+        assert ui_errors == []
+        # Both should be included since fc_param_keys is empty (no FC filter)
+        assert "SERIAL1_PROTOCOL" in derived_to_apply
+        assert derived_to_apply["SERIAL1_PROTOCOL"].value == 5.0
+        assert "CAN_P1_DRIVER" in derived_to_apply
+        assert derived_to_apply["CAN_P1_DRIVER"].value == 2.0
+        # Should have both parameters when no FC filtering is applied
+        assert len(derived_to_apply) == 2
+
+
+class TestConnectionRenamingWithSameNameSkip:
+    """Tests for connection renaming edge case where rename results in same name."""
+
+    def test_rename_operation_skips_when_new_name_equals_old_name(self, processor) -> None:
+        """
+        Rename operations are skipped when the new name equals the old name.
+
+        GIVEN: A parameter that would be renamed to itself (no-op rename)
+        WHEN: The rename operation is calculated
+        THEN: No rename should be in the result list for that parameter
+        AND: No duplicates should be tracked for it
+        """
+        # Use a parameter set where CAN1 → CAN1 (same) would be a no-op
+        # by using CAN1 as the new_connection_prefix
+        parameters = {
+            "CAN_P1_DRIVER": Par(value=1.0),
+        }
+
+        # Rename to CAN1 - same connection, which means CAN_P1 → CAN_P1 (no-op)
+        _duplicates, renamed_pairs = processor._calculate_connection_rename_operations(parameters, "CAN1", None)
+
+        # CAN_P1_DRIVER → CAN_P1_DRIVER (no change), should not be in renamed_pairs
+        assert ("CAN_P1_DRIVER", "CAN_P1_DRIVER") not in renamed_pairs
+        # Should have no renamed pairs since the rename would be a no-op
+        assert len(renamed_pairs) == 0
+        # Duplicates set is unused by this operation path
+        assert _duplicates == set()
+
+    def test_rename_operation_detects_conflict_with_existing_parameter(self, processor) -> None:
+        """
+        Rename operation handles conflict when target name already exists.
+
+        GIVEN: Parameters where a rename would create a conflict with an existing parameter
+        WHEN: The rename operation is calculated
+        THEN: The conflicting rename should not be added to renamed_pairs
+        AND: No exception should be raised
+        """
+        parameters = {
+            "CAN_P1_DRIVER": Par(value=1.0),
+            "CAN_P2_DRIVER": Par(value=2.0),  # Would be the target of CAN_P1 rename to CAN2
+        }
+
+        # Renaming to CAN2 would conflict with existing CAN_P2_DRIVER
+        _duplicates, renamed_pairs = processor._calculate_connection_rename_operations(parameters, "CAN2", None)
+
+        # CAN_P1_DRIVER → CAN_P2_DRIVER but CAN_P2_DRIVER already exists
+        # The conflicting rename should be silently skipped
+        assert ("CAN_P1_DRIVER", "CAN_P2_DRIVER") not in renamed_pairs
+        # Should have no renamed pairs due to conflict
+        assert len(renamed_pairs) == 0
+        # Duplicates set is unused by this operation path; conflict is tracked via renamed_pairs omission
+        assert _duplicates == set()
+        # Verify that both parameters are still present (not removed due to conflict)
+        assert "CAN_P1_DRIVER" in parameters
+        assert "CAN_P2_DRIVER" in parameters

--- a/tests/test_frontend_tkinter_about_popup_window.py
+++ b/tests/test_frontend_tkinter_about_popup_window.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+
+"""
+Behavior-driven tests for the frontend_tkinter_about_popup_window.py file.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import contextlib
+import tkinter as tk
+from collections.abc import Generator
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+
+from ardupilot_methodic_configurator.frontend_tkinter_about_popup_window import AboutWindow
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def root() -> Generator[tk.Tk, None, None]:
+    """Provide a hidden Tk root window for tests."""
+    root = tk.Tk()
+    root.withdraw()
+    yield root
+    root.update_idletasks()
+    root.destroy()
+
+
+def _create_about_window(root: tk.Tk, version: str = "1.2.3") -> AboutWindow:
+    """Helper to create an AboutWindow with all heavy operations mocked."""
+    with (
+        patch("ardupilot_methodic_configurator.frontend_tkinter_base_window.BaseWindow._setup_application_icon"),
+        patch("ardupilot_methodic_configurator.frontend_tkinter_base_window.BaseWindow._setup_theme_and_styling"),
+        patch(
+            "ardupilot_methodic_configurator.frontend_tkinter_base_window.BaseWindow._get_dpi_scaling_factor",
+            return_value=1.0,
+        ),
+        patch("ardupilot_methodic_configurator.frontend_tkinter_base_window.BaseWindow.center_window"),
+    ):
+        return AboutWindow(root, version)
+
+
+class TestAboutWindowCreation:
+    """Tests for About window creation and initialization."""
+
+    def test_user_can_open_about_window(self, root: tk.Tk) -> None:
+        """
+        User can open the About popup window.
+
+        GIVEN: The application is running
+        WHEN: User opens the About window
+        THEN: A window with title "About" should appear
+        AND: Version information should be displayed
+        """
+        window = _create_about_window(root, version="3.0.5")
+
+        assert window is not None
+        assert window.root is not None
+        assert "About" in window.root.title()
+
+    def test_user_sees_version_information_in_about_window(self, root: tk.Tk) -> None:
+        """
+        User sees correct version information in the About window.
+
+        GIVEN: The application has a specific version
+        WHEN: User opens the About window
+        THEN: The version number should be displayed in the about message
+        """
+        version = "3.0.5"
+        window = _create_about_window(root, version=version)
+
+        # Find the about label and check it contains the version
+        found_version = False
+        for widget in window.main_frame.winfo_children():
+            if hasattr(widget, "cget"):
+                try:
+                    text = widget.cget("text")
+                    if version in str(text):
+                        found_version = True
+                        break
+                except tk.TclError:
+                    pass
+        assert found_version, f"Version '{version}' not found in any widget text"
+
+    def test_user_sees_copyright_notice_in_about_window(self, root: tk.Tk) -> None:
+        """
+        User sees copyright notice in the About window.
+
+        GIVEN: The application is open
+        WHEN: User views the About window
+        THEN: Copyright information should be visible
+        """
+        window = _create_about_window(root)
+
+        found_copyright = False
+        for widget in window.main_frame.winfo_children():
+            if hasattr(widget, "cget"):
+                try:
+                    text = str(widget.cget("text"))
+                    if "Copyright" in text or "copyright" in text.lower():
+                        found_copyright = True
+                        break
+                except tk.TclError:
+                    pass
+        assert found_copyright, "Copyright notice not found in About window"
+
+    def test_about_window_has_action_buttons(self, root: tk.Tk) -> None:
+        """
+        About window has action buttons for external resources.
+
+        GIVEN: User opens the About window
+        WHEN: They look at the window
+        THEN: Buttons for User Manual, Support Forum, Report a Bug, Licenses, and Source Code should be present
+        """
+        window = _create_about_window(root)
+
+        button_texts = []
+        for widget in window.main_frame.winfo_children():
+            widget_class = widget.winfo_class()
+            if widget_class in ("TButton", "Button"):
+                with contextlib.suppress(tk.TclError):
+                    button_texts.append(widget.cget("text"))
+
+        # Verify specific button labels exist
+        button_labels_lower = [b.lower() for b in button_texts]
+        assert any("manual" in b for b in button_labels_lower), f"User Manual button not found in: {button_texts}"
+        assert any("support" in b or "forum" in b for b in button_labels_lower), (
+            f"Support Forum button not found in: {button_texts}"
+        )
+        assert any("bug" in b or "issue" in b for b in button_labels_lower), f"Report Bug button not found in: {button_texts}"
+        assert any("license" in b or "credit" in b for b in button_labels_lower), (
+            f"Licenses button not found in: {button_texts}"
+        )
+        assert any("source" in b or "code" in b for b in button_labels_lower), (
+            f"Source Code button not found in: {button_texts}"
+        )
+
+    def test_about_window_has_usage_popup_checkboxes(self, root: tk.Tk) -> None:
+        """
+        About window contains usage popup preference checkboxes.
+
+        GIVEN: User opens the About window
+        WHEN: They look at the window
+        THEN: Checkboxes for controlling usage popups should be present
+        """
+        window = _create_about_window(root)
+
+        checkbox_count = 0
+        for widget in window.main_frame.winfo_children():
+            widget_class = widget.winfo_class()
+            if widget_class in ("TFrame", "Frame"):
+                for child in widget.winfo_children():
+                    child_class = child.winfo_class()
+                    if child_class in ("TCheckbutton", "Checkbutton"):
+                        checkbox_count += 1
+
+        assert checkbox_count > 0, f"Usage popup checkboxes not found in About window (found {checkbox_count})"
+
+
+class TestAboutWindowButtonInteractions:
+    """Tests for button interactions in the About window."""
+
+    def _find_button_by_text(self, window: AboutWindow, text_fragment: str) -> None:
+        """Find a button in the window and invoke it. Raises AssertionError if not found."""
+        for widget in window.main_frame.winfo_children():
+            widget_class = widget.winfo_class()
+            if widget_class == "TButton":
+                try:
+                    btn_text = widget.cget("text")
+                    if text_fragment.lower() in str(btn_text).lower():
+                        widget.invoke()
+                        return
+                except tk.TclError:
+                    pass
+        children = [w.winfo_class() for w in window.main_frame.winfo_children()]
+        msg = f"No TButton containing '{text_fragment}' found among main_frame children: {children}"
+        raise AssertionError(msg)
+
+    def test_user_can_open_user_manual_via_about_window(self, root: tk.Tk) -> None:
+        """
+        User can open the User Manual from the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User clicks the User Manual button
+        THEN: The User Manual URL should be opened in the default web browser
+        """
+        window = _create_about_window(root)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_about_popup_window.webbrowser_open_url") as mock_open:
+            self._find_button_by_text(window, "Manual")
+            mock_open.assert_called_once()
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
+            assert "USERMANUAL" in call_args or "usermanual" in call_args.lower(), f"User Manual URL not found in {call_args}"
+            assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+
+    def test_user_can_open_support_forum_via_about_window(self, root: tk.Tk) -> None:
+        """
+        User can access the support forum from the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User clicks the Support Forum button
+        THEN: The support forum URL should be opened in the default web browser
+        """
+        window = _create_about_window(root)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_about_popup_window.webbrowser_open_url") as mock_open:
+            self._find_button_by_text(window, "Support")
+            mock_open.assert_called_once()
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
+            call_args_lower = call_args.lower()
+            assert "ardupilot" in call_args_lower or "discuss" in call_args_lower, (
+                f"Support forum URL not found in {call_args}"
+            )
+            assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+
+    def test_user_can_report_a_bug_via_about_window(self, root: tk.Tk) -> None:
+        """
+        User can report a bug via the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User clicks the Report a Bug button
+        THEN: The GitHub issues URL should be opened in the default web browser
+        """
+        window = _create_about_window(root)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_about_popup_window.webbrowser_open_url") as mock_open:
+            self._find_button_by_text(window, "Bug")
+            mock_open.assert_called_once()
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
+            call_args_lower = call_args.lower()
+            assert "issues" in call_args_lower or "bug" in call_args_lower, f"Issues URL not found in {call_args}"
+            parsed_url = urlparse(call_args)
+            host = parsed_url.hostname
+            assert host is not None, f"GitHub URL host not found in {call_args}"
+            assert host == "github.com" or host.endswith(".github.com"), f"GitHub URL not found in {call_args}"
+            assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+
+    def test_user_can_view_licenses_via_about_window(self, root: tk.Tk) -> None:
+        """
+        User can view licenses from the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User clicks the Licenses button
+        THEN: The CREDITS.md URL should be opened in the default web browser
+        """
+        window = _create_about_window(root)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_about_popup_window.webbrowser_open_url") as mock_open:
+            self._find_button_by_text(window, "License")
+            mock_open.assert_called_once()
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
+            call_args_lower = call_args.lower()
+            assert "credits" in call_args_lower, f"CREDITS URL not found in {call_args}"
+            assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+
+    def test_user_can_view_source_code_via_about_window(self, root: tk.Tk) -> None:
+        """
+        User can view source code from the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User clicks the Source Code button
+        THEN: The GitHub repository URL should be opened in the default web browser
+        """
+        window = _create_about_window(root)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_about_popup_window.webbrowser_open_url") as mock_open:
+            self._find_button_by_text(window, "Source")
+            mock_open.assert_called_once()
+            call_args = mock_open.call_args[0][0]
+            assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
+            assert "github.com/ArduPilot/MethodicConfigurator" in call_args, (
+                f"Expected repository URL not found in {call_args}"
+            )
+            assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+
+
+class TestAboutWindowUsagePopupPreferences:
+    """Tests for usage popup preference checkboxes in the About window."""
+
+    def test_user_can_toggle_usage_popup_display_preference(self, root: tk.Tk) -> None:
+        """
+        User can toggle usage popup display preferences from the About window.
+
+        GIVEN: User has the About window open
+        WHEN: User toggles a usage popup checkbox
+        THEN: The preference should be updated via ProgramSettings
+        """
+        window = _create_about_window(root)
+
+        with patch(
+            "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.set_display_usage_popup"
+        ) as mock_set:
+            # Find and click a checkbox in the usage popup frame
+            checkbox_invoked = False
+            for widget in window.main_frame.winfo_children():
+                if widget.winfo_class() in ("TFrame", "Frame"):
+                    for child in widget.winfo_children():
+                        if child.winfo_class() in ("TCheckbutton", "Checkbutton"):
+                            child.invoke()
+                            checkbox_invoked = True
+                            break
+            assert checkbox_invoked, "No checkbox found to invoke"
+            mock_set.assert_called_once()
+
+    def test_about_window_reads_current_usage_popup_preferences(self, root: tk.Tk) -> None:
+        """
+        About window displays current usage popup preferences correctly.
+
+        GIVEN: The user has previously set usage popup preferences
+        WHEN: User opens the About window
+        THEN: The checkboxes should reflect the current preferences
+        """
+        with patch(
+            "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.display_usage_popup",
+            return_value=True,
+        ):
+            window = _create_about_window(root)
+
+        # Verify window was created successfully
+        assert window is not None
+        assert window.root is not None
+        # Verify that preferences were read by checking checkboxes exist
+        checkbox_count = 0
+        for widget in window.main_frame.winfo_children():
+            if widget.winfo_class() in ("TFrame", "Frame"):
+                for child in widget.winfo_children():
+                    if child.winfo_class() in ("TCheckbutton", "Checkbutton"):
+                        checkbox_count += 1
+        assert checkbox_count > 0, "Preferences checkboxes should be present after initialization"
+
+    def test_about_window_initializes_with_different_version_strings(self, root: tk.Tk) -> None:
+        """
+        About window initializes correctly with different version strings.
+
+        GIVEN: Various valid version strings
+        WHEN: About window is created with each version
+        THEN: Window should display correctly for each version
+        """
+        versions = ["1.0.0", "2.5.3", "10.0.0", "0.1.0-beta"]
+        for version in versions:
+            window = _create_about_window(root, version=version)
+            assert window is not None, f"Window creation failed for version {version}"
+            assert window.root is not None, f"Window root is None for version {version}"
+
+            found_version = False
+            version_text = ""
+            for widget in window.main_frame.winfo_children():
+                if hasattr(widget, "cget"):
+                    try:
+                        text = str(widget.cget("text"))
+                        if version in text:
+                            found_version = True
+                            version_text = text
+                            break
+                    except tk.TclError:
+                        pass
+            assert found_version, f"Version '{version}' not found in About window. Searched text: {version_text}"
+            window.root.destroy()

--- a/tests/test_frontend_tkinter_about_popup_window.py
+++ b/tests/test_frontend_tkinter_about_popup_window.py
@@ -12,25 +12,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import contextlib
 import tkinter as tk
-from collections.abc import Generator
 from unittest.mock import patch
 from urllib.parse import urlparse
 
-import pytest
-
 from ardupilot_methodic_configurator.frontend_tkinter_about_popup_window import AboutWindow
-
-# pylint: disable=redefined-outer-name
-
-
-@pytest.fixture
-def root() -> Generator[tk.Tk, None, None]:
-    """Provide a hidden Tk root window for tests."""
-    root = tk.Tk()
-    root.withdraw()
-    yield root
-    root.update_idletasks()
-    root.destroy()
 
 
 def _create_about_window(root: tk.Tk, version: str = "1.2.3") -> AboutWindow:
@@ -43,6 +28,10 @@ def _create_about_window(root: tk.Tk, version: str = "1.2.3") -> AboutWindow:
             return_value=1.0,
         ),
         patch("ardupilot_methodic_configurator.frontend_tkinter_base_window.BaseWindow.center_window"),
+        patch(
+            "ardupilot_methodic_configurator.backend_filesystem_program_settings.ProgramSettings.display_usage_popup",
+            return_value=True,
+        ),
     ):
         return AboutWindow(root, version)
 
@@ -279,10 +268,12 @@ class TestAboutWindowButtonInteractions:
             mock_open.assert_called_once()
             call_args = mock_open.call_args[0][0]
             assert isinstance(call_args, str), f"Expected URL string but got {type(call_args)}"
-            assert "github.com/ArduPilot/MethodicConfigurator" in call_args, (
-                f"Expected repository URL not found in {call_args}"
-            )
             assert call_args.startswith("http"), f"URL should start with http but got {call_args}"
+            parsed_url = urlparse(call_args)
+            host = parsed_url.hostname
+            assert host is not None, f"GitHub URL host not found in {call_args}"
+            assert host == "github.com" or host.endswith(".github.com"), f"GitHub URL not found in {call_args}"
+            assert "ArduPilot/MethodicConfigurator" in parsed_url.path, f"Expected repository path not found in {call_args}"
 
 
 class TestAboutWindowUsagePopupPreferences:

--- a/tests/test_frontend_tkinter_directory_selection.py
+++ b/tests/test_frontend_tkinter_directory_selection.py
@@ -16,7 +16,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ardupilot_methodic_configurator.data_model_vehicle_project_creator import VehicleProjectCreationError
+from ardupilot_methodic_configurator.data_model_vehicle_project_opener import VehicleProjectOpenError
 from ardupilot_methodic_configurator.frontend_tkinter_directory_selection import (
+    BinLogSelectionWidgets,
     DirectorySelectionWidgets,
     PathEntryWidget,
     VehicleDirectorySelectionWidgets,
@@ -757,3 +760,241 @@ class TestWidgetStringMethods:
             # Assert: Returns the initial name
             assert isinstance(result, str)
             assert result == "TestVehicle"
+
+
+# ==================== BIN LOG SELECTION WIDGET TESTS ====================
+
+
+class TestBinLogSelectionWidgets:
+    """Tests for BinLogSelectionWidgets component behavior."""
+
+    @staticmethod
+    def _make_widget(root: tk.Tk, callback: MagicMock) -> BinLogSelectionWidgets:
+        """Create a BinLogSelectionWidgets with mocked tooltip for use in tests."""
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_directory_selection.show_tooltip"):
+            parent = MagicMock()
+            parent.root = root
+            parent_frame = ttk.Frame(root)
+            return BinLogSelectionWidgets(parent=parent, parent_frame=parent_frame, on_select_file_callback=callback)
+
+    def test_user_can_select_bin_log_file_successfully(self, root) -> None:
+        """
+        User can select a .bin log file successfully.
+
+        GIVEN: A BinLogSelectionWidgets instance with a callback
+        WHEN: User clicks the select file button and picks a file
+        THEN: The callback should be called with the selected file path
+        AND: True should be returned
+        """
+        mock_callback = MagicMock()
+        widget = self._make_widget(root, mock_callback)
+
+        selected_file = "/path/to/flight.bin"
+        with patch("tkinter.filedialog.askopenfilename", return_value=selected_file):
+            result = widget.on_select_file()
+
+        assert result is True
+        mock_callback.assert_called_once_with(selected_file)
+
+    def test_user_can_cancel_bin_log_file_selection(self, root) -> None:
+        """
+        User can cancel .bin log file selection.
+
+        GIVEN: A BinLogSelectionWidgets instance
+        WHEN: User opens the file dialog but cancels
+        THEN: False should be returned
+        AND: The callback should not be called
+        """
+        mock_callback = MagicMock()
+        widget = self._make_widget(root, mock_callback)
+
+        with patch("tkinter.filedialog.askopenfilename", return_value=""):
+            result = widget.on_select_file()
+
+        assert result is False
+        mock_callback.assert_not_called()
+
+    def test_bin_log_selection_handles_vehicle_creation_error(self, root) -> None:
+        """
+        BinLog selection handles VehicleProjectCreationError gracefully.
+
+        GIVEN: A BinLogSelectionWidgets instance with a callback that raises VehicleProjectCreationError
+        WHEN: User selects a file and the callback fails with VehicleProjectCreationError
+        THEN: An error dialog should be shown
+        AND: False should be returned
+        """
+        error = VehicleProjectCreationError(title="Creation Failed", message="Cannot create project")
+        widget = self._make_widget(root, MagicMock(side_effect=error))
+
+        with (
+            patch("tkinter.filedialog.askopenfilename", return_value="/path/to/flight.bin"),
+            patch("tkinter.messagebox.showerror") as mock_error,
+        ):
+            result = widget.on_select_file()
+
+        assert result is False
+        mock_error.assert_called_once()
+
+    def test_bin_log_selection_handles_vehicle_open_error(self, root) -> None:
+        """
+        BinLog selection handles VehicleProjectOpenError gracefully.
+
+        GIVEN: A BinLogSelectionWidgets instance with a callback that raises VehicleProjectOpenError
+        WHEN: User selects a file and the callback fails with VehicleProjectOpenError
+        THEN: An error dialog should be shown
+        AND: False should be returned
+        """
+        error = VehicleProjectOpenError(title="Open Failed", message="Cannot open project")
+        widget = self._make_widget(root, MagicMock(side_effect=error))
+
+        with (
+            patch("tkinter.filedialog.askopenfilename", return_value="/path/to/flight.bin"),
+            patch("tkinter.messagebox.showerror") as mock_error,
+        ):
+            result = widget.on_select_file()
+
+        assert result is False
+        mock_error.assert_called_once()
+
+    def test_bin_log_selection_handles_os_error(self, root) -> None:
+        """
+        BinLog selection handles OSError gracefully.
+
+        GIVEN: A BinLogSelectionWidgets instance with a callback that raises OSError
+        WHEN: User selects a file and an OS error occurs
+        THEN: An error dialog should be shown
+        AND: False should be returned
+        """
+        widget = self._make_widget(root, MagicMock(side_effect=OSError("Permission denied")))
+
+        with (
+            patch("tkinter.filedialog.askopenfilename", return_value="/path/to/flight.bin"),
+            patch("tkinter.messagebox.showerror") as mock_error,
+        ):
+            result = widget.on_select_file()
+
+        assert result is False
+        mock_error.assert_called_once()
+        # Verify the error message contains useful information
+        error_message = str(mock_error.call_args[0][1]) if mock_error.call_args and mock_error.call_args[0] else ""
+        assert len(error_message) > 0, "Error message should not be empty"
+
+
+# ==================== TARGETED COVERAGE TESTS ====================
+
+
+class TestDirectorySelectionEdgeCases:
+    """Tests targeting specific uncovered edge cases in directory selection."""
+
+    def test_update_directory_display_with_parent_without_root(self, root) -> None:
+        """
+        update_directory_display works when parent lacks a root attribute.
+
+        GIVEN: A DirectorySelectionWidgets with a parent that has no 'root' attribute
+        WHEN: update_directory_display is called
+        THEN: Directory should still be updated without calling update_idletasks
+        """
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_directory_selection.show_tooltip"):
+            parent_no_root = MagicMock(spec=[])  # No 'root' attribute
+            parent_frame = ttk.Frame(root)
+
+            widget = DirectorySelectionWidgets(
+                parent=parent_no_root,
+                parent_frame=parent_frame,
+                initialdir="/initial/dir",
+                label_text="Test:",
+                autoresize_width=False,
+                dir_tooltip="tooltip",
+                button_tooltip="Browse",
+            )
+
+            # Directly call update_directory_display
+            widget.update_directory_display("/new/directory")
+
+        assert widget.directory == "/new/directory"
+
+    def test_vehicle_directory_widget_destroys_parent_on_open(self, root) -> None:
+        """
+        VehicleDirectorySelectionWidgets destroys parent when destroy_parent_on_open is True.
+
+        GIVEN: A VehicleDirectorySelectionWidgets with destroy_parent_on_open=True
+        WHEN: User successfully selects a directory
+        THEN: The parent's root.destroy() should be called
+        """
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_directory_selection.show_tooltip"):
+            mock_parent = MagicMock()
+            mock_parent_root = MagicMock()
+            mock_parent.root = mock_parent_root
+            parent_frame = ttk.Frame(root)
+
+            widget = VehicleDirectorySelectionWidgets(
+                parent=mock_parent,
+                parent_frame=parent_frame,
+                initial_dir="/initial/dir",
+                destroy_parent_on_open=True,
+                on_select_directory_callback=None,
+            )
+
+        with patch("tkinter.filedialog.askdirectory", return_value="/new/vehicle/dir"):
+            result = widget.on_select_directory()
+
+        assert result is True
+        mock_parent_root.destroy.assert_called_once()
+
+    def test_vehicle_directory_widget_no_callback_with_destroy(self, root) -> None:
+        """
+        VehicleDirectorySelectionWidgets works without callback but with destroy.
+
+        GIVEN: A VehicleDirectorySelectionWidgets with destroy_parent_on_open=True but no callback
+        WHEN: User selects a directory
+        THEN: Parent should be destroyed and True should be returned
+        """
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_directory_selection.show_tooltip"):
+            mock_parent = MagicMock()
+            parent_frame = ttk.Frame(root)
+
+            widget = VehicleDirectorySelectionWidgets(
+                parent=mock_parent,
+                parent_frame=parent_frame,
+                initial_dir="/initial",
+                destroy_parent_on_open=True,
+                on_select_directory_callback=None,
+            )
+
+        with patch("tkinter.filedialog.askdirectory", return_value="/selected/dir"):
+            result = widget.on_select_directory()
+
+        assert result is True
+        mock_parent.root.destroy.assert_called_once()
+
+    def test_vehicle_directory_widget_handles_open_error_in_callback(self, root) -> None:
+        """
+        VehicleDirectorySelectionWidgets handles VehicleProjectOpenError in callback.
+
+        GIVEN: A VehicleDirectorySelectionWidgets with a callback that raises VehicleProjectOpenError
+        WHEN: User selects a directory and the callback fails
+        THEN: Error dialog should be shown and False should be returned
+        """
+        error = VehicleProjectOpenError(title="Error", message="Cannot open vehicle directory")
+        mock_callback = MagicMock(side_effect=error)
+
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_directory_selection.show_tooltip"):
+            mock_parent = MagicMock()
+            parent_frame = ttk.Frame(root)
+
+            widget = VehicleDirectorySelectionWidgets(
+                parent=mock_parent,
+                parent_frame=parent_frame,
+                initial_dir="/initial",
+                destroy_parent_on_open=False,
+                on_select_directory_callback=mock_callback,
+            )
+
+        with (
+            patch("tkinter.filedialog.askdirectory", return_value="/selected/dir"),
+            patch("tkinter.messagebox.showerror") as mock_error_dialog,
+        ):
+            result = widget.on_select_directory()
+
+        assert result is False
+        mock_error_dialog.assert_called_once_with("Error", "Cannot open vehicle directory")

--- a/tests/test_frontend_tkinter_rich_text.py
+++ b/tests/test_frontend_tkinter_rich_text.py
@@ -16,7 +16,11 @@ from platform import system as platform_system
 from tkinter import ttk
 from unittest.mock import MagicMock, patch
 
-from ardupilot_methodic_configurator.frontend_tkinter_rich_text import RichText, get_widget_font_family_and_size
+from ardupilot_methodic_configurator.frontend_tkinter_rich_text import (
+    RichText,
+    _get_ttk_label_color,
+    get_widget_font_family_and_size,
+)
 
 
 class TestRichText(unittest.TestCase):
@@ -200,3 +204,102 @@ class TestGetWidgetFontFamilyAndSize(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRichTextColorAndFontFallbacks(unittest.TestCase):
+    """Tests for color and font fallback behavior in RichText."""
+
+    def setUp(self) -> None:
+        self.root = tk.Tk()
+        self.root.withdraw()
+
+    def tearDown(self) -> None:
+        self.root.update_idletasks()
+        self.root.destroy()
+
+    def test_user_can_create_rich_text_with_explicit_background_color(self) -> None:
+        """
+        User can create RichText with an explicit background color.
+
+        GIVEN: User wants a custom background color for the text widget
+        WHEN: RichText is created with a background kwarg
+        THEN: The background kwarg should skip the auto-detection
+        AND: Widget should use the provided background color
+        """
+        rich_text = RichText(self.root, background="red")
+        assert rich_text.cget("background") == "red"
+
+    def test_user_can_create_rich_text_with_bg_shorthand(self) -> None:
+        """
+        User can create RichText with bg shorthand.
+
+        GIVEN: User wants a custom background color using 'bg' alias
+        WHEN: RichText is created with bg kwarg
+        THEN: The bg kwarg should skip the auto-detection
+        AND: Widget should use the provided background color
+        """
+        rich_text = RichText(self.root, bg="blue")
+        # Color may be returned as RGB by Tk on some platforms
+        assert rich_text.cget("background")
+
+    def test_user_can_create_rich_text_with_explicit_foreground_color(self) -> None:
+        """
+        User can create RichText with an explicit foreground color.
+
+        GIVEN: User wants a custom foreground color
+        WHEN: RichText is created with foreground kwarg
+        THEN: The foreground kwarg should skip auto-detection
+        AND: Widget should use provided foreground color
+        """
+        rich_text = RichText(self.root, foreground="green")
+        assert rich_text.cget("foreground")
+
+    def test_user_can_create_rich_text_with_fg_shorthand(self) -> None:
+        """
+        User can create RichText with fg shorthand.
+
+        GIVEN: User wants a custom foreground color using 'fg' alias
+        WHEN: RichText is created with fg kwarg
+        THEN: Widget should be created successfully
+        """
+        rich_text = RichText(self.root, fg="purple")
+        assert rich_text.cget("foreground")
+
+    def test_user_can_create_rich_text_when_safe_font_nametofont_returns_none(self) -> None:
+        """
+        User can create RichText even when safe_font_nametofont returns None.
+
+        GIVEN: The font lookup fails (returns None)
+        WHEN: RichText is created without an explicit font
+        THEN: Should fall back to get_safe_font_config for font configuration
+        AND: Widget should be created successfully
+        """
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_rich_text.safe_font_nametofont", return_value=None):
+            rich_text = RichText(self.root)
+
+        assert rich_text is not None
+        assert "bold" in rich_text.tag_names()
+        assert "italic" in rich_text.tag_names()
+        assert "h1" in rich_text.tag_names()
+
+    def test_get_ttk_label_color_handles_cget_tclerror(self) -> None:
+        """
+        _get_ttk_label_color handles TclError from widget.cget gracefully.
+
+        GIVEN: A widget where cget raises TclError for the requested option
+        WHEN: _get_ttk_label_color is called
+        THEN: TclError should be caught and fallback color should be used
+        """
+        mock_widget = MagicMock()
+        mock_widget.cget.side_effect = tk.TclError("Unknown option")
+
+        # Mock style lookup to return empty so we enter the fallback branch
+        with patch("ardupilot_methodic_configurator.frontend_tkinter_rich_text.ttk.Style") as mock_style_class:
+            mock_style = MagicMock()
+            mock_style.lookup.return_value = ""  # Empty = no style found
+            mock_style_class.return_value = mock_style
+
+            result = _get_ttk_label_color(mock_widget, "background", "white")
+
+        # Should use fallback since cget raised TclError
+        assert result == "white"

--- a/tests/test_frontend_tkinter_rich_text.py
+++ b/tests/test_frontend_tkinter_rich_text.py
@@ -206,18 +206,10 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class TestRichTextColorAndFontFallbacks(unittest.TestCase):
+class TestRichTextColorAndFontFallbacks:
     """Tests for color and font fallback behavior in RichText."""
 
-    def setUp(self) -> None:
-        self.root = tk.Tk()
-        self.root.withdraw()
-
-    def tearDown(self) -> None:
-        self.root.update_idletasks()
-        self.root.destroy()
-
-    def test_user_can_create_rich_text_with_explicit_background_color(self) -> None:
+    def test_user_can_create_rich_text_with_explicit_background_color(self, root: tk.Tk) -> None:
         """
         User can create RichText with an explicit background color.
 
@@ -226,10 +218,10 @@ class TestRichTextColorAndFontFallbacks(unittest.TestCase):
         THEN: The background kwarg should skip the auto-detection
         AND: Widget should use the provided background color
         """
-        rich_text = RichText(self.root, background="red")
+        rich_text = RichText(root, background="red")
         assert rich_text.cget("background") == "red"
 
-    def test_user_can_create_rich_text_with_bg_shorthand(self) -> None:
+    def test_user_can_create_rich_text_with_bg_shorthand(self, root: tk.Tk) -> None:
         """
         User can create RichText with bg shorthand.
 
@@ -238,11 +230,11 @@ class TestRichTextColorAndFontFallbacks(unittest.TestCase):
         THEN: The bg kwarg should skip the auto-detection
         AND: Widget should use the provided background color
         """
-        rich_text = RichText(self.root, bg="blue")
+        rich_text = RichText(root, bg="blue")
         # Color may be returned as RGB by Tk on some platforms
         assert rich_text.cget("background")
 
-    def test_user_can_create_rich_text_with_explicit_foreground_color(self) -> None:
+    def test_user_can_create_rich_text_with_explicit_foreground_color(self, root: tk.Tk) -> None:
         """
         User can create RichText with an explicit foreground color.
 
@@ -251,10 +243,10 @@ class TestRichTextColorAndFontFallbacks(unittest.TestCase):
         THEN: The foreground kwarg should skip auto-detection
         AND: Widget should use provided foreground color
         """
-        rich_text = RichText(self.root, foreground="green")
+        rich_text = RichText(root, foreground="green")
         assert rich_text.cget("foreground")
 
-    def test_user_can_create_rich_text_with_fg_shorthand(self) -> None:
+    def test_user_can_create_rich_text_with_fg_shorthand(self, root: tk.Tk) -> None:
         """
         User can create RichText with fg shorthand.
 
@@ -262,10 +254,10 @@ class TestRichTextColorAndFontFallbacks(unittest.TestCase):
         WHEN: RichText is created with fg kwarg
         THEN: Widget should be created successfully
         """
-        rich_text = RichText(self.root, fg="purple")
+        rich_text = RichText(root, fg="purple")
         assert rich_text.cget("foreground")
 
-    def test_user_can_create_rich_text_when_safe_font_nametofont_returns_none(self) -> None:
+    def test_user_can_create_rich_text_when_safe_font_nametofont_returns_none(self, root: tk.Tk) -> None:
         """
         User can create RichText even when safe_font_nametofont returns None.
 
@@ -275,7 +267,7 @@ class TestRichTextColorAndFontFallbacks(unittest.TestCase):
         AND: Widget should be created successfully
         """
         with patch("ardupilot_methodic_configurator.frontend_tkinter_rich_text.safe_font_nametofont", return_value=None):
-            rich_text = RichText(self.root)
+            rich_text = RichText(root)
 
         assert rich_text is not None
         assert "bold" in rich_text.tag_names()


### PR DESCRIPTION
# Description

- Add TestAboutWindowCreation, TestAboutWindowButtonInteractions, TestAboutWindowUsagePopupPreferences in new test file
- Add TestBinLogSelectionWidgets covering success, cancel, and all error paths (VehicleProjectCreationError, VehicleProjectOpenError, OSError)
- Add TestDerivedParametersFiltering covering FC-filtered, file-filtered, and offline (no FC) scenarios
- Add TestConnectionRenamingWithSameNameSkip covering no-op and conflict cases

Quality:
- Assert mock_set is called when toggling usage popup checkbox (was vacuous)
- _find_button_by_text raises AssertionError with diagnostics if not found
- Replace 6-tuple wildcard unpacking with named variables
- Assert _duplicates == set() in rename tests
- Replace unused bin_log_widget_setup fixture with _make_widget() helper to eliminate duplicated widget construction in every test method

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
