### PR TITLE
fix: prevent MAVFTP write path crashes for empty files and None write_list

### DIFF
--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -871,7 +871,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def __send_more_writes(self) -> None:
         """Send some more writes."""
-        if len(self.write_list) == 0 or self.write_list is None:
+        if self.write_list is None or len(self.write_list) == 0:
             # all done
             self.__put_finished(self.write_file_size)
             self.__terminate_session()
@@ -882,6 +882,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             # we seem to have lost a block of replies
             self.write_pending = max(0, self.write_pending - 1)
 
+        if self.write_list is None:
+            return
         n = min(self.ftp_settings.write_qsize - self.write_pending, len(self.write_list))
         for _i in range(n):
             # send in round-robin, skipping any that have been acked
@@ -910,6 +912,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # assume the FTP server processes the blocks sequentially. This means
         # when we receive an ack that any blocks between the last ack and this
         # one have been lost
+        if self.write_total == 0:
+            self.__terminate_session()
+            return MAVFTPReturn("WriteFile", ERR_None)
         idx = op.offset // self.write_block_size
         count = (idx - self.write_recv_idx) % self.write_total
 

--- a/tests/test_backend_mavftp.py
+++ b/tests/test_backend_mavftp.py
@@ -281,5 +281,45 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         self.log_stream.truncate(0)
 
 
+class TestMAVFTPWritePathCrashes(unittest.TestCase):
+    """Test MAVFTP write path crash fixes."""
+
+    def setUp(self) -> None:
+        self.mock_master = mavutil.mavlink_connection(device="udp:localhost:0", source_system=1)
+        self.mav_ftp = MAVFTP(self.mock_master, target_system=1, target_component=1)
+
+    def test_send_more_writes_none_write_list_does_not_crash(self) -> None:
+        """Bug fix: len(None) TypeError when write_list is None."""
+        self.mav_ftp.write_list = None
+        try:
+            self.mav_ftp._MAVFTP__send_more_writes()  # pylint: disable=protected-access
+        except TypeError as e:
+            self.fail(f"__send_more_writes raised TypeError with None write_list: {e}")
+
+    def test_handle_write_reply_empty_file_does_not_crash(self) -> None:
+        """Bug fix: ZeroDivisionError when uploading empty file (write_total=0)."""
+        self.mav_ftp.write_total = 0
+        self.mav_ftp.write_block_size = 239
+        self.mav_ftp.write_list = set()
+        self.mav_ftp.write_recv_idx = -1
+        self.mav_ftp.write_pending = 0
+        self.mav_ftp.write_acks = 0
+        self.mav_ftp.put_callback_progress = None
+        op = FTP_OP(seq=1, session=1, opcode=OP_Ack, size=0, req_opcode=0, burst_complete=0, offset=0, payload=None)
+        try:
+            self.mav_ftp._MAVFTP__handle_write_reply(op, None)  # pylint: disable=protected-access
+        except ZeroDivisionError as e:
+            self.fail(f"__handle_write_reply raised ZeroDivisionError for empty file: {e}")
+
+    def test_send_more_writes_none_guard_at_line_886(self) -> None:
+        """Bug fix: Missing None guard before len(write_list) at line 886."""
+        self.mav_ftp.write_list = None
+        self.mav_ftp.write_file_size = 0
+        try:
+            self.mav_ftp._MAVFTP__send_more_writes()  # pylint: disable=protected-access
+        except TypeError as e:
+            self.fail(f"__send_more_writes raised TypeError at len(write_list) guard: {e}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix three crashes in the MAVFTP write path that occur when uploading
empty files or when write_list becomes None during an active session.

Bug 1 (line 875): Wrong condition order causes TypeError.
len(self.write_list) is evaluated before write_list is None check.
If write_list is None, len(None) crashes immediately.
Fixed by swapping to: if self.write_list is None or len(self.write_list) == 0

Bug 2 (line 915): Uploading a 0-byte empty file sets write_total=0.
The expression (idx - write_recv_idx) % write_total causes ZeroDivisionError.
Fixed by early-returning ERR_None when write_total == 0.

Bug 3 (line 886): A second len(self.write_list) call has no None guard.
Same TypeError as Bug 1 if write_list is None at that point.
Fixed by adding: if self.write_list is None: return

## Checklist
- [x] Verified by a human programmer
- [x] Code follows our coding standards
- [x] No breaking changes or properly documented

## Testing
- [x] Unit tests pass

Three new regression tests added to tests/test_backend_mavftp.py:
- test_send_more_writes_none_write_list_does_not_crash
- test_handle_write_reply_empty_file_does_not_crash
- test_send_more_writes_none_guard_at_line_886

All 5 tests pass locally:
5 passed in 29.99s (Python 3.12.10, pytest-9.0.3)