### PR TITLE
fix: prevent division by zero in accel_at_temp and gyro_at_temp

### DIFF
--- a/ardupilot_methodic_configurator/tempcal_imu.py
+++ b/ardupilot_methodic_configurator/tempcal_imu.py
@@ -265,7 +265,8 @@ class IMUData:
             if self.accel[imu]["T"][i] <= temperature <= self.accel[imu]["T"][i + 1]:
                 v1 = self.accel[imu][axis][i]
                 v2 = self.accel[imu][axis][i + 1]
-                p = (temperature - self.accel[imu]["T"][i]) / (self.accel[imu]["T"][i + 1] - self.accel[imu]["T"][i])
+                denom = self.accel[imu]["T"][i + 1] - self.accel[imu]["T"][i]
+                p = (temperature - self.accel[imu]["T"][i]) / denom if denom != 0 else 0.0
                 return float(v1 + (v2 - v1) * p)
         return float(self.accel[imu][axis][-1])
 
@@ -277,7 +278,8 @@ class IMUData:
             if self.gyro[imu]["T"][i] <= temperature <= self.gyro[imu]["T"][i + 1]:
                 v1 = self.gyro[imu][axis][i]
                 v2 = self.gyro[imu][axis][i + 1]
-                p = (temperature - self.gyro[imu]["T"][i]) / (self.gyro[imu]["T"][i + 1] - self.gyro[imu]["T"][i])
+                denom = self.gyro[imu]["T"][i + 1] - self.gyro[imu]["T"][i]
+                p = (temperature - self.gyro[imu]["T"][i]) / denom if denom != 0 else 0.0
                 return float(v1 + (v2 - v1) * p)
         return float(self.gyro[imu][axis][-1])
 

--- a/tests/test_tempcal_imu.py
+++ b/tests/test_tempcal_imu.py
@@ -231,7 +231,32 @@ class TestIMUData(unittest.TestCase):
         # Test above maximum temperature
         value = self.data.accel_at_temp(0, "X", 40.0)
         assert value == 2.0  # Should return last value
+    def test_accel_at_temp_duplicate_temperature_does_not_crash(self) -> None:
+        """Bug fix: duplicate consecutive temperature samples must not cause division by zero.
 
+        Two log samples can realistically be recorded at the same rounded
+        temperature. Previously this produced a silent NaN (via numpy's
+        divide-by-zero) instead of returning a sane value.
+        """
+        self.data.add_accel(0, 25.0, 1.0, Vector3(1.0, 2.0, 3.0))
+        self.data.add_accel(0, 25.0, 1.1, Vector3(1.0, 2.0, 3.0))  # duplicate temperature
+        self.data.add_accel(0, 30.0, 2.0, Vector3(1.5, 2.5, 3.5))
+
+        value = self.data.accel_at_temp(0, "X", 25.0)
+
+        assert not np.isnan(value)
+        assert value == 1.0
+
+    def test_gyro_at_temp_duplicate_temperature_does_not_crash(self) -> None:
+        """Bug fix: duplicate consecutive temperature samples must not cause division by zero."""
+        self.data.add_gyro(0, 25.0, 1.0, Vector3(1.0, 2.0, 3.0))
+        self.data.add_gyro(0, 25.0, 1.1, Vector3(1.0, 2.0, 3.0))  # duplicate temperature
+        self.data.add_gyro(0, 30.0, 2.0, Vector3(1.5, 2.5, 3.5))
+
+        value = self.data.gyro_at_temp(0, "X", 25.0)
+
+        assert not np.isnan(value)
+        assert value == 1.0
 
 class TestUtilityFunctions(unittest.TestCase):
     """Test utility functions."""


### PR DESCRIPTION
While reviewing the IMU temperature calibration code, I found that accel_at_temp and gyro_at_temp perform linear interpolation between two consecutive logged temperature samples:

p = (temperature - T[i]) / (T[i+1] - T[i])

When two consecutive temperature samples are equal (a realistic occurrence, since IMU temperature changes slowly and two log entries close in time can be recorded at the same rounded temperature), the denominator is zero.

Since this code operates on numpy scalars, no exception is raised. Instead it silently produces NaN, which can propagate through to the temperature calibration polynomial fit (IMUfit) and corrupt the INS_TCAL* parameters written to the flight controller.

Reproduced directly against the IMUData class:

  data = IMUData()
  data.add_accel(0, 25.0, 1.0, Vector3(1.0, 2.0, 3.0))
  data.add_accel(0, 25.0, 1.1, Vector3(1.0, 2.0, 3.0))
  data.add_accel(0, 30.0, 2.0, Vector3(1.5, 2.5, 3.5))
  data.accel_at_temp(0, "X", 25.0)
  # RuntimeWarning: invalid value encountered in scalar divide
  # Returns: nan

Fixed by guarding the division: when the two temperature points are identical, the interpolation factor falls back to 0.0 (returning the first sample's value) instead of dividing by zero.

## Checklist
- [x] Verified by a human programmer
- [x] Code follows our coding standards
- [x] No breaking changes or properly documented

## Testing
- [x] Unit tests pass

Added two regression tests to tests/test_tempcal_imu.py:
- test_accel_at_temp_duplicate_temperature_does_not_crash
- test_gyro_at_temp_duplicate_temperature_does_not_crash

17/18 tests pass locally (Python 3.12.10, pytest-9.0.3). The one pre-existing failure (test_generate_tempcal_figures_multiple_imus) is an unrelated local Tcl/Tkinter installation issue on my machine, unrelated to this change.