### PR TITLE
fix: support tab- and space-separated param files in migration name parsing

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_migration.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_migration.py
@@ -332,11 +332,17 @@ def _param_name_from_line(line: str) -> str:
     Return the parameter name from a .param file line, or an empty string.
 
     Blank lines and comment-only lines (starting with ``#``) return ``""``.
+    Supports comma-, tab-, and space-separated parameter files, matching the
+    formats accepted by ParDict.load_param_file_into_dict.
     """
     stripped = line.strip()
     if not stripped or stripped.startswith("#"):
         return ""
-    return stripped.split(",", 1)[0].strip()
+    if "," in stripped:
+        return stripped.split(",", 1)[0].strip()
+    if "\t" in stripped:
+        return stripped.split("\t", 1)[0].strip()
+    return stripped.split(" ", 1)[0].strip()
 
 
 def _line_matches_any(param_name: str, patterns: list[str]) -> bool:

--- a/tests/test_backend_filesystem_migration.py
+++ b/tests/test_backend_filesystem_migration.py
@@ -19,6 +19,7 @@ import pytest
 from ardupilot_methodic_configurator.backend_filesystem_migration import (
     VEHICLE_COMPONENTS_FORMAT_VERSION,
     _line_matches_any,
+    _param_name_from_line,
     migrate_vehicle_project_if_needed,
 )
 
@@ -798,6 +799,43 @@ class TestPatternMatchingEdgeCases:
         THEN: False is returned without raising an exception
         """
         assert _line_matches_any("ARMING_CHECK", ["[invalid"]) is False
+
+    def test_param_name_from_line_handles_comma_separated(self) -> None:
+        """
+        Comma-separated lines (Mission Planner format) extract the parameter name.
+
+        GIVEN: A line in the format 'NAME,value'
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned, value is discarded
+        """
+        assert _param_name_from_line("BATT_MONITOR,4\n") == "BATT_MONITOR"
+
+    def test_param_name_from_line_handles_tab_separated(self) -> None:
+        r"""
+        Bug fix: tab-separated lines (mavproxy format) must extract only the name.
+
+        GIVEN: A line in the format 'NAME\tvalue', a valid ArduPilot param
+            file format also accepted by ParDict.load_param_file_into_dict
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned, not the full line
+
+        Previously this returned the entire line (name and value together),
+        which broke duplicate-parameter detection during migration: a
+        tab-separated file with the same parameter at a different value in
+        the source and destination would not be recognized as a duplicate,
+        producing an invalid .param file with the parameter listed twice.
+        """
+        assert _param_name_from_line("BATT_MONITOR\t4\n") == "BATT_MONITOR"
+
+    def test_param_name_from_line_handles_space_separated(self) -> None:
+        """
+        Bug fix: space-separated lines (mavproxy format) must extract only the name.
+
+        GIVEN: A line in the format 'NAME value'
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned, not the full line
+        """
+        assert _param_name_from_line("BATT_MONITOR 4\n") == "BATT_MONITOR"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
While reviewing the v0→v1 vehicle project migration code, I found that _param_name_from_line only correctly extracts the parameter name from comma-separated (Mission Planner style) .param file lines:

def _param_name_from_line(line: str) -> str:
    stripped = line.strip()
    if not stripped or stripped.startswith("#"):
        return ""
    return stripped.split(",", 1)[0].strip()

ParDict.load_param_file_into_dict supports three separator formats: comma, space, and tab (mavproxy style). For tab- or space-separated lines, _param_name_from_line returns the entire line (name and value together) instead of just the parameter name.

This breaks duplicate-parameter detection when merging extracted lines into an existing destination file during migration:

  existing = ["BATT_MONITOR\tab4\n"]
  lines_to_add = ["BATT_MONITOR\tab5\n"]   # same param, different value

  existing_names = {_param_name_from_line(l) for l in existing}
  # -> {"BATT_MONITOR\tab4"}  (wrong, should be {"BATT_MONITOR"})

  new_lines = [l for l in lines_to_add if _param_name_from_line(l) not in existing_names]
  # -> ["BATT_MONITOR\tab5\n"]  gets appended anyway!

The destination file ends up with BATT_MONITOR listed twice at different values, an invalid .param file. Loading it later via
ParDict.load_param_file_into_dict raises ParamFileError("Duplicated parameter"), surfacing as a crash the next time the user opens that vehicle project.

Fixed by detecting the separator (comma, then tab, then space, matching the same priority order used by ParDict.load_param_file_into_dict) before splitting off the parameter name.

## Checklist
- [x] Verified by a human programmer
- [x] Code follows our coding standards
- [x] No breaking changes or properly documented

## Testing
- [x] Unit tests pass

Added three regression tests to tests/test_backend_filesystem_migration.py:
- test_param_name_from_line_handles_comma_separated
- test_param_name_from_line_handles_tab_separated
- test_param_name_from_line_handles_space_separated

All 43 tests in the file pass locally (Python 3.12.10, pytest-9.0.3).