### PR TITLE
Allow override of forced/derived parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ It's simple graphical user interface (GUI) manages and visualizes ArduPilot para
 
 No visible menus, no hidden menus, no complicated options, what you see is what gets changed.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=ArduPilot/MethodicConfigurator&type=date&legend=top-left)](https://www.star-history.com/?repos=ArduPilot%2FMethodicConfigurator&type=date&legend=top-left)
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)
@@ -305,10 +309,6 @@ Now that tuning and configuration are done, some logging and tests can be disabl
 Congratulations your flight controller is now fully configured in the safest and fastest way publicly known.
 
 Enjoy your properly configured vehicle.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=ArduPilot/MethodicConfigurator&type=date&legend=top-left)](https://www.star-history.com/?repos=ArduPilot%2FMethodicConfigurator&type=date&legend=top-left)
 
 ## Documentation and Support
 

--- a/ardupilot_methodic_configurator/backend_filesystem.py
+++ b/ardupilot_methodic_configurator/backend_filesystem.py
@@ -50,7 +50,7 @@ from ardupilot_methodic_configurator.annotate_params import (
 from ardupilot_methodic_configurator.backend_filesystem_configuration_steps import ConfigurationSteps
 from ardupilot_methodic_configurator.backend_filesystem_program_settings import ProgramSettings
 from ardupilot_methodic_configurator.backend_filesystem_vehicle_components import VehicleComponents
-from ardupilot_methodic_configurator.data_model_par_dict import Par, ParDict, is_within_tolerance
+from ardupilot_methodic_configurator.data_model_par_dict import MANUAL_OVERRIDE_PREFIX, Par, ParDict, is_within_tolerance
 
 PARAMETER_FILE_REGEXP = r"^\d{2}_.*\.param$"
 TOOLTIP_MAX_LENGTH = 105
@@ -999,6 +999,10 @@ class LocalFilesystem(VehicleComponents, ConfigurationSteps, ProgramSettings):  
         for param_name, param in new_parameters[filename].items():
             if fc_param_names is None or not fc_param_names or param_name in fc_param_names:
                 if param_name in dest:
+                    # Skip parameters that have manual override active — user has explicitly
+                    # opted out of automated forced/derived value management for this param
+                    if (dest[param_name].comment or "").startswith(MANUAL_OVERRIDE_PREFIX):
+                        continue
                     if not is_within_tolerance(dest[param_name].value, param.value):
                         at_least_one_param_changed = True
                 else:

--- a/ardupilot_methodic_configurator/data_model_ardupilot_parameter.py
+++ b/ardupilot_methodic_configurator/data_model_ardupilot_parameter.py
@@ -12,7 +12,7 @@ from math import inf, isfinite, isnan, nan
 from typing import Any
 
 from ardupilot_methodic_configurator import _
-from ardupilot_methodic_configurator.data_model_par_dict import Par, is_within_tolerance
+from ardupilot_methodic_configurator.data_model_par_dict import MANUAL_OVERRIDE_PREFIX, Par, is_within_tolerance
 
 
 class ParameterUnchangedError(Exception):
@@ -72,12 +72,33 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
         self._is_forced = forced_value is not None and forced_value not in (nan, +inf, -inf)
         self._is_derived = derived_value is not None and derived_value not in (nan, +inf, -inf)
 
+        # Store original forced/derived values so they can be restored when manual override is disabled
+        self._forced_value = forced_value
+        self._forced_reason = forced_reason
+        self._derived_value = derived_value
+        self._derived_reason = derived_reason
+
         # these are the values read from file, not the new values
         self._value_on_file = par_obj.value
-        self._change_reason_on_file = par_obj.comment or ""
+        raw_comment = par_obj.comment if par_obj.comment is not None else ""
+        # Only forced/derived params can have a meaningful manual override. A regular
+        # param whose comment happens to start with the prefix is NOT treated as
+        # overridden; its comment is preserved verbatim.
+        self._is_manual_override = (self._is_forced or self._is_derived) and raw_comment.startswith(MANUAL_OVERRIDE_PREFIX)
+        self._manual_override_on_file = self._is_manual_override
+        if self._is_manual_override:
+            # Strip the "@manual_override " prefix so the user sees only their typed reason
+            stripped = raw_comment[len(MANUAL_OVERRIDE_PREFIX) :]
+            self._change_reason_on_file = stripped.lstrip(" ")
+        else:
+            self._change_reason_on_file = raw_comment
 
         # new value and change reason to be sent to the flight controller and/or saved to file
-        if self._is_forced and forced_value is not None:  # second condition is redundant, but keeps linters happy
+        if self._is_manual_override:
+            # Manual override active: use the file value regardless of forced/derived definition
+            self._new_value = par_obj.value
+            self._change_reason = self._change_reason_on_file
+        elif self._is_forced and forced_value is not None:  # second condition is redundant, but keeps linters happy
             self._new_value = forced_value
             self._change_reason = forced_reason or ""
         elif self._is_derived and derived_value is not None:  # second condition is redundant, but keeps linters happy
@@ -85,7 +106,7 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
             self._change_reason = derived_reason or ""
         else:
             self._new_value = par_obj.value
-            self._change_reason = par_obj.comment or ""
+            self._change_reason = self._change_reason_on_file
 
     @property
     def name(self) -> str:
@@ -139,9 +160,14 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
         )
 
     @property
+    def is_manual_override(self) -> bool:
+        """Return True if this forced/derived parameter has manual override active."""
+        return self._is_manual_override
+
+    @property
     def is_editable(self) -> bool:
         """Return True if the parameter can be edited, False otherwise."""
-        return not (self._is_forced or self._is_derived or self.is_readonly)
+        return not self.is_readonly and (not (self._is_forced or self._is_derived) or self._is_manual_override)
 
     @property
     def has_fc_value(self) -> bool:
@@ -187,7 +213,11 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
             if self.is_bitmask or self.is_multiple_choice
             else not is_within_tolerance(self._new_value, self._value_on_file)
         )
-        return value_dirty or self._change_reason != self._change_reason_on_file
+        return (
+            value_dirty
+            or self._change_reason != self._change_reason_on_file
+            or self._is_manual_override != self._manual_override_on_file
+        )
 
     @property
     def choices_dict(self) -> dict[str, str]:
@@ -257,6 +287,20 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
     @property
     def change_reason(self) -> str:
         """Return the change reason string for this parameter."""
+        return self._change_reason
+
+    @property
+    def change_reason_for_file(self) -> str:
+        """
+        Return the change reason as it should be stored in the .param file.
+
+        For parameters with manual override active, this prepends the
+        ``@manual_override`` placeholder so the backend can detect and
+        respect the override on the next load.
+        """
+        if self._is_manual_override:
+            reason = self._change_reason
+            return f"{MANUAL_OVERRIDE_PREFIX} {reason}" if reason else MANUAL_OVERRIDE_PREFIX
         return self._change_reason
 
     def get_new_value(self) -> float:
@@ -357,7 +401,7 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
                 change the currently stored value.
 
         """
-        if self._is_forced or self._is_derived:
+        if (self._is_forced or self._is_derived) and not self._is_manual_override:
             raise ValueError(_("This parameter is forced or derived and cannot be changed."))
 
         if not isinstance(value, str):
@@ -440,7 +484,7 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
             True if the change_reason was changed, False otherwise
 
         """
-        if self._is_forced or self._is_derived:
+        if (self._is_forced or self._is_derived) and not self._is_manual_override:
             return False
 
         if change_reason == self._change_reason or (change_reason == "" and self._change_reason is None):
@@ -493,10 +537,58 @@ class ArduPilotParameter:  # pylint: disable=too-many-instance-attributes, too-m
 
         self._change_reason = change_reason
 
+    def set_manual_override(self, enabled: bool) -> None:
+        """
+        Enable or disable manual override for a forced or derived parameter.
+
+        When enabled, the parameter becomes freely editable. If the file already had @manual_override
+        the persisted file value/reason are restored; otherwise the forced/derived value/reason are used
+        as a starting point.
+        When disabled, the forced/derived value and change reason are restored.
+
+        Args:
+            enabled: True to enable manual override, False to revert to forced/derived
+
+        Raises:
+            ValueError: If this parameter is neither forced nor derived
+
+        """
+        if not (self._is_forced or self._is_derived):
+            raise ValueError(_("Manual override is only applicable to forced or derived parameters."))
+
+        if enabled == self._is_manual_override:
+            return
+
+        if enabled:
+            self._is_manual_override = True
+            if self._manual_override_on_file:
+                # The file already had @manual_override: restore the persisted value and reason
+                # so re-enabling the checkbox does not overwrite the user's previous manual values.
+                self._new_value = self._value_on_file
+                self._change_reason = self._change_reason_on_file
+            elif self._is_forced and self._forced_value is not None:
+                self._new_value = self._forced_value
+                self._change_reason = self._forced_reason or ""
+            elif self._is_derived and self._derived_value is not None:
+                self._new_value = float(self._derived_value)
+                self._change_reason = self._derived_reason or ""
+            else:
+                self._new_value = self._value_on_file
+                self._change_reason = self._change_reason_on_file
+        else:
+            self._is_manual_override = False
+            if self._is_forced and self._forced_value is not None:
+                self._new_value = self._forced_value
+                self._change_reason = self._forced_reason or ""
+            elif self._is_derived and self._derived_value is not None:
+                self._new_value = float(self._derived_value)
+                self._change_reason = self._derived_reason or ""
+
     def copy_new_value_to_file(self) -> None:
         """Copy the new value to the value on file, marking it as saved, resetting the is_dirty property."""
         self._value_on_file = self._new_value
         self._change_reason_on_file = self._change_reason
+        self._manual_override_on_file = self._is_manual_override
 
 
 class BitmaskHelper:

--- a/ardupilot_methodic_configurator/data_model_configuration_step.py
+++ b/ardupilot_methodic_configurator/data_model_configuration_step.py
@@ -348,7 +348,12 @@ class ConfigurationStepProcessor:
                 old_prefix += "_" + parts[1]
                 new_prefix = "CAN_D" + new_number
                 is_exception_case = True
-            if new_type == "SERIAL" and len(parts) >= 2 and parts[0] == "BRD" and re.match(r"^SER\d+$", parts[1]):
+            if (
+                new_type == "SERIAL"
+                and len(parts) >= 2
+                and parts[0] == "BRD"
+                and re.match(r"^SER\d+$", parts[1])  # codespell:ignore
+            ):
                 old_prefix += "_" + parts[1]
                 new_prefix = "BRD_SER" + new_number
                 is_exception_case = True

--- a/ardupilot_methodic_configurator/data_model_par_dict.py
+++ b/ardupilot_methodic_configurator/data_model_par_dict.py
@@ -31,6 +31,11 @@ PARAM_NAME_MAX_LEN = 16
 # across different vehicles without intentional review.
 ID_PARAMETER_NAMES = {"SYSID_THISMAV", "SYSID_MYGCS", "FOLL_SYSID"}
 
+# Placeholder stored at the start of the change reason to indicate that a forced or derived
+# parameter has been manually overridden by the user. The backend skips re-applying
+# forced/derived values for parameters whose .param file comment begins with this prefix.
+MANUAL_OVERRIDE_PREFIX = "@manual_override"
+
 
 class ParamFileError(ValueError):
     """Raised when a .param file contains invalid or malformed data."""

--- a/ardupilot_methodic_configurator/data_model_parameter_editor.py
+++ b/ardupilot_methodic_configurator/data_model_parameter_editor.py
@@ -2103,7 +2103,10 @@ class ParameterEditor:  # pylint: disable=too-many-public-methods, too-many-inst
 
         return ParDict(
             {
-                name: Par(self.current_step_parameters[name].get_new_value(), self.current_step_parameters[name].change_reason)
+                name: Par(
+                    self.current_step_parameters[name].get_new_value(),
+                    self.current_step_parameters[name].change_reason_for_file,
+                )
                 for name in param_names
                 if name in self.current_step_parameters
             }

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor_table.py
@@ -171,6 +171,12 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
             base_headers.append(_("Upload"))
             base_tooltips.append(_("When selected, upload the new value to the flight controller"))
 
+        base_headers.append(_("Manual"))
+        base_tooltips.append(
+            _("When checked, allows manual editing of this forced or derived parameter.\n")
+            + _("When unchecked, reverts to the forced or derived value.")
+        )
+
         base_headers.append(_("Why are you changing this parameter?"))
         base_tooltips.append(change_reason_tooltip)
 
@@ -277,6 +283,7 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         if show_upload_column:
             row_widgets.append(self._create_upload_checkbutton(param_name))
 
+        row_widgets.append(self._create_manual_override_widget(param))
         row_widgets.append(change_reason_widget)
 
         return row_widgets
@@ -292,6 +299,9 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
 
         if show_upload_column:
             row_widgets[6].grid(row=row, column=6, sticky="e", padx=0)
+            row_widgets[7].grid(row=row, column=7, sticky="e", padx=0)  # manual
+        else:
+            row_widgets[6].grid(row=row, column=6, sticky="e", padx=0)  # manual
 
         change_reason_column = self._get_change_reason_column_index(show_upload_column)
         row_widgets[change_reason_column].grid(row=row, column=change_reason_column, sticky="ew", padx=(0, 5))
@@ -307,11 +317,12 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
             Column index for change reason entry
 
         """
-        # Base columns: Delete, Parameter, Current Value, New Value, Unit
+        # Base columns: Delete, Parameter, Current Value, ≠, New Value, Unit
         base_column_count = 6
+        # Manual column is always present (column 6 without upload, 7 with upload)
         if show_upload_column:
-            return base_column_count + 1  # Upload column + Change Reason
-        return base_column_count  # Change Reason directly after Unit
+            return base_column_count + 2  # Upload + Manual + Change Reason
+        return base_column_count + 1  # Manual + Change Reason
 
     def _configure_table_columns(self, show_upload_column: bool) -> None:
         """Configure table column weights and sizes."""
@@ -324,6 +335,9 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
 
         if show_upload_column:
             self.view_port.columnconfigure(6, weight=0)  # Upload to FC
+            self.view_port.columnconfigure(7, weight=0)  # Manual override
+        else:
+            self.view_port.columnconfigure(6, weight=0)  # Manual override
 
         self.view_port.columnconfigure(self._get_change_reason_column_index(show_upload_column), weight=1)  # Change Reason
 
@@ -734,6 +748,34 @@ class ParameterEditorTable(ScrollFrame):  # pylint: disable=too-many-ancestors
         msg = _("When selected upload {param_name} new value to the flight controller")
         show_tooltip(upload_checkbutton, msg.format(**locals()))
         return upload_checkbutton
+
+    def _create_manual_override_widget(self, param: ArduPilotParameter) -> ttk.Checkbutton | ttk.Label:
+        """
+        Create a manual override checkbox for forced/derived params, or an empty label for others.
+
+        For forced or derived parameters the checkbox lets the user bypass the automatic
+        value management so they can set the value and change reason freely.  Toggling the
+        checkbox reverts the table by calling repopulate_parameter_table() while preserving
+        the current scroll position.
+        """
+        if not (param.is_forced or param.is_derived) or param.is_readonly:
+            return ttk.Label(self.view_port, text="")
+
+        var = tk.BooleanVar(value=param.is_manual_override)
+
+        def on_toggle() -> None:
+            current_scroll = self.canvas.yview()[0]
+            param.set_manual_override(var.get())
+            self.parameter_editor_window.repopulate_parameter_table()
+            self.canvas.yview_moveto(current_scroll)
+
+        checkbox = ttk.Checkbutton(self.view_port, variable=var, command=on_toggle)
+        checkbox._manual_override_var = var  # type: ignore[attr-defined]  # noqa: SLF001 # pylint: disable=protected-access # keep var alive
+        tooltip_msg = _(
+            "When checked, allows manual editing of this forced or derived parameter value and change reason.\n"
+        ) + _("When unchecked, reverts to the forced or derived value.")
+        show_tooltip(checkbox, tooltip_msg)
+        return checkbox
 
     def _create_change_reason_entry(self, param: ArduPilotParameter) -> ttk.Entry:
         """Create an entry for the parameter change reason."""

--- a/tests/acceptance_manual_override.py
+++ b/tests/acceptance_manual_override.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+
+"""
+Acceptance tests for the manual override feature.
+
+These tests validate complete user journeys described in manual_override.md:
+- A user can activate manual override to freely edit a forced or derived parameter.
+- A user can deactivate manual override to restore forced/derived automatic management.
+- The override state survives saving to and reloading from a .param file.
+- The backend never overwrites a manually overridden parameter during re-computation.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import os
+import tempfile
+from typing import Any
+
+import pytest
+
+from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_ardupilot_parameter import ArduPilotParameter, ParameterOutOfRangeError
+from ardupilot_methodic_configurator.data_model_par_dict import MANUAL_OVERRIDE_PREFIX, Par, ParDict
+
+# pylint: disable=redefined-outer-name
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def basic_metadata() -> dict[str, Any]:
+    """Minimal metadata with realistic range constraints."""
+    return {
+        "doc_tooltip": "Test parameter",
+        "unit": "m/s",
+        "unit_tooltip": "Meters per second",
+        "min": 0.0,
+        "max": 100.0,
+        "Calibration": False,
+        "ReadOnly": False,
+    }
+
+
+@pytest.fixture
+def forced_param(basic_metadata: dict[str, Any]) -> ArduPilotParameter:
+    """A parameter that is forced by the configuration step."""
+    return ArduPilotParameter(
+        name="FORCED_PARAM",
+        par_obj=Par(5.0, "file reason"),
+        metadata=basic_metadata,
+        default_par=Par(10.0, "default"),
+        fc_value=5.0,
+        forced_par=Par(42.0, "Must be 42 for safety"),
+    )
+
+
+@pytest.fixture
+def derived_param(basic_metadata: dict[str, Any]) -> ArduPilotParameter:
+    """A parameter whose value is derived from the component editor."""
+    return ArduPilotParameter(
+        name="DERIVED_PARAM",
+        par_obj=Par(5.0, "file reason"),
+        metadata=basic_metadata,
+        default_par=Par(10.0, "default"),
+        fc_value=5.0,
+        derived_par=Par(99.0, "Derived from motor count"),
+    )
+
+
+# pylint: disable=duplicate-code
+
+
+@pytest.fixture
+def forced_param_with_override(basic_metadata: dict[str, Any]) -> ArduPilotParameter:
+    """A forced parameter that already has manual override active (as loaded from file)."""
+    return ArduPilotParameter(
+        name="FORCED_OVERRIDE",
+        par_obj=Par(7.0, "@manual_override My custom reason"),
+        metadata=basic_metadata,
+        default_par=Par(10.0, "default"),
+        fc_value=7.0,
+        forced_par=Par(42.0, "Must be 42 for safety"),
+    )
+
+
+@pytest.fixture
+def local_filesystem() -> LocalFilesystem:
+    """A LocalFilesystem instance pointing at a temporary directory."""
+    return LocalFilesystem(
+        "vehicle_dir",
+        "ArduCopter",
+        None,
+        allow_editing_template_files=False,
+        save_component_to_system_templates=False,
+    )
+
+
+# pylint: enable=duplicate-code
+
+# ===========================================================================
+# Acceptance tests: user activates manual override
+# ===========================================================================
+
+
+class TestUserActivatesManualOverride:
+    """User checks the 'Manual' checkbox for a forced or derived parameter."""
+
+    def test_user_can_activate_manual_override_on_forced_parameter(self, forced_param: ArduPilotParameter) -> None:
+        """
+        User can enable manual override on a forced parameter.
+
+        GIVEN: A forced parameter that is normally read-only
+        WHEN: The user checks the 'Manual' checkbox (set_manual_override(True))
+        THEN: The parameter becomes editable
+        AND: Its value is set to the forced value as a starting point
+        AND: Its change reason is set to the forced change reason
+        AND: The is_dirty flag is True
+        """
+        # Arrange: confirm initial state
+        assert forced_param.is_forced
+        assert not forced_param.is_editable
+        assert not forced_param.is_manual_override
+
+        # Act: user checks the checkbox
+        forced_param.set_manual_override(True)
+
+        # Assert: parameter is now editable
+        assert forced_param.is_manual_override
+        assert forced_param.is_editable
+        # Value starts at the forced value so the user can make a small intentional adjustment
+        assert forced_param.get_new_value() == 42.0
+        # Change reason starts at the forced reason
+        assert forced_param.change_reason == "Must be 42 for safety"
+        # Must be flagged for saving
+        assert forced_param.is_dirty
+
+    def test_user_can_activate_manual_override_on_derived_parameter(self, derived_param: ArduPilotParameter) -> None:
+        """
+        User can enable manual override on a derived parameter.
+
+        GIVEN: A derived parameter that is normally read-only
+        WHEN: The user checks the 'Manual' checkbox
+        THEN: The parameter becomes editable starting from the derived value and reason
+        """
+        # Arrange
+        assert derived_param.is_derived
+        assert not derived_param.is_editable
+
+        # Act
+        derived_param.set_manual_override(True)
+
+        # Assert
+        assert derived_param.is_manual_override
+        assert derived_param.is_editable
+        assert derived_param.get_new_value() == 99.0  # derived value, not file value
+        assert derived_param.change_reason == "Derived from motor count"
+        assert derived_param.is_dirty
+
+    def test_forced_and_derived_flags_remain_true_after_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        is_forced remains True even after manual override is activated.
+
+        GIVEN: A forced parameter
+        WHEN: Manual override is enabled
+        THEN: is_forced is still True (the config-step intent is unchanged)
+        AND: is_manual_override is also True
+        """
+        forced_param.set_manual_override(True)
+
+        assert forced_param.is_forced
+        assert forced_param.is_manual_override
+
+    def test_prefix_is_stripped_from_change_reason_display(self, forced_param_with_override: ArduPilotParameter) -> None:
+        """
+        The @manual_override prefix is never shown to the user.
+
+        GIVEN: A parameter loaded from a file whose comment starts with '@manual_override'
+        WHEN: The change_reason property is read
+        THEN: The returned string does not contain the @manual_override prefix
+        """
+        assert not forced_param_with_override.change_reason.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert forced_param_with_override.change_reason == "My custom reason"
+
+
+# ===========================================================================
+# Acceptance tests: user edits value and reason after override
+# ===========================================================================
+
+
+class TestUserEditsAfterOverride:
+    """User modifies value and change reason after enabling manual override."""
+
+    def test_user_can_change_value_after_manual_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        User can set a new value for a manually-overridden forced parameter.
+
+        GIVEN: A forced parameter with manual override enabled
+        WHEN: The user types a new value in the value entry
+        THEN: The new value is stored without raising ValueError
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+
+        # Act: user types a new value
+        forced_param.set_new_value("25.0")
+
+        # Assert
+        assert forced_param.get_new_value() == 25.0
+
+    def test_user_can_change_reason_after_manual_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        User can update the change reason for a manually-overridden forced parameter.
+
+        GIVEN: A forced parameter with manual override enabled
+        WHEN: The user types a new change reason
+        THEN: set_change_reason returns True and the reason is stored
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+
+        # Act
+        result = forced_param.set_change_reason("Changed for bench test")
+
+        # Assert
+        assert result is True
+        assert forced_param.change_reason == "Changed for bench test"
+
+    def test_range_validation_still_applies_after_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Out-of-range values trigger ParameterOutOfRangeError even with manual override active.
+
+        GIVEN: A forced parameter (max=100.0) with manual override enabled
+        WHEN: The user enters a value greater than the maximum
+        THEN: ParameterOutOfRangeError is raised
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+
+        # Act / Assert
+        with pytest.raises(ParameterOutOfRangeError):
+            forced_param.set_new_value("200.0")
+
+
+# ===========================================================================
+# Acceptance tests: user deactivates manual override
+# ===========================================================================
+
+
+class TestUserDeactivatesManualOverride:
+    """User unchecks the 'Manual' checkbox, reverting to forced/derived management."""
+
+    def test_user_can_deactivate_override_on_forced_parameter(self, forced_param: ArduPilotParameter) -> None:
+        """
+        User can disable manual override, restoring the forced value.
+
+        GIVEN: A forced parameter with manual override active
+        WHEN: The user unchecks the 'Manual' checkbox
+        THEN: The parameter reverts to the forced value and forced change reason
+        AND: The parameter is no longer editable
+        AND: is_dirty is True (so the revert gets saved)
+        """
+        # Arrange: activate override, change the value
+        forced_param.set_manual_override(True)
+        forced_param.set_new_value("25.0")
+
+        # Act: user unchecks the checkbox
+        forced_param.set_manual_override(False)
+
+        # Assert: reverted to forced value
+        assert not forced_param.is_manual_override
+        assert not forced_param.is_editable
+        assert forced_param.get_new_value() == 42.0  # forced value
+        assert forced_param.change_reason == "Must be 42 for safety"
+        assert forced_param.is_dirty
+
+    def test_user_can_deactivate_override_on_derived_parameter(self, derived_param: ArduPilotParameter) -> None:
+        """
+        User can disable manual override, restoring the derived value.
+
+        GIVEN: A derived parameter with manual override active
+        WHEN: The user unchecks the 'Manual' checkbox
+        THEN: The parameter reverts to the derived value and derived change reason
+        """
+        # Arrange
+        derived_param.set_manual_override(True)
+
+        # Act
+        derived_param.set_manual_override(False)
+
+        # Assert: reverted to derived value
+        assert not derived_param.is_manual_override
+        assert derived_param.get_new_value() == 99.0  # derived value
+        assert derived_param.change_reason == "Derived from motor count"
+
+
+# ===========================================================================
+# Acceptance tests: persistence round-trip
+# ===========================================================================
+
+
+class TestManualOverridePersistence:
+    """Manual override state survives saving to and reloading from a .param file."""
+
+    def test_override_prefix_is_written_to_file_when_active(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Activating manual override causes the @manual_override prefix to be written to the .param file.
+
+        GIVEN: A forced parameter with manual override just activated and a reason set
+        WHEN: change_reason_for_file is read (used when saving to disk)
+        THEN: The returned string starts with '@manual_override'
+        AND: The user's reason follows the prefix
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+        forced_param.set_change_reason("Changed for bench test")
+
+        # Act
+        comment_for_file = forced_param.change_reason_for_file
+
+        # Assert
+        assert comment_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert "Changed for bench test" in comment_for_file
+
+    def test_override_prefix_is_absent_from_file_when_inactive(self, forced_param: ArduPilotParameter) -> None:
+        """
+        When manual override is NOT active, no prefix is written to the .param file.
+
+        GIVEN: A forced parameter whose override has been deactivated
+        WHEN: change_reason_for_file is read
+        THEN: The returned string does not start with '@manual_override'
+        """
+        # Arrange: never activate (starts inactive)
+        # Act
+        comment_for_file = forced_param.change_reason_for_file
+
+        # Assert
+        assert not comment_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_override_state_is_restored_after_reload_from_file(self, basic_metadata: dict[str, Any]) -> None:
+        """
+        Loading a parameter whose .param comment starts with '@manual_override' restores override state.
+
+        GIVEN: A .param file whose comment for FORCED_PARAM begins with '@manual_override Bench reason'
+        WHEN: The parameter is created from that Par object
+        THEN: is_manual_override is True
+        AND: The displayed change_reason is 'Bench reason' (no prefix)
+        AND: The parameter's new value is taken from the file, not the forced definition
+        """
+        # Arrange: simulate loading from file
+        par_from_file = Par(25.0, "@manual_override Bench reason")
+        forced_definition = Par(42.0, "Must be 42 for safety")
+
+        # Act: create domain model as if reloaded
+        param = ArduPilotParameter(
+            name="FORCED_PARAM",
+            par_obj=par_from_file,
+            metadata=basic_metadata,
+            default_par=Par(10.0, "default"),
+            fc_value=25.0,
+            forced_par=forced_definition,
+        )
+
+        # Assert
+        assert param.is_manual_override
+        assert param.is_editable
+        assert param.get_new_value() == 25.0  # file value preserved
+        assert param.change_reason == "Bench reason"  # prefix stripped
+
+    def test_override_with_no_reason_survives_round_trip(self, basic_metadata: dict[str, Any]) -> None:
+        """
+        A manual override with no typed reason stores and loads '@manual_override' alone.
+
+        GIVEN: A forced parameter with override active but empty change reason
+        WHEN: change_reason_for_file is stored and re-parsed
+        THEN: is_manual_override is True and change_reason is empty
+        """
+        # Arrange: override with empty reason
+        par_from_file = Par(5.0, "@manual_override")
+        param = ArduPilotParameter(
+            name="FORCED_PARAM",
+            par_obj=par_from_file,
+            metadata=basic_metadata,
+            forced_par=Par(42.0, "Must be 42"),
+        )
+
+        # Assert: round-trip is clean
+        assert param.is_manual_override
+        assert param.change_reason == ""
+        assert param.change_reason_for_file == MANUAL_OVERRIDE_PREFIX
+
+    def test_full_round_trip_via_param_file_on_disk(self, basic_metadata: dict[str, Any]) -> None:
+        """
+        Manual override state is preserved through an actual .param file write and read cycle.
+
+        GIVEN: A forced parameter with manual override active and a custom value and reason
+        WHEN: The parameter is exported to a .param file and re-loaded
+        THEN: The reloaded parameter has the same value, change_reason, and is_manual_override=True
+        AND: The forced definition is still present but not applied (override wins)
+        """
+        # Arrange
+        forced_par = Par(42.0, "Must be 42")
+        par_from_file = Par(25.0, "@manual_override Bench test value")
+        param = ArduPilotParameter(
+            name="FORCED_PARAM",
+            par_obj=par_from_file,
+            metadata=basic_metadata,
+            forced_par=forced_par,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".param", mode="w", delete=False, encoding="utf-8") as f:
+            param_file_path = f.name
+
+        try:
+            # Act: export ParDict containing the overridden parameter to disk
+            par_dict = ParDict({"FORCED_PARAM": Par(param.get_new_value(), param.change_reason_for_file)})
+            par_dict.export_to_param(param_file_path)
+
+            # Re-load the file
+            loaded_dict = ParDict.load_param_file_into_dict(param_file_path)
+            loaded_par = loaded_dict["FORCED_PARAM"]
+
+            # Reconstruct the domain model (simulating application reload)
+            reloaded_param = ArduPilotParameter(
+                name="FORCED_PARAM",
+                par_obj=loaded_par,
+                metadata=basic_metadata,
+                forced_par=forced_par,
+            )
+
+            # Assert: state fully preserved
+            assert reloaded_param.is_manual_override
+            assert reloaded_param.get_new_value() == 25.0
+            assert reloaded_param.change_reason == "Bench test value"
+            assert reloaded_param.is_editable
+        finally:
+            if os.path.exists(param_file_path):
+                os.remove(param_file_path)
+
+
+# ===========================================================================
+# Acceptance tests: backend merge bypass
+# ===========================================================================
+
+
+class TestBackendRespectsManualOverride:
+    """The backend never overwrites a manually-overridden parameter during forced/derived merge."""
+
+    def test_backend_does_not_overwrite_manually_overridden_parameter(self, local_filesystem: LocalFilesystem) -> None:
+        """
+        merge_forced_or_derived_parameters skips parameters with @manual_override in the destination.
+
+        GIVEN: A ParDict containing a parameter whose comment starts with '@manual_override'
+        WHEN: merge_forced_or_derived_parameters is called with a new forced value for that param
+        THEN: The parameter's value and comment in the destination are unchanged
+        AND: The function returns True because OTHER_PARAM did change
+        """
+        # Arrange: file has a manually-overridden parameter
+        filename = "test_step.param"
+        local_filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "FORCED_PARAM": Par(25.0, "@manual_override Bench test value"),
+                    "OTHER_PARAM": Par(1.0, "normal reason"),
+                }
+            )
+        }
+
+        # The forced computation wants to set FORCED_PARAM to 42.0
+        new_forced = {
+            filename: ParDict(
+                {
+                    "FORCED_PARAM": Par(42.0, "Must be 42 for safety"),
+                    "OTHER_PARAM": Par(9.0, "forced other"),
+                }
+            )
+        }
+
+        # Act
+        changed = local_filesystem.merge_forced_or_derived_parameters(filename, new_forced, fc_param_names=None)
+
+        # Assert: FORCED_PARAM was NOT overwritten
+        dest = local_filesystem.file_parameters[filename]
+        assert dest["FORCED_PARAM"].value == 25.0
+        assert (dest["FORCED_PARAM"].comment or "").startswith(MANUAL_OVERRIDE_PREFIX)
+        # OTHER_PARAM was still updated
+        assert dest["OTHER_PARAM"].value == 9.0
+        # changed is True because OTHER_PARAM did change
+        assert changed is True
+
+    def test_backend_skips_all_manual_override_params_returns_false_when_no_other_changes(
+        self, local_filesystem: LocalFilesystem
+    ) -> None:
+        """
+        merge_forced_or_derived_parameters returns False when ALL forced params are overridden.
+
+        GIVEN: A file where every parameter has @manual_override
+        WHEN: merge_forced_or_derived_parameters is called
+        THEN: No values change and the function returns False
+        """
+        filename = "test_step.param"
+        local_filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "PARAM_A": Par(1.0, "@manual_override reason A"),
+                    "PARAM_B": Par(2.0, "@manual_override reason B"),
+                }
+            )
+        }
+
+        new_forced = {
+            filename: ParDict(
+                {
+                    "PARAM_A": Par(10.0, "forced A"),
+                    "PARAM_B": Par(20.0, "forced B"),
+                }
+            )
+        }
+
+        changed = local_filesystem.merge_forced_or_derived_parameters(filename, new_forced, fc_param_names=None)
+
+        dest = local_filesystem.file_parameters[filename]
+        assert dest["PARAM_A"].value == 1.0
+        assert dest["PARAM_B"].value == 2.0
+        assert changed is False
+
+    def test_backend_still_adds_newly_forced_params_not_in_file(self, local_filesystem: LocalFilesystem) -> None:
+        """
+        A forced parameter not yet present in the file is added even when other params are overridden.
+
+        GIVEN: A file with one manually-overridden parameter
+        WHEN: A NEW forced parameter (not in the file) is merged
+        THEN: The new parameter is added to the file
+        AND: The overridden parameter remains unchanged
+        """
+        filename = "test_step.param"
+        local_filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "EXISTING_FORCED": Par(25.0, "@manual_override My reason"),
+                }
+            )
+        }
+
+        new_forced = {
+            filename: ParDict(
+                {
+                    "EXISTING_FORCED": Par(42.0, "Must be 42"),
+                    "NEW_FORCED": Par(5.0, "Newly required"),
+                }
+            )
+        }
+
+        changed = local_filesystem.merge_forced_or_derived_parameters(filename, new_forced, fc_param_names=None)
+
+        dest = local_filesystem.file_parameters[filename]
+        assert dest["EXISTING_FORCED"].value == 25.0  # unchanged
+        assert dest["NEW_FORCED"].value == 5.0  # added
+        assert changed is True
+
+
+# ===========================================================================
+# Acceptance tests: dirty detection
+# ===========================================================================
+
+
+class TestDirtyDetectionForManualOverride:
+    """is_dirty correctly tracks manual override state changes."""
+
+    def test_toggling_checkbox_marks_parameter_dirty(self) -> None:
+        """
+        Checking the 'Manual' checkbox marks the parameter as dirty even if value is unchanged.
+
+        GIVEN: A forced parameter whose file value happens to equal the forced value
+        WHEN: The user checks the 'Manual' checkbox
+        THEN: is_dirty is True even though the numeric value did not change
+        """
+        # Arrange: forced value == file value AND reasons match so param starts clean
+        par_obj = Par(42.0, "Must be 42")
+        forced_par = Par(42.0, "Must be 42")
+        param = ArduPilotParameter(
+            name="SAME_VALUE",
+            par_obj=par_obj,
+            forced_par=forced_par,
+        )
+        assert not param.is_dirty  # clean initially
+
+        # Act
+        param.set_manual_override(True)
+
+        # Assert: dirty because override state changed
+        assert param.is_dirty
+
+    def test_copy_new_value_to_file_resets_dirty_flag(self, forced_param: ArduPilotParameter) -> None:
+        """
+        copy_new_value_to_file resets is_dirty after saving.
+
+        GIVEN: A forced parameter whose manual override was just activated (is_dirty=True)
+        WHEN: copy_new_value_to_file is called (simulating a file save)
+        THEN: is_dirty returns False
+        AND: The override state is still active
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+        assert forced_param.is_dirty
+
+        # Act: simulate save
+        forced_param.copy_new_value_to_file()
+
+        # Assert
+        assert not forced_param.is_dirty
+        assert forced_param.is_manual_override  # override still active
+
+    def test_disabling_override_after_save_marks_dirty_again(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Unchecking 'Manual' after a save marks the parameter dirty again.
+
+        GIVEN: A manually-overridden parameter that was saved (is_dirty=False)
+        WHEN: The user unchecks the checkbox
+        THEN: is_dirty becomes True again
+        """
+        # Arrange: activate, save
+        forced_param.set_manual_override(True)
+        forced_param.copy_new_value_to_file()
+        assert not forced_param.is_dirty
+
+        # Act: uncheck
+        forced_param.set_manual_override(False)
+
+        # Assert
+        assert forced_param.is_dirty
+
+
+# ===========================================================================
+# Acceptance tests: constraints and invariants
+# ===========================================================================
+
+
+class TestManualOverrideConstraints:
+    """Constraints described in the specification are enforced."""
+
+    def test_set_manual_override_raises_for_regular_parameter(self, basic_metadata: dict[str, Any]) -> None:
+        """
+        Calling set_manual_override on a non-forced, non-derived parameter raises ValueError.
+
+        GIVEN: A regular parameter (not forced, not derived)
+        WHEN: set_manual_override is called
+        THEN: ValueError is raised
+        """
+        # Arrange
+        regular = ArduPilotParameter(
+            name="NORMAL_PARAM",
+            par_obj=Par(5.0, "reason"),
+            metadata=basic_metadata,
+        )
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="only applicable to forced or derived"):
+            regular.set_manual_override(True)
+
+    def test_readonly_parameter_is_not_editable_even_with_override_in_file(self, basic_metadata: dict[str, Any]) -> None:
+        """
+        A read-only parameter loaded with @manual_override comment is still not editable.
+
+        GIVEN: A read-only forced parameter whose .param comment starts with '@manual_override'
+        WHEN: The domain model is constructed
+        THEN: is_editable is False because is_readonly takes precedence
+        """
+        # Arrange: make metadata readonly
+        ro_metadata = {**basic_metadata, "ReadOnly": True}
+        param = ArduPilotParameter(
+            name="RO_FORCED",
+            par_obj=Par(5.0, "@manual_override Some reason"),
+            metadata=ro_metadata,
+            forced_par=Par(42.0, "Must be 42"),
+        )
+
+        # Assert
+        assert param.is_readonly
+        assert not param.is_editable
+
+    def test_calling_set_manual_override_with_same_state_is_noop(self) -> None:
+        """
+        Calling set_manual_override(False) when override is already off is a no-op.
+
+        GIVEN: A forced parameter with manual override inactive (value/reason match file so not dirty)
+        WHEN: set_manual_override(False) is called
+        THEN: The parameter state is unchanged and is_dirty remains False
+        """
+        # Arrange: use a clean param where file value/reason == forced value/reason
+        clean_param = ArduPilotParameter(
+            name="CLEAN",
+            par_obj=Par(42.0, "Must be 42"),
+            forced_par=Par(42.0, "Must be 42"),
+        )
+        assert not clean_param.is_manual_override
+        assert not clean_param.is_dirty
+
+        # Act
+        clean_param.set_manual_override(False)
+
+        # Assert: no change, no dirty
+        assert not clean_param.is_manual_override
+        assert not clean_param.is_dirty

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,7 @@ PARAMETER_EDITOR_TABLE_HEADERS_SIMPLE = (
     NEW_VALUE_DIFFERENT_STR,
     "New Value",
     "Unit",
+    "Manual",
     "Why are you changing this parameter?",
 )
 
@@ -223,6 +224,7 @@ PARAMETER_EDITOR_TABLE_HEADERS_ADVANCED = (
     "New Value",
     "Unit",
     "Upload",
+    "Manual",
     "Why are you changing this parameter?",
 )
 

--- a/tests/gui_frontend_tkinter_parameter_editor_table.py
+++ b/tests/gui_frontend_tkinter_parameter_editor_table.py
@@ -463,10 +463,10 @@ class TestParameterEditorTableUserWorkflows:
         children = parameter_table.view_port.winfo_children()
         assert len(children) > 0, "Table should have child widgets after population"
 
-        # Each parameter row has 8 widgets (del, name, fc_val, diff, new_val, unit, upload, change_reason)
+        # Each parameter row has 9 widgets (del, name, fc_val, diff, new_val, unit, upload, manual, change_reason)
         # Plus 1 Add button at the bottom
         # In "normal" mode, upload column is shown
-        expected_widgets_per_row = 8
+        expected_widgets_per_row = 9
         assert len(children) == len(test_params) * expected_widgets_per_row + 1, (
             f"Expected {len(test_params) * expected_widgets_per_row + 1} widgets "
             f"({len(test_params)} rows x {expected_widgets_per_row} + Add button), got {len(children)}"

--- a/tests/integration_manual_override.py
+++ b/tests/integration_manual_override.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+
+"""
+Integration tests for the manual override feature.
+
+These tests validate the interactions between components:
+- ArduPilotParameter domain model and the MANUAL_OVERRIDE_PREFIX storage convention
+- ArduPilotParameter + ParameterEditor: override state flows correctly through the editor layer
+- ArduPilotParameter + LocalFilesystem.merge_forced_or_derived_parameters: merge bypass
+- Storage format: change_reason_for_file / change_reason round-trip correctness
+- ParameterEditor.get_parameters_as_par_dict: override prefix is included in exported Par objects
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from typing import Any
+
+import pytest
+
+from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
+from ardupilot_methodic_configurator.data_model_ardupilot_parameter import (
+    ArduPilotParameter,
+    ParameterOutOfRangeError,
+    ParameterUnchangedError,
+)
+from ardupilot_methodic_configurator.data_model_par_dict import MANUAL_OVERRIDE_PREFIX, Par, ParDict
+
+# pylint: disable=redefined-outer-name
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def metadata() -> dict[str, Any]:
+    return {
+        "doc_tooltip": "Integration test parameter",
+        "unit": "Hz",
+        "unit_tooltip": "Hertz",
+        "min": 0.0,
+        "max": 500.0,
+        "Calibration": False,
+        "ReadOnly": False,
+    }
+
+
+@pytest.fixture
+def forced_param(metadata: dict[str, Any]) -> ArduPilotParameter:
+    """Forced parameter with file value 10.0, forced value 99.0."""
+    return ArduPilotParameter(
+        name="INT_FORCED",
+        par_obj=Par(10.0, "original file reason"),
+        metadata=metadata,
+        default_par=Par(0.0, "default"),
+        fc_value=10.0,
+        forced_par=Par(99.0, "Auto-forced by config step"),
+    )
+
+
+@pytest.fixture
+def derived_param(metadata: dict[str, Any]) -> ArduPilotParameter:
+    """Derived parameter with file value 3.0, derived value 15.0."""
+    return ArduPilotParameter(
+        name="INT_DERIVED",
+        par_obj=Par(3.0, "original file reason"),
+        metadata=metadata,
+        default_par=Par(0.0, "default"),
+        fc_value=3.0,
+        derived_par=Par(15.0, "Derived from component count"),
+    )
+
+
+# pylint: disable=duplicate-code
+
+
+@pytest.fixture
+def already_overridden_param(metadata: dict[str, Any]) -> ArduPilotParameter:
+    """Forced parameter already loaded from file with '@manual_override' in its comment."""
+    return ArduPilotParameter(
+        name="INT_OVERRIDDEN",
+        par_obj=Par(22.0, "@manual_override Previously set reason"),
+        metadata=metadata,
+        default_par=Par(0.0, "default"),
+        fc_value=22.0,
+        forced_par=Par(99.0, "Auto-forced by config step"),
+    )
+
+
+@pytest.fixture
+def filesystem() -> LocalFilesystem:
+    return LocalFilesystem(
+        "vehicle_dir",
+        "ArduCopter",
+        None,
+        allow_editing_template_files=False,
+        save_component_to_system_templates=False,
+    )
+
+
+# pylint: enable=duplicate-code
+
+# ===========================================================================
+# Integration: MANUAL_OVERRIDE_PREFIX constant and storage format
+# ===========================================================================
+
+
+class TestManualOverridePrefixStorageFormat:
+    """Verify the storage format constant and its use in change_reason_for_file."""
+
+    def test_prefix_constant_has_expected_value(self) -> None:
+        """
+        MANUAL_OVERRIDE_PREFIX has the exact value '@manual_override'.
+
+        GIVEN: The MANUAL_OVERRIDE_PREFIX constant is imported
+        WHEN: Its value is inspected
+        THEN: It equals the literal string '@manual_override'
+        """
+        assert MANUAL_OVERRIDE_PREFIX == "@manual_override"
+
+    def test_change_reason_for_file_adds_prefix_with_space_separator(self, forced_param: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file uses a space separator between prefix and reason.
+
+        GIVEN: A forced parameter with override enabled and a non-empty reason
+        WHEN: change_reason_for_file is read
+        THEN: The format is exactly '@manual_override <reason>'
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+        forced_param.set_change_reason("My typed reason")
+
+        # Act
+        result = forced_param.change_reason_for_file
+
+        # Assert
+        assert result == "@manual_override My typed reason"
+
+    def test_change_reason_for_file_stores_prefix_alone_when_reason_is_empty(self, forced_param: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file stores just '@manual_override' when the reason is empty.
+
+        GIVEN: A forced parameter with override enabled and empty change reason
+        WHEN: change_reason_for_file is read
+        THEN: The stored string is exactly '@manual_override' (no trailing space)
+        """
+        # Arrange: enable override, then clear the reason via public API
+        forced_param.set_manual_override(True)  # _change_reason becomes "Auto-forced by config step"
+        forced_param.set_change_reason("")  # explicitly set to empty (different from current, so not a no-op)
+
+        # Act
+        result = forced_param.change_reason_for_file
+
+        # Assert: no trailing space
+        assert result == "@manual_override"
+        assert not result.endswith(" ")
+
+    def test_change_reason_for_file_omits_prefix_when_override_inactive(self, forced_param: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file does not add a prefix when override is not active.
+
+        GIVEN: A forced parameter with override inactive
+        WHEN: change_reason_for_file is read
+        THEN: The result equals the plain change_reason with no prefix
+        """
+        # Act (override never activated)
+        result = forced_param.change_reason_for_file
+
+        # Assert: for a forced param, change_reason is the forced reason
+        assert not result.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_loading_parameter_with_prefix_only_sets_empty_reason(self, metadata: dict[str, Any]) -> None:
+        """
+        A file comment of '@manual_override' (no text after) gives an empty displayed reason.
+
+        GIVEN: A Par whose comment is '@manual_override' with nothing after it
+        WHEN: ArduPilotParameter is constructed
+        THEN: change_reason is ''
+        AND: is_manual_override is True
+        """
+        param = ArduPilotParameter(
+            name="BARE",
+            par_obj=Par(1.0, "@manual_override"),
+            metadata=metadata,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert param.is_manual_override
+        assert param.change_reason == ""
+
+    def test_loading_parameter_with_prefix_and_space_only_gives_empty_reason(self, metadata: dict[str, Any]) -> None:
+        """
+        '@manual_override ' (trailing space, no text) strips to an empty displayed reason.
+
+        GIVEN: A Par whose comment is '@manual_override ' (prefix + single space)
+        WHEN: ArduPilotParameter is constructed
+        THEN: change_reason is ''
+        """
+        param = ArduPilotParameter(
+            name="SPACE",
+            par_obj=Par(1.0, "@manual_override "),
+            metadata=metadata,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert param.is_manual_override
+        assert param.change_reason == ""
+
+    def test_non_override_prefix_comment_is_not_detected_as_override(self, metadata: dict[str, Any]) -> None:
+        """
+        A comment that merely contains '@manual_override' in the middle is not treated as override.
+
+        GIVEN: A Par whose comment does not START with '@manual_override'
+        WHEN: ArduPilotParameter is constructed
+        THEN: is_manual_override is False
+        """
+        param = ArduPilotParameter(
+            name="PARTIAL",
+            par_obj=Par(1.0, "See @manual_override docs"),
+            metadata=metadata,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert not param.is_manual_override
+
+
+# ===========================================================================
+# Integration: ArduPilotParameter state transitions
+# ===========================================================================
+
+
+class TestArduPilotParameterStateTransitions:
+    """State transitions in ArduPilotParameter when manual override is toggled."""
+
+    def test_activate_override_keeps_forced_value(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Activating override retains the forced value as the starting point.
+
+        GIVEN: A forced parameter whose new_value is the forced value (99.0)
+        WHEN: set_manual_override(True) is called
+        THEN: new_value remains the forced value (99.0) so the user starts from the recommendation
+        """
+        assert forced_param.get_new_value() == 99.0  # forced value initially
+
+        forced_param.set_manual_override(True)
+
+        assert forced_param.get_new_value() == 99.0
+
+    def test_activate_override_keeps_forced_change_reason(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Activating override retains the forced change reason as the starting point.
+
+        GIVEN: A forced parameter whose change_reason is the forced reason
+        WHEN: set_manual_override(True) is called
+        THEN: change_reason remains the forced reason
+        """
+        assert forced_param.change_reason == "Auto-forced by config step"
+
+        forced_param.set_manual_override(True)
+
+        assert forced_param.change_reason == "Auto-forced by config step"
+
+    def test_deactivate_override_restores_forced_value(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Deactivating override restores the forced value even after the user edited it.
+
+        GIVEN: A forced parameter with override active; user has typed a new value
+        WHEN: set_manual_override(False) is called
+        THEN: new_value is restored to 99.0 (the forced value)
+        """
+        forced_param.set_manual_override(True)
+        forced_param.set_new_value("50.0")
+        assert forced_param.get_new_value() == 50.0
+
+        forced_param.set_manual_override(False)
+
+        assert forced_param.get_new_value() == 99.0
+
+    def test_deactivate_override_restores_derived_value(self, derived_param: ArduPilotParameter) -> None:
+        """
+        Deactivating override on a derived parameter restores the derived value.
+
+        GIVEN: A derived parameter with override active
+        WHEN: set_manual_override(False) is called
+        THEN: new_value is restored to 15.0 (the derived value)
+        """
+        derived_param.set_manual_override(True)
+        derived_param.set_new_value("7.0")
+
+        derived_param.set_manual_override(False)
+
+        assert derived_param.get_new_value() == 15.0
+        assert derived_param.change_reason == "Derived from component count"
+
+    def test_set_new_value_raises_for_inactive_override_on_forced_param(self, forced_param: ArduPilotParameter) -> None:
+        """
+        set_new_value raises ValueError when manual override is NOT active on a forced param.
+
+        GIVEN: A forced parameter with override inactive
+        WHEN: set_new_value is called
+        THEN: ValueError is raised
+        """
+        with pytest.raises(ValueError, match="forced or derived"):
+            forced_param.set_new_value("50.0")
+
+    def test_set_new_value_succeeds_when_override_active(self, forced_param: ArduPilotParameter) -> None:
+        """
+        set_new_value succeeds when override is active.
+
+        GIVEN: A forced parameter with override active
+        WHEN: set_new_value("50.0") is called
+        THEN: No exception is raised and new_value is 50.0
+        """
+        forced_param.set_manual_override(True)
+
+        forced_param.set_new_value("50.0")
+
+        assert forced_param.get_new_value() == 50.0
+
+    def test_set_change_reason_returns_false_for_inactive_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        set_change_reason returns False for a forced param with override inactive.
+
+        GIVEN: A forced parameter with override inactive
+        WHEN: set_change_reason is called
+        THEN: False is returned and the reason is unchanged
+        """
+        original_reason = forced_param.change_reason
+
+        result = forced_param.set_change_reason("Trying to change")
+
+        assert result is False
+        assert forced_param.change_reason == original_reason
+
+    def test_set_change_reason_returns_true_when_override_active(self, forced_param: ArduPilotParameter) -> None:
+        """
+        set_change_reason returns True for a forced param with override active.
+
+        GIVEN: A forced parameter with override active
+        WHEN: set_change_reason is called with a new reason
+        THEN: True is returned and the reason is updated
+        """
+        forced_param.set_manual_override(True)
+
+        result = forced_param.set_change_reason("New integration reason")
+
+        assert result is True
+        assert forced_param.change_reason == "New integration reason"
+
+    def test_is_forced_and_is_derived_remain_true_when_override_active(
+        self, forced_param: ArduPilotParameter, derived_param: ArduPilotParameter
+    ) -> None:
+        """
+        is_forced and is_derived remain True even when override is active.
+
+        GIVEN: A forced and a derived parameter
+        WHEN: Manual override is activated on both
+        THEN: is_forced and is_derived still return True
+        """
+        forced_param.set_manual_override(True)
+        derived_param.set_manual_override(True)
+
+        assert forced_param.is_forced
+        assert forced_param.is_manual_override
+        assert derived_param.is_derived
+        assert derived_param.is_manual_override
+
+    def test_already_overridden_param_uses_file_value_on_construction(
+        self, already_overridden_param: ArduPilotParameter
+    ) -> None:
+        """
+        A parameter loaded with '@manual_override' in its comment uses the file value, not forced.
+
+        GIVEN: A Par whose comment starts with '@manual_override'
+        WHEN: ArduPilotParameter is constructed with a forced_par
+        THEN: new_value is the file value (22.0), not the forced value (99.0)
+        AND: is_forced is still True
+        """
+        assert already_overridden_param.get_new_value() == 22.0
+        assert already_overridden_param.is_manual_override
+        assert already_overridden_param.is_forced
+        assert already_overridden_param.is_editable
+
+    def test_range_check_applies_normally_after_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Range validation is not bypassed by manual override.
+
+        GIVEN: A forced parameter (max=500.0) with override active
+        WHEN: A value greater than the max is entered
+        THEN: ParameterOutOfRangeError is raised
+        """
+        forced_param.set_manual_override(True)
+
+        with pytest.raises(ParameterOutOfRangeError):
+            forced_param.set_new_value("9999.0")
+
+    def test_unchanged_value_raises_unchanged_error_after_override(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Setting the same value raises ParameterUnchangedError even with override active.
+
+        GIVEN: A forced parameter with override active, current new_value is 99.0 (forced value)
+        WHEN: set_new_value("99.0") is called
+        THEN: ParameterUnchangedError is raised
+        """
+        forced_param.set_manual_override(True)
+        assert forced_param.get_new_value() == 99.0  # forced value retained after activation
+
+        with pytest.raises(ParameterUnchangedError):
+            forced_param.set_new_value("99.0")
+
+
+# ===========================================================================
+# Integration: get_parameters_as_par_dict includes @manual_override prefix
+# ===========================================================================
+
+
+class TestGetParametersAsParDictWithOverride:
+    """ParameterEditor.get_parameters_as_par_dict correctly includes the @manual_override prefix."""
+
+    def test_par_dict_comment_contains_prefix_for_overridden_param(self, forced_param: ArduPilotParameter) -> None:
+        """
+        get_parameters_as_par_dict produces Par with @manual_override prefix for overridden params.
+
+        GIVEN: A forced parameter with manual override active and a custom reason
+        WHEN: get_parameters_as_par_dict is called directly via its logic
+        THEN: The Par.comment for that parameter starts with '@manual_override'
+        """
+        # Arrange
+        forced_param.set_manual_override(True)
+        forced_param.set_change_reason("Custom reason")
+
+        # Act: replicate the get_parameters_as_par_dict logic (the real method)
+        result = ParDict({forced_param.name: Par(forced_param.get_new_value(), forced_param.change_reason_for_file)})
+
+        # Assert
+        comment = result[forced_param.name].comment or ""
+        assert comment.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert "Custom reason" in comment
+
+    def test_par_dict_comment_has_no_prefix_for_non_overridden_forced_param(self, forced_param: ArduPilotParameter) -> None:
+        """
+        get_parameters_as_par_dict produces Par without prefix for non-overridden forced params.
+
+        GIVEN: A forced parameter with override NOT active
+        WHEN: get_parameters_as_par_dict logic is applied
+        THEN: Par.comment does not start with '@manual_override'
+        """
+        # Act
+        result = ParDict({forced_param.name: Par(forced_param.get_new_value(), forced_param.change_reason_for_file)})
+
+        # Assert
+        comment = result[forced_param.name].comment or ""
+        assert not comment.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_par_dict_value_equals_file_value_when_override_active(self, forced_param: ArduPilotParameter) -> None:
+        """
+        The exported Par.value reflects the manually-entered value, not the forced value.
+
+        GIVEN: A forced parameter (forced=99.0, file=10.0) with override active
+         AND: The user has changed the value to 35.0
+        WHEN: The Par is built from change_reason_for_file and get_new_value()
+        THEN: Par.value is 35.0 (the user's value)
+        """
+        forced_param.set_manual_override(True)
+        forced_param.set_new_value("35.0")
+
+        par = Par(forced_param.get_new_value(), forced_param.change_reason_for_file)
+
+        assert par.value == 35.0
+
+
+# ===========================================================================
+# Integration: backend merge bypass with filesystem
+# ===========================================================================
+
+
+class TestBackendMergeBypassIntegration:
+    """LocalFilesystem.merge_forced_or_derived_parameters correctly skips overridden params."""
+
+    def test_merge_skips_only_the_overridden_parameter(self, filesystem: LocalFilesystem) -> None:
+        """
+        merge_forced_or_derived_parameters skips only the param with @manual_override, updates others.
+
+        GIVEN: Two parameters in a file; one has @manual_override, the other does not
+        WHEN: merge is called with new values for both
+        THEN: The overridden param retains its file value; the other is updated
+        """
+        filename = "step.param"
+        filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(10.0, "@manual_override My reason"),
+                    "NORMAL_P": Par(1.0, "normal reason"),
+                }
+            )
+        }
+        new_params = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(99.0, "forced"),
+                    "NORMAL_P": Par(77.0, "forced"),
+                }
+            )
+        }
+
+        filesystem.merge_forced_or_derived_parameters(filename, new_params, fc_param_names=None)
+
+        dest = filesystem.file_parameters[filename]
+        assert dest["MANUAL_P"].value == 10.0  # unchanged
+        assert dest["NORMAL_P"].value == 77.0  # updated
+
+    def test_merge_skips_override_param_regardless_of_fc_param_names(self, filesystem: LocalFilesystem) -> None:
+        """
+        The @manual_override skip takes precedence over the fc_param_names filter.
+
+        GIVEN: An overridden param that IS in fc_param_names
+        WHEN: merge is called
+        THEN: The overridden param is still not updated
+        """
+        filename = "step.param"
+        filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(10.0, "@manual_override Reason"),
+                }
+            )
+        }
+        new_params = {filename: ParDict({"MANUAL_P": Par(99.0, "forced")})}
+
+        filesystem.merge_forced_or_derived_parameters(filename, new_params, fc_param_names=["MANUAL_P"])
+
+        assert filesystem.file_parameters[filename]["MANUAL_P"].value == 10.0
+
+    def test_non_overridden_forced_params_are_still_merged(self, filesystem: LocalFilesystem) -> None:
+        """
+        Normal forced parameters (without @manual_override) are merged as before.
+
+        GIVEN: A parameter in the file with a plain comment (no override prefix)
+        WHEN: merge is called with a new forced value
+        THEN: The parameter value is updated
+        """
+        filename = "step.param"
+        filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "NORMAL_P": Par(1.0, "old reason"),
+                }
+            )
+        }
+        new_params = {filename: ParDict({"NORMAL_P": Par(42.0, "new forced reason")})}
+
+        changed = filesystem.merge_forced_or_derived_parameters(filename, new_params, fc_param_names=None)
+
+        assert filesystem.file_parameters[filename]["NORMAL_P"].value == 42.0
+        assert changed is True
+
+    def test_merge_with_target_kwarg_also_respects_override(self, filesystem: LocalFilesystem) -> None:
+        """
+        The @manual_override bypass works when merging into an explicit target ParDict.
+
+        GIVEN: A working-copy ParDict (target) containing a param with @manual_override
+        WHEN: merge_forced_or_derived_parameters is called with target=working_copy
+        THEN: The overridden param in the target is not mutated
+        """
+        filename = "step.param"
+        filesystem.file_parameters = {}  # not used when target is provided
+
+        target = ParDict(
+            {
+                "MANUAL_P": Par(10.0, "@manual_override Keep this"),
+                "NORMAL_P": Par(1.0, "plain reason"),
+            }
+        )
+        new_params = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(99.0, "forced"),
+                    "NORMAL_P": Par(55.0, "forced"),
+                }
+            )
+        }
+
+        filesystem.merge_forced_or_derived_parameters(filename, new_params, fc_param_names=None, target=target)
+
+        assert target["MANUAL_P"].value == 10.0  # untouched
+        assert target["NORMAL_P"].value == 55.0  # updated
+
+    def test_new_param_not_in_file_is_added_even_if_other_params_are_overridden(self, filesystem: LocalFilesystem) -> None:
+        """
+        Forced params that are new (not yet in file) are added even when some existing params are overridden.
+
+        GIVEN: A file with one overridden param; a SECOND forced param not in the file
+        WHEN: merge is called
+        THEN: The second param is added; the first remains unchanged
+        """
+        filename = "step.param"
+        filesystem.file_parameters = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(10.0, "@manual_override Reason"),
+                }
+            )
+        }
+        new_params = {
+            filename: ParDict(
+                {
+                    "MANUAL_P": Par(99.0, "forced A"),
+                    "NEW_P": Par(7.0, "new forced"),
+                }
+            )
+        }
+
+        changed = filesystem.merge_forced_or_derived_parameters(filename, new_params, fc_param_names=None)
+
+        dest = filesystem.file_parameters[filename]
+        assert dest["MANUAL_P"].value == 10.0
+        assert dest["NEW_P"].value == 7.0
+        assert changed is True
+
+
+# ===========================================================================
+# Integration: parameter reload correctly detects override vs non-override
+# ===========================================================================
+
+
+class TestParameterReloadBehavior:
+    """ArduPilotParameter correctly interprets comments on construction."""
+
+    @pytest.mark.parametrize(
+        ("comment", "expected_override", "expected_reason"),
+        [
+            ("@manual_override My reason", True, "My reason"),
+            ("@manual_override", True, ""),
+            ("@manual_override ", True, ""),
+            # For non-overridden forced params, change_reason returns the forced reason
+            # ("forced"), not the file comment — the file comment is stored internally
+            # as _change_reason_on_file for potential restore purposes only.
+            ("Normal reason", False, "forced"),
+            ("", False, "forced"),
+            (None, False, "forced"),
+            ("prefix@manual_override", False, "forced"),
+            ("@MANUAL_OVERRIDE wrong case", False, "forced"),
+        ],
+        ids=[
+            "prefix_with_reason",
+            "prefix_only",
+            "prefix_trailing_space",
+            "normal_reason",
+            "empty_reason",
+            "none_comment",
+            "prefix_mid_string",
+            "wrong_case_not_detected",
+        ],
+    )
+    def test_override_detection_from_par_comment(
+        self,
+        metadata: dict[str, Any],
+        comment: str | None,
+        expected_override: bool,
+        expected_reason: str,
+    ) -> None:
+        """
+        ArduPilotParameter correctly detects override and strips prefix based on Par.comment.
+
+        GIVEN: A Par with a specific comment
+        WHEN: ArduPilotParameter is constructed with a forced_par
+        THEN: is_manual_override matches expected_override
+        AND: change_reason matches expected_reason
+        """
+        param = ArduPilotParameter(
+            name="P",
+            par_obj=Par(1.0, comment),
+            metadata=metadata,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert param.is_manual_override is expected_override
+        assert param.change_reason == expected_reason
+
+    def test_non_forced_non_derived_param_never_gets_override(self, metadata: dict[str, Any]) -> None:
+        """
+        A regular parameter has is_manual_override=False even if its comment starts with the prefix.
+
+        GIVEN: A regular (non-forced, non-derived) parameter whose comment starts with '@manual_override'
+        WHEN: is_manual_override is checked
+        THEN: is_manual_override is False (the prefix is only meaningful for forced/derived params)
+        AND: set_manual_override raises ValueError for both True and False
+        """
+        regular = ArduPilotParameter(
+            name="REGULAR",
+            par_obj=Par(5.0, "@manual_override weird case"),
+            metadata=metadata,
+        )
+
+        # The prefix in the comment is irrelevant — is_manual_override is False for regular params
+        assert not regular.is_manual_override
+
+        # set_manual_override always raises ValueError for non-forced/non-derived params
+        with pytest.raises(ValueError, match="forced or derived"):
+            regular.set_manual_override(True)
+        with pytest.raises(ValueError, match="forced or derived"):
+            regular.set_manual_override(False)
+
+
+# ===========================================================================
+# Integration: multiple toggle cycles
+# ===========================================================================
+
+
+class TestMultipleToggleCycles:
+    """Override can be toggled on and off multiple times correctly."""
+
+    def test_multiple_override_cycles_restore_forced_value_each_time(self, forced_param: ArduPilotParameter) -> None:
+        """
+        Toggling override on/off multiple times always restores the original forced value.
+
+        GIVEN: A forced parameter
+        WHEN: The override is enabled, a new value set, then disabled — repeated 3 times
+        THEN: The forced value (99.0) is restored each time override is disabled
+        """
+        for cycle in range(3):
+            forced_param.set_manual_override(True)
+            forced_param.set_new_value(str(10.0 + cycle))  # different value each cycle
+            assert forced_param.get_new_value() == 10.0 + cycle
+
+            forced_param.set_manual_override(False)
+            assert forced_param.get_new_value() == 99.0, f"Cycle {cycle}: forced value not restored"
+
+    def test_change_reason_for_file_reflects_current_override_state(self, forced_param: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file reflects the current override state in every cycle.
+
+        GIVEN: A forced parameter that is toggled on/off
+        WHEN: change_reason_for_file is read after each toggle
+        THEN: It contains '@manual_override' when active, plain reason when inactive
+        """
+        # Cycle 1: active
+        forced_param.set_manual_override(True)
+        forced_param.set_change_reason("My reason")
+        assert forced_param.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+        # Cycle 2: inactive
+        forced_param.set_manual_override(False)
+        assert not forced_param.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+        # Cycle 3: active again
+        forced_param.set_manual_override(True)
+        forced_param.set_change_reason("Another reason")
+        assert forced_param.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)

--- a/tests/test_frontend_tkinter_parameter_editor_table.py
+++ b/tests/test_frontend_tkinter_parameter_editor_table.py
@@ -626,8 +626,8 @@ class TestUIComplexityBehavior:
         # Act: Get column index with upload column enabled
         column_index = parameter_editor_table._get_change_reason_column_index(show_upload_column=True)
 
-        # Assert: Base columns (6) + Upload column (1) = 7
-        assert column_index == 7
+        # Assert: Base columns (6) + Upload column (1) + Manual column (1) = 8
+        assert column_index == 8
 
     def test_get_change_reason_column_index_without_upload(self, parameter_editor_table: ParameterEditorTable) -> None:
         """
@@ -641,8 +641,8 @@ class TestUIComplexityBehavior:
         # Act: Get column index with upload column disabled
         column_index = parameter_editor_table._get_change_reason_column_index(show_upload_column=False)
 
-        # Assert: Base columns (6) only
-        assert column_index == 6
+        # Assert: Base columns (6) + Manual column (1) = 7
+        assert column_index == 7
 
 
 class TestParameterChangeStateBehavior:
@@ -706,7 +706,7 @@ class TestIntegrationBehavior:
 
         # Assert: Simple mode calculations
         assert show_upload is False
-        assert column_index == 6  # No upload column
+        assert column_index == 7  # No upload column, but Manual column added
 
         # Act: Calculate columns for advanced mode override
         show_upload_advanced = parameter_editor_table._should_show_upload_column("normal")
@@ -714,7 +714,7 @@ class TestIntegrationBehavior:
 
         # Assert: Advanced mode calculations
         assert show_upload_advanced is True
-        assert column_index_advanced == 7  # With upload column
+        assert column_index_advanced == 8  # With upload column + Manual column
 
 
 class TestParameterValueUpdateHandling:
@@ -1028,7 +1028,7 @@ class TestHeaderCreationBehavior:
         # Assert: Headers match expected simple mode structure
         assert headers == PARAMETER_EDITOR_TABLE_HEADERS_SIMPLE
         assert len(tooltips) == len(headers)
-        assert len(tooltips) == 7  # No upload column tooltip
+        assert len(tooltips) == 8  # No upload column tooltip, but Manual column tooltip
 
     def test_create_headers_and_tooltips_advanced_mode(self, parameter_editor_table: ParameterEditorTable) -> None:
         """
@@ -1044,7 +1044,7 @@ class TestHeaderCreationBehavior:
         # Assert: Headers match expected advanced mode structure
         assert headers == PARAMETER_EDITOR_TABLE_HEADERS_ADVANCED
         assert len(tooltips) == len(headers)
-        assert len(tooltips) == 8  # With upload column tooltip
+        assert len(tooltips) == 9  # With upload column tooltip and Manual column tooltip
 
     def test_headers_and_tooltips_localization(self, parameter_editor_table: ParameterEditorTable) -> None:
         """
@@ -1145,7 +1145,7 @@ class TestCompleteIntegrationWorkflows:
 
         # Assert: Simple mode excludes upload column
         assert "Upload" not in headers_simple
-        assert column_index_simple == 6
+        assert column_index_simple == 7  # Manual column only
 
         # Arrange & Act: Test advanced mode
         parameter_editor_table.parameter_editor_window.gui_complexity = "normal"
@@ -1159,7 +1159,7 @@ class TestCompleteIntegrationWorkflows:
 
         # Assert: Advanced mode includes upload column
         assert "Upload" in headers_advanced
-        assert column_index_advanced == 7
+        assert column_index_advanced == 8
 
 
 class TestMousewheelHandlingBehavior:
@@ -1685,7 +1685,7 @@ class TestUIErrorInfoHandling:
             patch("tkinter.ttk.Button") as mock_button,
             patch("ardupilot_methodic_configurator.frontend_tkinter_parameter_editor_table.show_tooltip") as mock_tooltip,
         ):
-            mock_create_widgets.return_value = [MagicMock() for _ in range(7)]  # Mock 7 column widgets
+            mock_create_widgets.return_value = [MagicMock() for _ in range(8)]  # Mock 8 column widgets
 
             # Act: Update the table
             parameter_editor_table._update_table(params, "simple")
@@ -2146,10 +2146,21 @@ class TestLayoutUtilityMethods:
         ):
             widgets = parameter_editor_table._create_column_widgets("PARAM", param, show_upload_column=True)
 
-        assert widgets == ["delete", "name", "fc", "diff", "new", "unit", "upload", "change"]
+        # The manual widget is created by _create_manual_override_widget (not mocked here),
+        # so verify length and all mocked slots by position rather than equality.
+        assert len(widgets) == 9
+        assert widgets[0] == "delete"
+        assert widgets[1] == "name"
+        assert widgets[2] == "fc"
+        assert widgets[3] == "diff"
+        assert widgets[4] == "new"
+        assert widgets[5] == "unit"
+        assert widgets[6] == "upload"
+        # widgets[7] is the manual override widget (real tk widget, not mocked)
+        assert widgets[8] == "change"
 
     def test_grid_column_widgets_places_upload_column(self, parameter_editor_table: ParameterEditorTable) -> None:
-        row_widgets = [MagicMock() for _ in range(8)]
+        row_widgets = [MagicMock() for _ in range(9)]
 
         parameter_editor_table._grid_column_widgets(row_widgets, row=2, show_upload_column=True)
 

--- a/tests/unit_manual_override.py
+++ b/tests/unit_manual_override.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+
+"""
+Unit tests for the manual override feature.
+
+These tests exercise fine-grained behaviour of ArduPilotParameter that is not
+covered by the acceptance and integration test suites:
+
+- MANUAL_OVERRIDE_PREFIX constant value and format contract
+- change_reason_for_file for every combination of override state / reason content
+- _manual_override_on_file baseline tracking across save cycles
+- Disable-then-re-enable when the file already carried @manual_override
+- Post-save restore: re-enable after save restores the *saved* values
+- set_manual_override raises for both True and False on non-forced/non-derived params
+- is_editable never True for read-only params regardless of override flag
+- change_reason_for_file returns plain change_reason for regular (non-forced) params
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from typing import Any
+
+import pytest
+
+from ardupilot_methodic_configurator.data_model_ardupilot_parameter import ArduPilotParameter
+from ardupilot_methodic_configurator.data_model_par_dict import MANUAL_OVERRIDE_PREFIX, Par
+
+# pylint: disable=redefined-outer-name
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def meta() -> dict[str, Any]:
+    """Minimal metadata with range constraints for unit tests."""
+    return {
+        "doc_tooltip": "Unit test parameter",
+        "unit": "rpm",
+        "unit_tooltip": "Revolutions per minute",
+        "min": 0.0,
+        "max": 1000.0,
+        "Calibration": False,
+        "ReadOnly": False,
+    }
+
+
+@pytest.fixture
+def ro_meta() -> dict[str, Any]:
+    """Read-only variant of the metadata fixture."""
+    return {
+        "doc_tooltip": "Read-only unit test parameter",
+        "unit": "",
+        "unit_tooltip": "",
+        "min": 0.0,
+        "max": 1000.0,
+        "Calibration": False,
+        "ReadOnly": True,
+    }
+
+
+@pytest.fixture
+def forced_clean(meta: dict[str, Any]) -> ArduPilotParameter:
+    """Forced param whose file value and reason already match the forced definition (starts clean)."""
+    return ArduPilotParameter(
+        name="FORCED_CLEAN",
+        par_obj=Par(55.0, "forced reason"),
+        metadata=meta,
+        forced_par=Par(55.0, "forced reason"),
+    )
+
+
+@pytest.fixture
+def forced_dirty(meta: dict[str, Any]) -> ArduPilotParameter:
+    """Forced param whose file value differs from the forced definition (starts dirty)."""
+    return ArduPilotParameter(
+        name="FORCED_DIRTY",
+        par_obj=Par(10.0, "old file reason"),
+        metadata=meta,
+        forced_par=Par(55.0, "forced reason"),
+    )
+
+
+@pytest.fixture
+def forced_with_file_override(meta: dict[str, Any]) -> ArduPilotParameter:
+    """Forced param loaded from a file that already carries @manual_override."""
+    return ArduPilotParameter(
+        name="FORCED_OVERRIDE",
+        par_obj=Par(7.0, "@manual_override Saved user reason"),
+        metadata=meta,
+        forced_par=Par(55.0, "forced reason"),
+    )
+
+
+@pytest.fixture
+def derived_clean(meta: dict[str, Any]) -> ArduPilotParameter:
+    """Derived param whose file value and reason already match the derived definition."""
+    return ArduPilotParameter(
+        name="DERIVED_CLEAN",
+        par_obj=Par(20.0, "derived reason"),
+        metadata=meta,
+        derived_par=Par(20.0, "derived reason"),
+    )
+
+
+@pytest.fixture
+def regular(meta: dict[str, Any]) -> ArduPilotParameter:
+    """Regular (non-forced, non-derived) param."""
+    return ArduPilotParameter(
+        name="REGULAR",
+        par_obj=Par(3.0, "just a reason"),
+        metadata=meta,
+    )
+
+
+# ===========================================================================
+# MANUAL_OVERRIDE_PREFIX constant
+# ===========================================================================
+
+
+class TestManualOverridePrefixConstant:
+    """The MANUAL_OVERRIDE_PREFIX constant satisfies the storage format contract."""
+
+    def test_prefix_value_is_exact_literal(self) -> None:
+        """
+        MANUAL_OVERRIDE_PREFIX equals the exact string '@manual_override'.
+
+        GIVEN: The constant is imported
+        WHEN: Its value is compared
+        THEN: It equals '@manual_override' exactly (ASCII, no leading/trailing whitespace)
+        """
+        assert MANUAL_OVERRIDE_PREFIX == "@manual_override"
+
+    def test_prefix_starts_with_at_sign(self) -> None:
+        """
+        Prefix begins with '@' so it cannot be a valid human-entered reason by accident.
+
+        GIVEN: MANUAL_OVERRIDE_PREFIX
+        WHEN: Its first character is inspected
+        THEN: It is '@'
+        """
+        assert MANUAL_OVERRIDE_PREFIX[0] == "@"
+
+    def test_prefix_is_lowercase(self) -> None:
+        """
+        Prefix uses lowercase only, ensuring case-sensitive detection works deterministically.
+
+        GIVEN: MANUAL_OVERRIDE_PREFIX
+        WHEN: It is compared to its lowercased form
+        THEN: They are identical
+        """
+        assert MANUAL_OVERRIDE_PREFIX.lower() == MANUAL_OVERRIDE_PREFIX
+
+    def test_prefix_contains_no_whitespace(self) -> None:
+        """
+        Prefix itself contains no internal whitespace; only a separator space follows it.
+
+        GIVEN: MANUAL_OVERRIDE_PREFIX
+        WHEN: It is stripped
+        THEN: The result is unchanged
+        """
+        assert MANUAL_OVERRIDE_PREFIX.strip() == MANUAL_OVERRIDE_PREFIX
+
+
+# ===========================================================================
+# change_reason_for_file property
+# ===========================================================================
+
+
+class TestChangeReasonForFile:
+    """change_reason_for_file produces the correct string for every scenario."""
+
+    def test_inactive_override_returns_plain_change_reason(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file returns the raw change_reason when override is inactive.
+
+        GIVEN: A forced parameter with override NOT active
+        WHEN: change_reason_for_file is read
+        THEN: It equals change_reason with no prefix
+        """
+        assert not forced_dirty.is_manual_override
+        assert not forced_dirty.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert forced_dirty.change_reason_for_file == forced_dirty.change_reason
+
+    def test_active_override_with_non_empty_reason_prepends_prefix_and_space(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file is '@manual_override <reason>' when override active and reason non-empty.
+
+        GIVEN: A forced parameter with override active and a non-empty reason
+        WHEN: change_reason_for_file is read
+        THEN: It equals '@manual_override <reason>'
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_change_reason("Intentional value")
+
+        result = forced_dirty.change_reason_for_file
+
+        assert result == f"{MANUAL_OVERRIDE_PREFIX} Intentional value"
+
+    def test_active_override_with_empty_reason_returns_prefix_only(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file returns exactly '@manual_override' when reason is empty.
+
+        GIVEN: A forced parameter with override active and empty change reason
+        WHEN: change_reason_for_file is read
+        THEN: It equals '@manual_override' with no trailing space
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty._change_reason = ""  # pylint: disable=protected-access  # set_change_reason rejects no-op
+
+        result = forced_dirty.change_reason_for_file
+
+        assert result == MANUAL_OVERRIDE_PREFIX
+        assert not result.endswith(" ")
+
+    def test_active_override_with_reason_containing_spaces_is_not_stripped(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        Trailing spaces in the reason are preserved in the stored comment.
+
+        GIVEN: A forced parameter with override active and a reason that ends with a space
+        WHEN: change_reason_for_file is read
+        THEN: The trailing space in the reason is preserved (no silent rstrip)
+
+        This ensures that the stored comment round-trips correctly: loading the comment
+        back strips the prefix and lstrips the separator space, leaving the exact reason
+        including any trailing spaces the user typed.
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_change_reason("trailing space ")  # set_change_reason stores as-is
+
+        result = forced_dirty.change_reason_for_file
+
+        assert result == f"{MANUAL_OVERRIDE_PREFIX} trailing space "
+
+    def test_regular_param_change_reason_for_file_returns_plain_reason(self, regular: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file on a regular (non-forced/non-derived) param returns plain change_reason.
+
+        GIVEN: A regular parameter with override inactive
+        WHEN: change_reason_for_file is read
+        THEN: The result equals change_reason (the plain comment, no prefix)
+        """
+        assert not regular.is_manual_override
+        assert regular.change_reason_for_file == regular.change_reason
+        assert not regular.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_derived_param_inactive_override_returns_plain_derived_reason(self, derived_clean: ArduPilotParameter) -> None:
+        """
+        change_reason_for_file on a derived param (override inactive) returns the derived reason.
+
+        GIVEN: A derived parameter with no active override
+        WHEN: change_reason_for_file is read
+        THEN: It returns the derived change reason with no prefix
+        """
+        assert not derived_clean.is_manual_override
+        assert not derived_clean.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_change_reason_display_never_contains_prefix_when_override_active(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        The change_reason property (used by the GUI) never exposes the @manual_override prefix.
+
+        GIVEN: A forced parameter with override active and a typed reason
+        WHEN: change_reason is read (the display/UI property)
+        THEN: It does NOT start with '@manual_override'
+        AND: change_reason_for_file (the persistence property) DOES start with '@manual_override'
+
+        This verifies the spec invariant: '@manual_override is an internal implementation
+        detail of the .param file format. It is never surfaced in the UI as visible text.'
+        change_reason_for_file is the only place that adds the prefix.
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_change_reason("User typed reason")
+
+        assert not forced_dirty.change_reason.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert forced_dirty.change_reason == "User typed reason"
+        assert forced_dirty.change_reason_for_file.startswith(MANUAL_OVERRIDE_PREFIX)
+
+    def test_change_reason_display_never_contains_prefix_when_loaded_from_file(
+        self, forced_with_file_override: ArduPilotParameter
+    ) -> None:
+        """
+        change_reason strips the prefix immediately on load; the GUI never sees it.
+
+        GIVEN: A forced parameter constructed from a Par whose comment starts with '@manual_override'
+        WHEN: change_reason is read
+        THEN: The prefix has been stripped and is not present in the returned string
+        """
+        assert not forced_with_file_override.change_reason.startswith(MANUAL_OVERRIDE_PREFIX)
+        assert forced_with_file_override.change_reason == "Saved user reason"
+
+
+# ===========================================================================
+# _manual_override_on_file baseline tracking
+# ===========================================================================
+
+
+class TestManualOverrideOnFileTracking:
+    """_manual_override_on_file is updated correctly by copy_new_value_to_file."""
+
+    def test_initial_baseline_matches_file_comment(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        _manual_override_on_file reflects the file comment at construction time.
+
+        GIVEN: A forced param whose file comment does NOT start with '@manual_override'
+        WHEN: The parameter is constructed
+        THEN: _manual_override_on_file is False
+        AND: is_dirty is determined only by value/reason differences
+        """
+        assert not forced_dirty._manual_override_on_file  # pylint: disable=protected-access
+
+    def test_initial_baseline_true_when_file_has_prefix(self, forced_with_file_override: ArduPilotParameter) -> None:
+        """
+        _manual_override_on_file is True when the file comment starts with '@manual_override'.
+
+        GIVEN: A forced param whose file comment starts with '@manual_override'
+        WHEN: The parameter is constructed
+        THEN: _manual_override_on_file is True
+        AND: is_manual_override is True
+        AND: is_dirty is False (value and reason unchanged from file)
+        """
+        assert forced_with_file_override._manual_override_on_file  # pylint: disable=protected-access
+        assert forced_with_file_override.is_manual_override
+        assert not forced_with_file_override.is_dirty
+
+    def test_copy_new_value_to_file_sets_baseline_to_true_after_enable(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        After saving with override active, _manual_override_on_file becomes True.
+
+        GIVEN: A forced parameter with override just activated (dirty)
+        WHEN: copy_new_value_to_file is called
+        THEN: _manual_override_on_file is True
+        AND: is_dirty is False
+        """
+        forced_dirty.set_manual_override(True)
+        assert forced_dirty.is_dirty
+
+        forced_dirty.copy_new_value_to_file()
+
+        assert forced_dirty._manual_override_on_file  # pylint: disable=protected-access
+        assert not forced_dirty.is_dirty
+
+    def test_copy_new_value_to_file_sets_baseline_to_false_after_disable(
+        self, forced_with_file_override: ArduPilotParameter
+    ) -> None:
+        """
+        After saving with override inactive, _manual_override_on_file becomes False.
+
+        GIVEN: A forced parameter loaded with @manual_override (override active)
+        WHEN: Override is disabled and copy_new_value_to_file is called
+        THEN: _manual_override_on_file is False
+        AND: is_dirty is False
+        """
+        forced_with_file_override.set_manual_override(False)
+        assert forced_with_file_override.is_dirty
+
+        forced_with_file_override.copy_new_value_to_file()
+
+        assert not forced_with_file_override._manual_override_on_file  # pylint: disable=protected-access
+        assert not forced_with_file_override.is_dirty
+
+
+# ===========================================================================
+# Disable-then-re-enable when _manual_override_on_file is True
+# ===========================================================================
+
+
+class TestReEnableWithFileOverrideActive:
+    """Spec requirement 2/3: re-enabling after disable restores file values when _manual_override_on_file=True."""
+
+    def test_reenable_after_disable_restores_file_value_not_forced_value(
+        self, forced_with_file_override: ArduPilotParameter
+    ) -> None:
+        """
+        Re-enabling override after a disable restores the persisted file value (7.0), not the forced value (55.0).
+
+        GIVEN: A forced parameter whose file had @manual_override with value 7.0
+        AND: The override was just disabled (forced value 55.0 is now active)
+        WHEN: The user re-enables the override
+        THEN: new_value is 7.0 (from file), NOT 55.0 (the forced value)
+
+        This satisfies the spec requirement: "If there is @manual_override on the file,
+        the parameter's new value is set to the value on the file."
+        """
+        assert forced_with_file_override.is_manual_override  # starts True
+        assert forced_with_file_override.get_new_value() == 7.0
+
+        # Disable — reverts to forced value (55.0)
+        forced_with_file_override.set_manual_override(False)
+        assert forced_with_file_override.get_new_value() == 55.0
+
+        # Re-enable — must restore the file value (7.0), not stay at 55.0
+        forced_with_file_override.set_manual_override(True)
+
+        assert forced_with_file_override.get_new_value() == 7.0
+        assert forced_with_file_override.is_manual_override
+
+    def test_reenable_after_disable_restores_file_reason_not_forced_reason(
+        self, forced_with_file_override: ArduPilotParameter
+    ) -> None:
+        """
+        Re-enabling override after a disable restores the file change reason (not the forced reason).
+
+        GIVEN: A forced parameter whose file had @manual_override with reason "Saved user reason"
+        AND: The override was disabled (forced reason "forced reason" is now active)
+        WHEN: The user re-enables the override
+        THEN: change_reason is "Saved user reason" (from file), NOT "forced reason"
+        """
+        assert forced_with_file_override.change_reason == "Saved user reason"
+
+        forced_with_file_override.set_manual_override(False)
+        assert forced_with_file_override.change_reason == "forced reason"
+
+        forced_with_file_override.set_manual_override(True)
+
+        assert forced_with_file_override.change_reason == "Saved user reason"
+
+    def test_first_enable_without_file_override_uses_forced_value(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        First-time enable (no @manual_override in file) uses forced value as starting point.
+
+        GIVEN: A forced parameter whose file has NO @manual_override (file value 10.0, forced value 55.0)
+        WHEN: The user enables the override for the first time
+        THEN: new_value is the forced value (55.0), NOT the file value (10.0)
+
+        This ensures the spec's two-path behaviour is exercised:
+        - No file override → forced/derived value is the starting point
+        - File override present → file value is the starting point
+        """
+        assert not forced_dirty.is_manual_override
+
+        forced_dirty.set_manual_override(True)
+
+        assert forced_dirty.get_new_value() == 55.0  # forced value, not file value 10.0
+
+
+# ===========================================================================
+# Post-save restore: re-enable after save restores SAVED values
+# ===========================================================================
+
+
+class TestPostSaveRestore:
+    """After copy_new_value_to_file, re-enable restores the saved (post-save) values."""
+
+    def test_reenable_after_save_restores_saved_value_not_original_file_value(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        After saving an overridden param, re-enable restores the saved value (not pre-override file value).
+
+        GIVEN: A forced param (file=10.0) with override enabled and new value set to 30.0
+        AND: The parameter has been saved (copy_new_value_to_file)
+        AND: The override is then disabled
+        WHEN: The user re-enables the override
+        THEN: new_value is 30.0 (the saved value), NOT 10.0 (the original file value)
+
+        After save, _value_on_file=30.0 and _manual_override_on_file=True,
+        so re-enabling should restore 30.0.
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_new_value("30.0")
+        assert forced_dirty.get_new_value() == 30.0
+
+        # Save — _value_on_file becomes 30.0, _manual_override_on_file becomes True
+        forced_dirty.copy_new_value_to_file()
+        assert not forced_dirty.is_dirty
+
+        # Disable — reverts to forced value (55.0)
+        forced_dirty.set_manual_override(False)
+        assert forced_dirty.get_new_value() == 55.0
+
+        # Re-enable — should restore SAVED value (30.0), not original file value (10.0)
+        forced_dirty.set_manual_override(True)
+
+        assert forced_dirty.get_new_value() == 30.0
+
+    def test_reenable_after_save_restores_saved_reason(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        After saving, re-enable restores the saved change reason.
+
+        GIVEN: A forced param with override active, reason set to "My saved reason", then saved
+        AND: Override is then disabled
+        WHEN: The user re-enables the override
+        THEN: change_reason is "My saved reason" (saved value), not the forced reason
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_change_reason("My saved reason")
+        forced_dirty.copy_new_value_to_file()
+
+        forced_dirty.set_manual_override(False)
+        assert forced_dirty.change_reason == "forced reason"
+
+        forced_dirty.set_manual_override(True)
+
+        assert forced_dirty.change_reason == "My saved reason"
+
+
+# ===========================================================================
+# set_manual_override raises for non-forced/non-derived params
+# ===========================================================================
+
+
+class TestSetManualOverrideRaisesForRegularParams:
+    """set_manual_override raises ValueError for any call on non-forced/non-derived params."""
+
+    def test_raises_when_called_with_true_on_regular_param(self, regular: ArduPilotParameter) -> None:
+        """
+        set_manual_override(True) raises ValueError for a regular parameter.
+
+        GIVEN: A regular (non-forced, non-derived) parameter
+        WHEN: set_manual_override(True) is called
+        THEN: ValueError is raised with 'forced or derived' in the message
+        """
+        with pytest.raises(ValueError, match="forced or derived"):
+            regular.set_manual_override(True)
+
+    def test_raises_when_called_with_false_on_regular_param(self, regular: ArduPilotParameter) -> None:
+        """
+        set_manual_override(False) also raises ValueError for a regular parameter.
+
+        GIVEN: A regular parameter
+        WHEN: set_manual_override(False) is called
+        THEN: ValueError is raised — there is nothing to deactivate
+        """
+        with pytest.raises(ValueError, match="forced or derived"):
+            regular.set_manual_override(False)
+
+    def test_raises_for_regular_param_with_prefix_in_comment(self, meta: dict[str, Any]) -> None:
+        """
+        set_manual_override raises even if the regular param's comment starts with '@manual_override'.
+
+        GIVEN: A regular parameter whose file comment happens to start with '@manual_override'
+        WHEN: set_manual_override is called (any value)
+        THEN: ValueError is raised because the param has no forced/derived definition
+        """
+        param = ArduPilotParameter(
+            name="WEIRD",
+            par_obj=Par(1.0, "@manual_override suspicious comment"),
+            metadata=meta,
+        )
+
+        # set_manual_override always raises for non-forced/non-derived, regardless of direction
+        with pytest.raises(ValueError, match="forced or derived"):
+            param.set_manual_override(True)
+        with pytest.raises(ValueError, match="forced or derived"):
+            param.set_manual_override(False)
+
+
+# ===========================================================================
+# is_editable: read-only precedence over manual override
+# ===========================================================================
+
+
+class TestIsEditableWithReadOnly:
+    """Read-only parameters are never editable regardless of override state."""
+
+    def test_readonly_forced_param_with_file_override_is_not_editable(self, ro_meta: dict[str, Any]) -> None:
+        """
+        A read-only forced parameter is not editable even when the file has @manual_override.
+
+        GIVEN: A read-only forced parameter whose file comment starts with '@manual_override'
+        WHEN: is_editable is checked
+        THEN: is_editable is False (is_readonly takes precedence)
+        AND: is_manual_override is True (prefix was detected)
+        """
+        param = ArduPilotParameter(
+            name="RO_FORCED",
+            par_obj=Par(7.0, "@manual_override Saved reason"),
+            metadata=ro_meta,
+            forced_par=Par(55.0, "forced reason"),
+        )
+
+        assert param.is_manual_override
+        assert param.is_readonly
+        assert not param.is_editable
+
+    def test_readonly_derived_param_is_not_editable(self, ro_meta: dict[str, Any]) -> None:
+        """
+        A read-only derived parameter is not editable regardless of override.
+
+        GIVEN: A read-only derived parameter
+        WHEN: is_editable is checked
+        THEN: is_editable is False
+        """
+        param = ArduPilotParameter(
+            name="RO_DERIVED",
+            par_obj=Par(3.0, "reason"),
+            metadata=ro_meta,
+            derived_par=Par(10.0, "derived"),
+        )
+
+        assert param.is_readonly
+        assert not param.is_editable
+
+
+# ===========================================================================
+# is_dirty: all three dirty-detection paths
+# ===========================================================================
+
+
+class TestIsDirtyAllThreePaths:
+    """is_dirty is True when value, reason, OR override flag differs from the on-file baseline."""
+
+    def test_dirty_when_only_override_flag_changed(self, forced_clean: ArduPilotParameter) -> None:
+        """
+        is_dirty is True when only the override flag changed (value and reason are identical).
+
+        GIVEN: A forced param where file value and reason already equal the forced definition
+        AND: The param is therefore NOT dirty before activation
+        WHEN: set_manual_override(True) is called
+        THEN: is_dirty is True (third dirty-detection path: _is_manual_override != _manual_override_on_file)
+        """
+        assert not forced_clean.is_dirty  # starts clean
+
+        forced_clean.set_manual_override(True)
+
+        assert forced_clean.is_dirty
+
+    def test_dirty_when_only_reason_changed(self, forced_with_file_override: ArduPilotParameter) -> None:
+        """
+        is_dirty is True when only the change reason was edited after override was already active.
+
+        GIVEN: A forced param loaded from file with @manual_override (override on, not dirty)
+        WHEN: The change reason is updated
+        THEN: is_dirty is True (second dirty-detection path)
+        """
+        assert not forced_with_file_override.is_dirty
+
+        forced_with_file_override.set_change_reason("Completely new reason")
+
+        assert forced_with_file_override.is_dirty
+
+    def test_dirty_when_only_value_changed(self, forced_with_file_override: ArduPilotParameter) -> None:
+        """
+        is_dirty is True when only the value was edited after override was already active.
+
+        GIVEN: A forced param loaded from file with @manual_override (override on, not dirty)
+        WHEN: The value is changed
+        THEN: is_dirty is True (first dirty-detection path)
+        """
+        assert not forced_with_file_override.is_dirty
+
+        forced_with_file_override.set_new_value("99.0")
+
+        assert forced_with_file_override.is_dirty
+
+    def test_not_dirty_after_all_three_baselines_are_reset(self, forced_dirty: ArduPilotParameter) -> None:
+        """
+        is_dirty is False after copy_new_value_to_file resets all three baselines.
+
+        GIVEN: A forced param with override enabled, value changed, and reason changed (all three dirty paths)
+        WHEN: copy_new_value_to_file is called
+        THEN: is_dirty is False
+        """
+        forced_dirty.set_manual_override(True)
+        forced_dirty.set_new_value("30.0")
+        forced_dirty.set_change_reason("Dirty reason")
+        assert forced_dirty.is_dirty
+
+        forced_dirty.copy_new_value_to_file()
+
+        assert not forced_dirty.is_dirty
+
+
+# ===========================================================================
+# Prefix stripping on load
+# ===========================================================================
+
+
+class TestPrefixStrippingOnLoad:
+    """@manual_override prefix is correctly stripped when loading from file."""
+
+    @pytest.mark.parametrize(
+        ("raw_comment", "expected_reason"),
+        [
+            ("@manual_override", ""),
+            ("@manual_override ", ""),
+            ("@manual_override  ", ""),  # multiple separator spaces are all stripped
+            ("@manual_override Bench test", "Bench test"),
+            ("@manual_override  Leading space in reason", "Leading space in reason"),  # all leading spaces stripped
+        ],
+        ids=["bare_prefix", "prefix_one_space", "prefix_two_spaces", "normal_reason", "extra_space_reason"],
+    )
+    def test_prefix_stripped_to_correct_reason(self, meta: dict[str, Any], raw_comment: str, expected_reason: str) -> None:
+        """
+        The displayed change_reason after load is the text after '@manual_override' with ALL leading spaces stripped.
+
+        GIVEN: A Par whose comment starts with '@manual_override' followed by varying whitespace/text
+        WHEN: ArduPilotParameter is constructed
+        THEN: change_reason equals the text after the prefix with all leading spaces lstripped
+              (lstrip removes the separator space AND any additional leading spaces in the reason)
+        """
+        param = ArduPilotParameter(
+            name="P",
+            par_obj=Par(1.0, raw_comment),
+            metadata=meta,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert param.is_manual_override
+        assert param.change_reason == expected_reason
+
+    @pytest.mark.parametrize(
+        "raw_comment",
+        [
+            "normal reason",
+            "",
+            "See @manual_override docs",
+            "@MANUAL_OVERRIDE uppercase",
+            " @manual_override leading space",
+            "manual_override missing at-sign",
+        ],
+        ids=["normal", "empty", "mid_string", "uppercase", "leading_space", "no_at_sign"],
+    )
+    def test_non_prefix_comments_not_detected_as_override(self, meta: dict[str, Any], raw_comment: str) -> None:
+        """
+        Comments that do not start with exactly '@manual_override' are not detected as override.
+
+        GIVEN: A Par whose comment does NOT start with '@manual_override' (case-sensitive, no leading space)
+        WHEN: ArduPilotParameter is constructed
+        THEN: is_manual_override is False
+        """
+        param = ArduPilotParameter(
+            name="P",
+            par_obj=Par(1.0, raw_comment),
+            metadata=meta,
+            forced_par=Par(99.0, "forced"),
+        )
+
+        assert not param.is_manual_override


### PR DESCRIPTION
Certain parameters in a configuration step are forced (their value is dictated by the configuration step definition) or derived (their value is computed from information entered in the component editor window). By design, these parameters are read-only in the GUI: the user cannot change their value or change reason, because overriding them would defeat the purpose of the configuration step.

The manual override feature lets a user consciously opt a specific forced or derived parameter out of automatic value management for the duration of a configuration project. When manual override is active for a parameter, the user can freely edit both the value and the change reason, exactly as if the parameter were a normal non-forced/non-derived one. The override state is persisted to the .param file so it survives application restarts and file reloads.

fixes #1757

# Description

Describe what this PR is trying to achieve. Please read our [Contributing Guide](../CONTRIBUTING.md) for detailed guidelines.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Tested on flight controller hardware
