### PR TITLE
Support tab- and space-separated param files in migration name parsing

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_migration.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_migration.py
@@ -332,11 +332,27 @@ def _param_name_from_line(line: str) -> str:
     Return the parameter name from a .param file line, or an empty string.
 
     Blank lines and comment-only lines (starting with ``#``) return ``""``.
+    Supports comma-, space-, and tab-separated parameter files using the same
+    priority order as ParDict.load_param_file_into_dict: comma first, then
+    space, then tab.
     """
     stripped = line.strip()
     if not stripped or stripped.startswith("#"):
         return ""
-    return stripped.split(",", 1)[0].strip()
+    # Strip inline comments before separator detection, matching the behaviour
+    # of ParDict.load_param_file_into_dict, so that a line like
+    # "NAME\t4 # comment" doesn't falsely split on the space before '#'.
+    if "#" in stripped:
+        stripped = stripped.split("#", 1)[0].strip()
+    if not stripped:
+        return ""
+    if "," in stripped:
+        return stripped.split(",", 1)[0].strip()
+    if " " in stripped:
+        return stripped.split(" ", 1)[0].strip()
+    if "\t" in stripped:
+        return stripped.split("\t", 1)[0].strip()
+    return stripped
 
 
 def _line_matches_any(param_name: str, patterns: list[str]) -> bool:

--- a/tests/test_backend_filesystem_migration.py
+++ b/tests/test_backend_filesystem_migration.py
@@ -19,6 +19,7 @@ import pytest
 from ardupilot_methodic_configurator.backend_filesystem_migration import (
     VEHICLE_COMPONENTS_FORMAT_VERSION,
     _line_matches_any,
+    _param_name_from_line,
     migrate_vehicle_project_if_needed,
 )
 
@@ -798,6 +799,107 @@ class TestPatternMatchingEdgeCases:
         THEN: False is returned without raising an exception
         """
         assert _line_matches_any("ARMING_CHECK", ["[invalid"]) is False
+
+
+# ---------------------------------------------------------------------------
+# _param_name_from_line
+# ---------------------------------------------------------------------------
+
+
+class TestParamNameFromLine:
+    """Unit tests for the _param_name_from_line helper."""
+
+    def test_comma_separated_returns_name_only(self) -> None:
+        """
+        Comma-separated lines (Mission Planner format) return only the parameter name.
+
+        GIVEN: A line in the format 'NAME,value'
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned
+        """
+        assert _param_name_from_line("BATT_MONITOR,4\n") == "BATT_MONITOR"
+
+    def test_space_separated_returns_name_only(self) -> None:
+        """
+        Bug fix: space-separated lines must extract only the parameter name.
+
+        GIVEN: A line in the format 'NAME value' (mavproxy format)
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned, not the full 'NAME value' string
+        """
+        assert _param_name_from_line("BATT_MONITOR 4\n") == "BATT_MONITOR"
+
+    def test_tab_separated_returns_name_only(self) -> None:
+        r"""
+        Bug fix: tab-separated lines must extract only the parameter name.
+
+        GIVEN: A line in the format 'NAME\tvalue' (mavproxy format)
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned, not the full 'NAME\tvalue' string
+
+        Previously returned the entire line, breaking duplicate-parameter
+        detection during migration and producing invalid .param files.
+        """
+        assert _param_name_from_line("BATT_MONITOR\t4\n") == "BATT_MONITOR"
+
+    def test_comma_takes_priority_over_space(self) -> None:
+        """
+        When both comma and space are present, comma separator is used first.
+
+        GIVEN: A line 'NAME,value with spaces'
+        WHEN: _param_name_from_line is called
+        THEN: The name before the comma is returned, matching load_param_file_into_dict priority
+        """
+        assert _param_name_from_line("PARAM_NAME,val ue\n") == "PARAM_NAME"  # codespell:ignore
+
+    def test_blank_line_returns_empty_string(self) -> None:
+        """
+        Blank-only lines return an empty string.
+
+        GIVEN: A blank line
+        WHEN: _param_name_from_line is called
+        THEN: An empty string is returned.
+        """
+        assert _param_name_from_line("   \n") == ""
+
+    def test_comment_line_returns_empty_string(self) -> None:
+        """
+        Comment lines starting with '#' return an empty string.
+
+        GIVEN: A comment line starting with '#'
+        WHEN: _param_name_from_line is called
+        THEN: An empty string is returned.
+        """
+        assert _param_name_from_line("# this is a comment\n") == ""
+
+    def test_duplicate_detection_with_tab_separated_file(self) -> None:
+        r"""
+        End-to-end regression: tab-separated duplicate params are detected.
+
+        GIVEN: An existing .param file with 'BATT_MONITOR\t4' (tab-separated)
+          AND: A list of lines to merge containing 'BATT_MONITOR\t5'
+        WHEN: Duplicate detection uses _param_name_from_line on both sides
+        THEN: The duplicate is detected and the second line is NOT appended,
+              leaving a file with exactly one BATT_MONITOR entry
+        """
+        existing = ["BATT_MONITOR\t4\n"]
+        lines_to_add = ["BATT_MONITOR\t5\n"]
+
+        existing_names = {name for line in existing if (name := _param_name_from_line(line))}
+        new_lines = [line for line in lines_to_add if _param_name_from_line(line) not in existing_names]
+
+        assert new_lines == [], "duplicate should be suppressed, not appended"
+
+    def test_tab_separated_line_with_inline_comment_returns_name_only(self) -> None:
+        r"""
+        Tab-separated line with an inline comment returns only the parameter name.
+
+        GIVEN: A line in the format 'NAME\tvalue # inline comment'
+        WHEN: _param_name_from_line is called
+        THEN: Only the parameter name is returned; the inline comment must not
+              cause the space before '#' to be treated as the separator.
+        """
+        assert _param_name_from_line("BATT_MONITOR\t4 # inline comment\n") == "BATT_MONITOR"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Original from #1759 but I'm not allowed to push into the forked repository

_param_name_from_line only correctly extracted the parameter name from comma-separated (Mission Planner style) .param file lines.

ParDict.load_param_file_into_dict supports three separator formats: comma, space, and tab (mavproxy style). For tab- or space-separated lines, _param_name_from_line returned the entire line, value included, instead of just the parameter name.

This broke duplicate-parameter detection during vehicle project migration: when merging extracted parameter lines into an existing destination file, the same parameter at a different value in the source and destination would not be recognized as a duplicate, producing an invalid .param file with the parameter listed twice. Loading such a file later raises ParamFileError(Duplicated parameter).

Fixed by detecting the separator (comma, space then tab, matching the priority order used by ParDict.load_param_file_into_dict) before splitting off the parameter name.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
