### PR TITLE
fix: avoid mutating configuration_phases in get_sorted_phases_with_end_and_weight

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
@@ -672,7 +672,7 @@ class ConfigurationSteps:
             text = documentation.get(tooltip_key, text.format(**locals()))
         return text
 
-    def get_sorted_phases_with_end_and_weight(self, total_files: int) -> dict[str, PhaseData]:
+    def get_sorted_phases_with_end_and_weight(self, last_file_nr: int) -> dict[str, PhaseData]:
         """
         Get sorted phases with added 'end' and 'weight' information.
 
@@ -692,11 +692,11 @@ class ConfigurationSteps:
         for i, phase_name in enumerate(phase_names):
             if i < len(phase_names) - 1:
                 next_phase_name = phase_names[i + 1]
-                sorted_phases[phase_name]["end"] = sorted_phases[next_phase_name].get("start", total_files)
+                sorted_phases[phase_name]["end"] = sorted_phases[next_phase_name].get("start", last_file_nr)
             else:
-                sorted_phases[phase_name]["end"] = total_files
+                sorted_phases[phase_name]["end"] = last_file_nr + 1
             phase_start = sorted_phases[phase_name].get("start", 0)
-            phase_end = sorted_phases[phase_name].get("end", total_files)
+            phase_end = sorted_phases[phase_name].get("end", last_file_nr + 1)
             sorted_phases[phase_name]["weight"] = max(2, phase_end - phase_start)
 
         return sorted_phases

--- a/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
@@ -680,26 +680,23 @@ class ConfigurationSteps:
         - 'end': The end file number (start of next phase or total_files)
         - 'weight': Weight for UI layout (max(2, end - start))
         """
-        active_phases = {k: v for k, v in self.configuration_phases.items() if "start" in v}
-
-        # Sort phases by start position, copying each dict to avoid mutating configuration_phases
-        sorted_phases: dict[str, PhaseData] = dict(
-            sorted(((k, dict(v)) for k, v in active_phases.items()), key=lambda x: x[1].get("start", 0))
+        active_phases = sorted(
+            ((k, v) for k, v in self.configuration_phases.items() if "start" in v),
+            key=lambda x: x[1].get("start", 0),
         )
 
-        # Add the end information to each phase using the start of the next phase
-        phase_names = list(sorted_phases.keys())
-        for i, phase_name in enumerate(phase_names):
-            if i < len(phase_names) - 1:
-                next_phase_name = phase_names[i + 1]
-                sorted_phases[phase_name]["end"] = sorted_phases[next_phase_name].get("start", last_file_nr)
-            else:
-                sorted_phases[phase_name]["end"] = last_file_nr + 1
-            phase_start = sorted_phases[phase_name].get("start", 0)
-            phase_end = sorted_phases[phase_name].get("end", last_file_nr + 1)
-            sorted_phases[phase_name]["weight"] = max(2, phase_end - phase_start)
+        # Compute 'end' for each phase: start of the next phase, or last_file_nr for the last phase
+        ends = [v.get("start", last_file_nr) for _, v in active_phases[1:]] + [last_file_nr]
 
-        return sorted_phases
+        # Build the enriched result as new PhaseData dicts, leaving configuration_phases untouched
+        return {
+            name: PhaseData(
+                **{k: v for k, v in src.items() if k not in ("end", "weight")},  # type: ignore[typeddict-item]
+                end=end,
+                weight=max(2, end - src.get("start", 0)),
+            )
+            for (name, src), end in zip(active_phases, ends, strict=True)
+        }
 
     def get_component(self, selected_file: str) -> str | None:
         """

--- a/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_configuration_steps.py
@@ -682,8 +682,10 @@ class ConfigurationSteps:
         """
         active_phases = {k: v for k, v in self.configuration_phases.items() if "start" in v}
 
-        # Sort phases by start position
-        sorted_phases: dict[str, PhaseData] = dict(sorted(active_phases.items(), key=lambda x: x[1].get("start", 0)))
+        # Sort phases by start position, copying each dict to avoid mutating configuration_phases
+        sorted_phases: dict[str, PhaseData] = dict(
+            sorted(((k, dict(v)) for k, v in active_phases.items()), key=lambda x: x[1].get("start", 0))
+        )
 
         # Add the end information to each phase using the start of the next phase
         phase_names = list(sorted_phases.keys())

--- a/ardupilot_methodic_configurator/frontend_tkinter_stage_progress.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_stage_progress.py
@@ -232,17 +232,28 @@ def main() -> None:  # pragma: no cover
     config_steps = ConfigurationSteps("", "ArduCopter")
     config_steps.re_init("", "ArduCopter")
 
-    processed_phases = config_steps.get_sorted_phases_with_end_and_weight(54)
-    progress = StageProgressBar(root, processed_phases, 54, "normal")
-    progress.pack(padx=10, pady=10, fill="both", expand=True)
+    try:
+        first_step_filename = next(iter(config_steps.configuration_steps))
+        last_step_filename = next(reversed(config_steps.configuration_steps))
+        first_step_number = int(first_step_filename.split("_", 1)[0])
+        last_step_number = int(last_step_filename.split("_", 1)[0])
+        processed_phases = config_steps.get_sorted_phases_with_end_and_weight(last_step_number)
+        progress = StageProgressBar(root, processed_phases, last_step_number, "normal")
+        progress.pack(padx=10, pady=10, fill="both", expand=True)
+    except StopIteration:
+        logging_error(_("No configuration steps found."))
+        return
+    except ValueError as e:
+        logging_error(_("Error parsing either first or last step numbers: {error}").format(error=str(e)))
+        return
 
     # Demo update function
-    current_file = 2
+    current_file = first_step_number
 
     def update_demo() -> None:
         nonlocal current_file
         progress.update_progress(current_file)
-        current_file = 2 if current_file > 54 else current_file + 1
+        current_file = first_step_number if current_file >= last_step_number else current_file + 1
         root.after(1000, update_demo)
 
     # Start demo updates

--- a/tests/test_backend_filesystem_configuration_steps.py
+++ b/tests/test_backend_filesystem_configuration_steps.py
@@ -1914,6 +1914,51 @@ class TestConfigurationNavigation:
         assert result["phase1"]["weight"] == 2  # max(2, 2-1) = 2
         assert result["phase2"]["weight"] == 2  # max(2, 3-2) = 2
 
+    def test_get_sorted_phases_does_not_mutate_configuration_phases(self, config_steps: ConfigurationSteps) -> None:
+        """
+        Bug fix: get_sorted_phases_with_end_and_weight must not modify configuration_phases.
+
+        GIVEN: Three phases with only 'start' and 'description' keys
+        WHEN: get_sorted_phases_with_end_and_weight is called
+        THEN: configuration_phases still has only 'start' and 'description' keys (no 'end' or 'weight')
+
+        Previously the function mutated the inner dicts of configuration_phases by adding
+        'end' and 'weight' keys, because sorted_phases held references to the same dict
+        objects rather than copies. A second call with a different total_files would then
+        return stale 'end' values from the first call.
+        """
+        config_steps.configuration_phases = {
+            "phase1": {"start": 1, "description": "Phase 1"},  # type: ignore[typeddict-item]
+            "phase2": {"start": 5, "description": "Phase 2"},  # type: ignore[typeddict-item]
+            "phase3": {"start": 10, "description": "Phase 3"},  # type: ignore[typeddict-item]
+        }
+
+        config_steps.get_sorted_phases_with_end_and_weight(15)
+
+        # configuration_phases must not have been mutated
+        for phase_data in config_steps.configuration_phases.values():
+            assert "end" not in phase_data
+            assert "weight" not in phase_data
+
+    def test_get_sorted_phases_second_call_uses_new_total_files(self, config_steps: ConfigurationSteps) -> None:
+        """
+        Bug fix: a second call with different total_files returns correct results.
+
+        GIVEN: Phases set up and a first call made with total_files=15
+        WHEN: get_sorted_phases_with_end_and_weight is called again with total_files=30
+        THEN: The last phase end equals 30, not the stale value 15 from the first call
+        """
+        config_steps.configuration_phases = {
+            "phase1": {"start": 1, "description": "Phase 1"},  # type: ignore[typeddict-item]
+            "phase2": {"start": 10, "description": "Phase 2"},  # type: ignore[typeddict-item]
+        }
+
+        config_steps.get_sorted_phases_with_end_and_weight(15)
+        result = config_steps.get_sorted_phases_with_end_and_weight(30)
+
+        assert result["phase2"]["end"] == 30
+        assert result["phase1"]["end"] == 10
+
 
 # ---------------------------------------------------------------------------
 # compute_add_parameters - parameters_to_delete priority


### PR DESCRIPTION
`get_sorted_phases_with_end_and_weight` built `sorted_phases` as a dict of references to the same inner dict objects as `configuration_phases`. It then added `"end"` and `"weight"` keys to those inner dicts, permanently mutating the original
`configuration_phases` attribute on every call.

A second call with a different `total_files` argument would then return stale `"end"` values set during the first call, because the
inner dicts already contained `"end"` keys that were reused instead of recomputed.

This bug is reachable in a normal user session: the function is called from two separate places with different `total_files` values:
- `frontend_tkinter_stage_progress.py` calls it with hardcoded `54`
- `frontend_tkinter_parameter_editor.py` calls it with dynamic `last_step_nr`

Fixed by shallow-copying each inner dict before inserting it into `sorted_phases`, so mutations stay local to the returned dict and
`configuration_phases` is left unchanged between calls.

## Checklist
- [x] Verified by a human programmer
- [x] Code follows our coding standards
- [x] No breaking changes or properly documented

## Testing
- [x] Unit tests pass

Added two regression tests to tests/test_backend_filesystem_configuration_steps.py:
- test_get_sorted_phases_does_not_mutate_configuration_phases
- test_get_sorted_phases_second_call_uses_new_total_files

All 6 sorted_phases tests pass locally (Python 3.12.10, pytest-9.0.3).