### PR TITLE
fix: prevent ZeroDivisionError in IMU temperature interpolation on sensor stall

### DIFF
--- a/ardupilot_methodic_configurator/tempcal_imu.py
+++ b/ardupilot_methodic_configurator/tempcal_imu.py
@@ -265,7 +265,10 @@ class IMUData:
             if self.accel[imu]["T"][i] <= temperature <= self.accel[imu]["T"][i + 1]:
                 v1 = self.accel[imu][axis][i]
                 v2 = self.accel[imu][axis][i + 1]
-                p = (temperature - self.accel[imu]["T"][i]) / (self.accel[imu]["T"][i + 1] - self.accel[imu]["T"][i])
+                delta_t = self.accel[imu]["T"][i + 1] - self.accel[imu]["T"][i]
+                if delta_t == 0.0:
+                    return float(v1)
+                p = (temperature - self.accel[imu]["T"][i]) / delta_t
                 return float(v1 + (v2 - v1) * p)
         return float(self.accel[imu][axis][-1])
 
@@ -277,7 +280,11 @@ class IMUData:
             if self.gyro[imu]["T"][i] <= temperature <= self.gyro[imu]["T"][i + 1]:
                 v1 = self.gyro[imu][axis][i]
                 v2 = self.gyro[imu][axis][i + 1]
-                p = (temperature - self.gyro[imu]["T"][i]) / (self.gyro[imu]["T"][i + 1] - self.gyro[imu]["T"][i])
+                delta_t = self.gyro[imu]["T"][i + 1] - self.gyro[imu]["T"][i]
+                if delta_t == 0.0:
+                    return float(v1)
+                p = (temperature - self.gyro[imu]["T"][i]) / delta_t
+
                 return float(v1 + (v2 - v1) * p)
         return float(self.gyro[imu][axis][-1])
 

--- a/tests/test_tempcal_imu.py
+++ b/tests/test_tempcal_imu.py
@@ -231,6 +231,43 @@ class TestIMUData(unittest.TestCase):
         # Test above maximum temperature
         value = self.data.accel_at_temp(0, "X", 40.0)
         assert value == 2.0  # Should return last value
+        # Test above maximum temperature
+        value = self.data.accel_at_temp(0, "X", 40.0)
+        assert value == 2.0  # Should return last value
+
+    def test_accel_at_temp_duplicate_temperature_does_not_crash(self) -> None:
+        """
+        Bug fix: ZeroDivisionError when two consecutive temperature readings are identical.
+
+        If IMU sensor stalls, T[i] == T[i+1], causing division by zero in interpolation.
+        Fixed by checking delta_t == 0.0 and returning the current value instead.
+        """
+        self.data.add_accel(0, 25.0, 1.0, Vector3(1.0, 2.0, 3.0))
+        self.data.add_accel(0, 25.0, 2.0, Vector3(1.5, 2.5, 3.5))  # duplicate temperature
+        self.data.add_accel(0, 30.0, 3.0, Vector3(2.0, 3.0, 4.0))
+
+        try:
+            value = self.data.accel_at_temp(0, "X", 25.0)
+            assert isinstance(value, float)
+        except ZeroDivisionError as e:
+            self.fail(f"accel_at_temp raised ZeroDivisionError with duplicate temperatures: {e}")
+
+    def test_gyro_at_temp_duplicate_temperature_does_not_crash(self) -> None:
+        """
+        Bug fix: ZeroDivisionError when two consecutive temperature readings are identical.
+
+        If IMU sensor stalls, T[i] == T[i+1], causing division by zero in interpolation.
+        Fixed by checking delta_t == 0.0 and returning the current value instead.
+        """
+        self.data.add_gyro(0, 25.0, 1.0, Vector3(0.1, 0.2, 0.3))
+        self.data.add_gyro(0, 25.0, 2.0, Vector3(0.15, 0.25, 0.35))  # duplicate temperature
+        self.data.add_gyro(0, 30.0, 3.0, Vector3(0.2, 0.3, 0.4))
+
+        try:
+            value = self.data.gyro_at_temp(0, "X", 25.0)
+            assert isinstance(value, float)
+        except ZeroDivisionError as e:
+            self.fail(f"gyro_at_temp raised ZeroDivisionError with duplicate temperatures: {e}")
 
 
 class TestUtilityFunctions(unittest.TestCase):


### PR DESCRIPTION
While reviewing the temperature calibration code, I found that
accel_at_temp and gyro_at_temp can crash with ZeroDivisionError
when an IMU sensor stalls during a flight log recording.

When a sensor stalls, it reports the same temperature for two
consecutive readings. This makes T[i] == T[i+1], so the
interpolation denominator becomes zero and the function crashes.

Changes made:

accel_at_temp (line 268):
Compute delta_t = T[i+1] - T[i] before dividing.
If delta_t is zero, return the current value instead of dividing.

gyro_at_temp (line 280):
Same fix applied for gyro interpolation.

I tested this by adding two IMU readings with identical temperatures
and confirmed the crash before the fix and no crash after.

## Checklist
- [x] Verified by a human programmer
- [x] Code follows our coding standards
- [x] No breaking changes or properly documented

## Testing
- [x] Unit tests pass

Added two regression tests to tests/test_tempcal_imu.py:
- test_accel_at_temp_duplicate_temperature_does_not_crash
- test_gyro_at_temp_duplicate_temperature_does_not_crash

All 18 tests pass locally.