### PR TITLE
fix(configuration steps): delete_parameters takes priority over add_p…

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload coverage to Coveralls (parallel)
         # https://docs.coveralls.io/parallel-builds
-        if: always() && github.repository == 'ArduPilot/MethodicConfigurator'
+        if: always() && github.repository == 'ArduPilot/MethodicConfigurator' && matrix.os != 'macos-latest'
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -924,11 +924,14 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
                 self.merge_forced_or_derived_parameters(
                     param_filename, self.derived_parameters, fc_param_names, target=working
                 )
-                self.compute_add_parameters(param_filename, step_dict, eval_variables, existing_params=working)
+                # Compute deletions once and reuse in compute_add_parameters to avoid redundant evaluation
+                to_delete = self.compute_deletions(param_filename, step_dict, eval_variables)
+                self.compute_add_parameters(
+                    param_filename, step_dict, eval_variables, existing_params=working, parameters_to_delete=to_delete
+                )
                 self.merge_forced_or_derived_parameters(param_filename, self.add_parameters, None, target=working)
 
                 # Apply deletions from delete_parameters
-                to_delete = self.compute_deletions(param_filename, step_dict, eval_variables)
                 actually_deleted = [p for p in sorted(to_delete) if p in working]
                 if actually_deleted:
                     logging_info(_("Deleting parameters %s from '%s'"), actually_deleted, param_filename)

--- a/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
@@ -547,14 +547,22 @@ class ConfigurationSteps:
                 errors.append(error_msg)
         return "\n".join(errors)
 
-    def compute_add_parameters(
-        self, filename: str, file_info: dict, variables: dict, existing_params: ParDict | None = None
+    def compute_add_parameters(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        self,
+        filename: str,
+        file_info: dict,
+        variables: dict,
+        existing_params: ParDict | None = None,
+        parameters_to_delete: set[str] | None = None,
     ) -> None:
         """
         Compute the add_parameters for a given configuration file.
 
         Entries whose 'if' condition evaluates to False are skipped. Any stale entries
         from a previous call for this file are cleared first.
+
+        Parameters that appear in ``delete_parameters`` (and whose delete condition passes)
+        are skipped because ``delete_parameters`` takes priority over ``add_parameters``.
 
         For parameters with conditions referencing ``fc_parameters``, automatically skips
         evaluation when ``fc_parameters`` is not available (e.g., when no FC is connected).
@@ -573,6 +581,8 @@ class ConfigurationSteps:
             if not self._condition_passes(parameter_info, variables):
                 continue
             if existing_params is not None and parameter in existing_params:
+                continue
+            if parameters_to_delete is not None and parameter in parameters_to_delete:
                 continue
             if "New Value" in parameter_info:
                 result, error_msg = self._eval_new_value(parameter_info["New Value"], filename, parameter, "add", variables)

--- a/ardupilot_methodic_configurator/data_model_configuration_step.py
+++ b/ardupilot_methodic_configurator/data_model_configuration_step.py
@@ -90,6 +90,7 @@ class ConfigurationStepProcessor:
         duplicates_to_remove: set[str] = set()
         renames_to_apply: list[tuple[str, str]] = []
         derived_params_to_apply: ParDict = ParDict()
+        parameters_to_delete: set[str] = set()
 
         # Process configuration step operations if configuration steps exist
         if self.local_filesystem.configuration_steps and selected_file in self.local_filesystem.configuration_steps:
@@ -118,12 +119,19 @@ class ConfigurationStepProcessor:
                     if not fc_param_keys or param_name in fc_param_keys:
                         derived_params_to_apply[param_name] = param
 
+            # Compute deletions first so they can be passed to both compute_add_parameters and _apply_auto_imports,
+            # avoiding redundant evaluate calls.
+            parameters_to_delete = self.local_filesystem.compute_deletions(
+                selected_file, self.local_filesystem.configuration_steps[selected_file], variables
+            )
+
             # Compute add_parameters (does NOT mutate filesystem.file_parameters)
             self.local_filesystem.compute_add_parameters(
                 selected_file,
                 self.local_filesystem.configuration_steps[selected_file],
                 variables,
                 existing_params=self.local_filesystem.file_parameters.get(selected_file),
+                parameters_to_delete=parameters_to_delete,
             )
 
             # Populate new_connection_prefix from rename_connection configuration step (per-step scope)
@@ -144,7 +152,7 @@ class ConfigurationStepProcessor:
         current_step_parameters = self._create_domain_model_parameters(selected_file, fc_parameters)
 
         # Apply auto-imports for the current step
-        self._apply_auto_imports(selected_file, fc_parameters, current_step_parameters)
+        self._apply_auto_imports(selected_file, fc_parameters, current_step_parameters, parameters_to_delete)
 
         # Check for ExpressLRS and add FLTMODE_CH warning
         if current_step_parameters.get("RC_OPTIONS") is not None or current_step_parameters.get("FLTMODE_CH") is not None:
@@ -170,15 +178,22 @@ class ConfigurationStepProcessor:
         selected_file: str,
         fc_parameters: dict[str, float],
         current_step_parameters: dict[str, ArduPilotParameter],
+        parameters_to_delete: set[str] | None = None,
     ) -> None:
         """Automatically import non-default FC parameters matching regex rules into the domain model."""
         step_dict = self.local_filesystem.configuration_steps.get(selected_file, {})
         if "autoimport_nondefault_regexp" not in step_dict or not fc_parameters:
             return
 
+        # Parameters that will be deleted take priority; skip auto-importing them
+        if parameters_to_delete is None:
+            parameters_to_delete = set()
+
         regex_rules = step_dict["autoimport_nondefault_regexp"]
         for live_key, live_value in fc_parameters.items():
             if live_key in current_step_parameters:
+                continue
+            if live_key in parameters_to_delete:
                 continue
 
             is_matching_regex = any(re.match(pattern, live_key) for pattern in regex_rules)

--- a/tests/test_backend_filesystem_configuration_steps.py
+++ b/tests/test_backend_filesystem_configuration_steps.py
@@ -1913,3 +1913,159 @@ class TestConfigurationNavigation:
 
         assert result["phase1"]["weight"] == 2  # max(2, 2-1) = 2
         assert result["phase2"]["weight"] == 2  # max(2, 3-2) = 2
+
+
+# ---------------------------------------------------------------------------
+# compute_add_parameters - parameters_to_delete priority
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAddParametersDeletePriority:
+    """Tests that delete_parameters entries take priority over add_parameters entries."""
+
+    def _make_file_info(self, add_params: dict) -> dict:
+        """Build a minimal file_info dict with add_parameters."""
+        return {"add_parameters": add_params}
+
+    def test_parameter_in_delete_set_is_not_added(self, config_steps: ConfigurationSteps) -> None:
+        """
+        A parameter listed in parameters_to_delete is skipped by compute_add_parameters.
+
+        GIVEN: A configuration step whose add_parameters contains only PARAM_A
+        AND: PARAM_A is also in the parameters_to_delete set
+        WHEN: compute_add_parameters is called with that delete set
+        THEN: PARAM_A must NOT appear in add_parameters output
+        AND: The entire file entry must be absent (nothing was added)
+        """
+        # Arrange (Given): single add-param that is also in the delete set
+        file_info = self._make_file_info({"PARAM_A": {"New Value": "1.0", "Change Reason": "added"}})
+        variables: dict = {"fc_parameters": {}}
+
+        # Act (When): compute with the delete set containing the only param
+        config_steps.compute_add_parameters(
+            "step.param",
+            file_info,
+            variables,
+            existing_params=None,
+            parameters_to_delete={"PARAM_A"},
+        )
+
+        # Assert (Then): nothing added — the file entry must not exist
+        assert "step.param" not in config_steps.add_parameters
+
+    def test_parameter_not_in_delete_set_is_added_normally(self, config_steps: ConfigurationSteps) -> None:
+        """
+        A parameter absent from parameters_to_delete is added as usual.
+
+        GIVEN: A configuration step whose add_parameters contains PARAM_B
+        AND: The parameters_to_delete set contains only an unrelated PARAM_A
+        WHEN: compute_add_parameters is called
+        THEN: PARAM_B appears in add_parameters output with the expected value and change reason
+        """
+        # Arrange (Given): PARAM_B to add, unrelated PARAM_A in delete set
+        file_info = self._make_file_info({"PARAM_B": {"New Value": "42.0", "Change Reason": "reason"}})
+        variables: dict = {"fc_parameters": {}}
+
+        # Act (When): compute with a delete set that does not contain PARAM_B
+        config_steps.compute_add_parameters(
+            "step.param",
+            file_info,
+            variables,
+            existing_params=None,
+            parameters_to_delete={"PARAM_A"},
+        )
+
+        # Assert (Then): PARAM_B added with correct value and reason
+        result = config_steps.add_parameters.get("step.param", {})
+        assert "PARAM_B" in result
+        assert result["PARAM_B"].value == 42.0
+        assert result["PARAM_B"].comment == "reason"
+
+    def test_none_delete_set_does_not_block_any_parameter(self, config_steps: ConfigurationSteps) -> None:
+        """
+        Passing parameters_to_delete=None does not block any add_parameters entry.
+
+        GIVEN: A configuration step with add_parameters containing PARAM_C
+        WHEN: compute_add_parameters is called with parameters_to_delete=None
+        THEN: PARAM_C is added normally with the correct value and change reason
+        """
+        # Arrange (Given): single add-param, no delete set
+        file_info = self._make_file_info({"PARAM_C": {"New Value": "7.0", "Change Reason": "none-test"}})
+        variables: dict = {"fc_parameters": {}}
+
+        # Act (When): compute with None delete set
+        config_steps.compute_add_parameters(
+            "step.param",
+            file_info,
+            variables,
+            existing_params=None,
+            parameters_to_delete=None,
+        )
+
+        # Assert (Then): param added with correct value and reason
+        result = config_steps.add_parameters.get("step.param", {})
+        assert "PARAM_C" in result
+        assert result["PARAM_C"].value == 7.0
+        assert result["PARAM_C"].comment == "none-test"
+
+    def test_delete_set_takes_priority_over_add_when_both_present(self, config_steps: ConfigurationSteps) -> None:
+        """
+        delete_parameters takes priority when a parameter appears in both add and delete sets.
+
+        GIVEN: Two add_parameters entries: KEEP_PARAM and DELETE_PARAM
+        AND: DELETE_PARAM is in the parameters_to_delete set
+        WHEN: compute_add_parameters is called
+        THEN: KEEP_PARAM appears in output with its correct value and change reason
+        AND: DELETE_PARAM does not appear in output at all
+        """
+        # Arrange (Given): two params to add, one of which is in the delete set
+        file_info = self._make_file_info(
+            {
+                "KEEP_PARAM": {"New Value": "1.0", "Change Reason": "keep-me"},
+                "DELETE_PARAM": {"New Value": "2.0", "Change Reason": "remove-me"},
+            }
+        )
+        variables: dict = {"fc_parameters": {}}
+
+        # Act (When): compute with DELETE_PARAM in the delete set
+        config_steps.compute_add_parameters(
+            "step.param",
+            file_info,
+            variables,
+            existing_params=None,
+            parameters_to_delete={"DELETE_PARAM"},
+        )
+
+        # Assert (Then): only KEEP_PARAM is present; DELETE_PARAM was suppressed
+        result = config_steps.add_parameters.get("step.param", {})
+        assert "KEEP_PARAM" in result
+        assert result["KEEP_PARAM"].value == 1.0
+        assert result["KEEP_PARAM"].comment == "keep-me"
+        assert "DELETE_PARAM" not in result
+
+    def test_empty_delete_set_does_not_block_any_parameter(self, config_steps: ConfigurationSteps) -> None:
+        """
+        An empty parameters_to_delete set leaves all add_parameters unaffected.
+
+        GIVEN: A configuration step with add_parameters containing PARAM_D
+        WHEN: compute_add_parameters is called with an empty delete set
+        THEN: PARAM_D is added normally with the correct value and change reason
+        """
+        # Arrange (Given): single add-param, empty delete set
+        file_info = self._make_file_info({"PARAM_D": {"New Value": "3.14", "Change Reason": "pi"}})
+        variables: dict = {"fc_parameters": {}}
+
+        # Act (When): compute with an empty delete set
+        config_steps.compute_add_parameters(
+            "step.param",
+            file_info,
+            variables,
+            existing_params=None,
+            parameters_to_delete=set(),
+        )
+
+        # Assert (Then): param added with correct value and reason
+        result = config_steps.add_parameters.get("step.param", {})
+        assert "PARAM_D" in result
+        assert result["PARAM_D"].value == 3.14
+        assert result["PARAM_D"].comment == "pi"

--- a/tests/test_data_model_configuration_step.py
+++ b/tests/test_data_model_configuration_step.py
@@ -1189,3 +1189,127 @@ class TestConnectionRenamingWithSameNameSkip:
         # Verify that both parameters are still present (not removed due to conflict)
         assert "CAN_P1_DRIVER" in parameters
         assert "CAN_P2_DRIVER" in parameters
+
+
+class TestDeleteParametersPriority:
+    """Tests that delete_parameters takes priority over add_parameters and auto-import."""
+
+    def test_deleted_parameter_is_not_auto_imported_from_fc(self, processor) -> None:
+        """
+        A parameter scheduled for deletion is not auto-imported from the flight controller.
+
+        GIVEN: A configuration step with an autoimport regexp and a delete_parameters entry for the same param
+        WHEN: The step is processed with that parameter present in fc_parameters (non-default)
+        THEN: The parameter must NOT appear in the domain model
+        AND: compute_add_parameters is called with the delete set so add_parameters also cannot re-add it
+        AND: No errors are reported
+        """
+        # Arrange (Given): BATT_OPTIONS matches import regexp but is also scheduled for deletion
+        selected_file = "test_file.param"
+        processor.local_filesystem.param_default_dict = {
+            "BATT_OPTIONS": Par(value=0.0, comment="default"),
+        }
+        processor.local_filesystem.file_parameters = {selected_file: {}}
+        processor.local_filesystem.configuration_steps = {selected_file: {"autoimport_nondefault_regexp": ["BATT.*"]}}
+        processor.local_filesystem.compute_deletions.return_value = {"BATT_OPTIONS"}
+        processor.local_filesystem.compute_add_parameters.return_value = None
+
+        # Act (When): process the step with a non-default FC value for the to-be-deleted param
+        fc_params = {"BATT_OPTIONS": 5.0}
+        parameters, ui_errors, _ui_infos, _dup, _ren, _derived = processor.process_configuration_step(selected_file, fc_params)
+
+        # Assert (Then): BATT_OPTIONS absent because it is in the delete set
+        assert "BATT_OPTIONS" not in parameters
+        assert ui_errors == []
+        # compute_add_parameters must have received the delete set
+        call_kwargs = processor.local_filesystem.compute_add_parameters.call_args
+        assert call_kwargs is not None
+        passed_delete_set = call_kwargs.kwargs.get("parameters_to_delete")
+        if passed_delete_set is None and len(call_kwargs.args) > 4:
+            passed_delete_set = call_kwargs.args[4]
+        assert passed_delete_set == {"BATT_OPTIONS"}
+
+    def test_apply_auto_imports_skips_parameters_in_delete_set(self, processor) -> None:
+        """
+        _apply_auto_imports skips every parameter that appears in parameters_to_delete.
+
+        GIVEN: An auto-import step where two params match the regex and are non-default
+        AND: One of them is in the parameters_to_delete set
+        WHEN: _apply_auto_imports is called
+        THEN: Only the non-deleted parameter is added to the domain model with the correct FC value
+        AND: The deleted parameter is absent from the domain model
+        """
+        # Arrange (Given): two matching non-default params, one scheduled for deletion
+        selected_file = "test_file.param"
+        processor.local_filesystem.configuration_steps = {selected_file: {"autoimport_nondefault_regexp": ["BATT.*"]}}
+        processor.local_filesystem.param_default_dict = {
+            "BATT_OPTIONS": Par(value=0.0),
+            "BATT_MONITOR": Par(value=0.0),
+        }
+        processor.local_filesystem.file_parameters = {selected_file: {}}
+        fc_params = {
+            "BATT_OPTIONS": 5.0,  # non-default, NOT deleted → must be imported
+            "BATT_MONITOR": 4.0,  # non-default, IN delete set → must be skipped
+        }
+        parameters_to_delete = {"BATT_MONITOR"}
+        current_step_parameters: dict = {}
+
+        # Act (When): run auto-import with the delete set
+        processor._apply_auto_imports(selected_file, fc_params, current_step_parameters, parameters_to_delete)
+
+        # Assert (Then): imported param present with correct value; deleted param absent
+        assert "BATT_OPTIONS" in current_step_parameters
+        assert current_step_parameters["BATT_OPTIONS"].get_new_value() == 5.0
+        assert "BATT_MONITOR" not in current_step_parameters
+
+    def test_apply_auto_imports_with_none_delete_set_behaves_as_empty_set(self, processor) -> None:
+        """
+        _apply_auto_imports treats a None parameters_to_delete the same as an empty set.
+
+        GIVEN: An auto-import step with a matching non-default FC parameter
+        WHEN: _apply_auto_imports is called with parameters_to_delete=None
+        THEN: The parameter is imported normally with the correct FC value
+        AND: No exception is raised
+        """
+        # Arrange (Given): single matching non-default param, no delete set provided
+        selected_file = "test_file.param"
+        processor.local_filesystem.configuration_steps = {selected_file: {"autoimport_nondefault_regexp": ["GPS.*"]}}
+        processor.local_filesystem.param_default_dict = {"GPS_TYPE": Par(value=0.0)}
+        processor.local_filesystem.file_parameters = {selected_file: {}}
+        current_step_parameters: dict = {}
+
+        # Act (When): call with None delete set
+        processor._apply_auto_imports(selected_file, {"GPS_TYPE": 1.0}, current_step_parameters, None)
+
+        # Assert (Then): param imported with correct value
+        assert "GPS_TYPE" in current_step_parameters
+        assert current_step_parameters["GPS_TYPE"].get_new_value() == 1.0
+
+    def test_process_configuration_step_passes_delete_set_to_add_parameters(self, processor) -> None:
+        """
+        process_configuration_step passes the computed delete set to compute_add_parameters.
+
+        GIVEN: A step whose compute_deletions returns a non-empty delete set
+        WHEN: The step is processed
+        THEN: compute_add_parameters is called exactly once with that delete set as parameters_to_delete
+        """
+        # Arrange (Given): step that yields a delete set from compute_deletions
+        selected_file = "test_file.param"
+        processor.local_filesystem.file_parameters = {selected_file: {}}
+        processor.local_filesystem.configuration_steps = {selected_file: {}}
+        delete_set = {"PARAM_TO_DELETE"}
+        processor.local_filesystem.compute_deletions.return_value = delete_set
+        processor.local_filesystem.compute_add_parameters.return_value = None
+        processor.local_filesystem.compute_parameters.return_value = None
+
+        # Act (When): process the step
+        processor.process_configuration_step(selected_file, {})
+
+        # Assert (Then): compute_add_parameters received the delete set via the named kwarg
+        call_kwargs = processor.local_filesystem.compute_add_parameters.call_args
+        assert call_kwargs is not None
+        # Prefer keyword argument; fall back to positional only when not passed as kwarg
+        passed_delete_set = call_kwargs.kwargs.get("parameters_to_delete")
+        if passed_delete_set is None and len(call_kwargs.args) > 4:
+            passed_delete_set = call_kwargs.args[4]
+        assert passed_delete_set == delete_set


### PR DESCRIPTION
…arameters and autoimport

Previously, parameters listed in delete_parameters could still be injected by compute_add_parameters or autoimport_nondefault_regexp, causing a priority conflict. compute_deletions is now called once before compute_add_parameters and its result is threaded through to both compute_add_parameters and _apply_auto_imports so that any parameter scheduled for deletion is unconditionally skipped during addition.

# Description

Describe what this PR is trying to achieve. Please read our [Contributing Guide](../CONTRIBUTING.md) for detailed guidelines.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Tested on flight controller hardware
