### PR TITLE
Auto-select empty template from connected FC firmware version

### DIFF
--- a/ardupilot_methodic_configurator/data_model_vehicle_project.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project.py
@@ -77,7 +77,7 @@ class VehicleProjectManager:  # pylint: disable=too-many-public-methods
                             return str(candidate)
                     except ValueError:
                         pass
-        template_dir, _nbd, _vd = LocalFilesystem.get_recently_used_dirs()
+        template_dir, _nbd, _vd = self.get_recently_used_dirs()
         return template_dir
 
     def get_recently_used_dirs(self) -> tuple[str, str, str]:

--- a/ardupilot_methodic_configurator/data_model_vehicle_project.py
+++ b/ardupilot_methodic_configurator/data_model_vehicle_project.py
@@ -12,6 +12,7 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from ardupilot_methodic_configurator import _
@@ -50,6 +51,35 @@ class VehicleProjectManager:  # pylint: disable=too-many-public-methods
         self.configuration_template: str = ""  # It will be set if a new project is created successfully
 
     # Directory and path operations
+    def get_fc_default_template_dir(self) -> str:
+        """
+        Get the default template directory derived from the connected FC's vehicle type and firmware version.
+
+        If a flight controller is connected and its vehicle type and firmware version are known,
+        this returns the path to the matching empty template (e.g. ArduCopter/empty_4.6.x).
+        Falls back to the recently used template directory if the FC-derived path does not exist.
+
+        Returns:
+            Path to the best matching template directory
+
+        """
+        if self._flight_controller is not None and self.is_flight_controller_connected():
+            vehicle_type = self._flight_controller.info.vehicle_type
+            fw_version = self._flight_controller.info.flight_sw_version  # e.g. "4.6.0"
+            if vehicle_type and fw_version:
+                parts = fw_version.split(".")
+                if len(parts) >= 2:
+                    try:
+                        major, minor = int(parts[0]), int(parts[1])
+                        template_name = f"empty_{major}.{minor}.x"
+                        candidate = Path(LocalFilesystem.get_templates_base_dir()) / vehicle_type / template_name
+                        if candidate.is_dir():
+                            return str(candidate)
+                    except ValueError:
+                        pass
+        template_dir, _nbd, _vd = LocalFilesystem.get_recently_used_dirs()
+        return template_dir
+
     def get_recently_used_dirs(self) -> tuple[str, str, str]:
         """
         Get the recently used template, base, and vehicle directories.

--- a/ardupilot_methodic_configurator/frontend_tkinter_project_creator.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_project_creator.py
@@ -62,8 +62,8 @@ class VehicleProjectCreatorWindow(BaseWindow):
         self.new_project_settings_vars: dict[str, tk.BooleanVar] = {}
         self.new_project_settings_widgets: dict[str, ttk.Checkbutton] = {}
 
-        _template_dir, new_base_dir, vehicle_dir = self.project_manager.get_recently_used_dirs()
-        template_dir = project_manager.get_fc_default_template_dir() if fc_connected else _template_dir
+        recent_template_dir, new_base_dir, vehicle_dir = self.project_manager.get_recently_used_dirs()
+        template_dir = self.project_manager.get_fc_default_template_dir() if fc_connected else recent_template_dir
         logging_debug("template_dir: %s", template_dir)  # this string is intentionally left untranslated
         logging_debug("new_base_dir: %s", new_base_dir)  # this string is intentionally left untranslated
         logging_debug("vehicle_dir: %s", vehicle_dir)  # this string is intentionally left untranslated
@@ -107,8 +107,15 @@ class VehicleProjectCreatorWindow(BaseWindow):
         def template_selection_callback(_widget: "DirectorySelectionWidgets") -> str:
             # Template selection logic
             if isinstance(self.root, tk.Tk):  # this keeps mypy and pyright happy
-                to = TemplateOverviewWindow(self.root, connected_fc_vehicle_type=connected_fc_vehicle_type)
+                to = TemplateOverviewWindow(
+                    self.root,
+                    connected_fc_vehicle_type=connected_fc_vehicle_type,
+                    current_template_dir=_widget.get_selected_directory(),
+                )
                 to.run_app()
+                if not to.user_made_selection:
+                    # User closed the window without confirming - keep the current widget value
+                    return _widget.get_selected_directory()
             # Get recently used template directory from project manager
             template_dir, _nbd, _vd = self.project_manager.get_recently_used_dirs()
             logging_info(_("Selected template directory: %s"), template_dir)

--- a/ardupilot_methodic_configurator/frontend_tkinter_project_creator.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_project_creator.py
@@ -62,7 +62,8 @@ class VehicleProjectCreatorWindow(BaseWindow):
         self.new_project_settings_vars: dict[str, tk.BooleanVar] = {}
         self.new_project_settings_widgets: dict[str, ttk.Checkbutton] = {}
 
-        template_dir, new_base_dir, vehicle_dir = self.project_manager.get_recently_used_dirs()
+        _template_dir, new_base_dir, vehicle_dir = self.project_manager.get_recently_used_dirs()
+        template_dir = project_manager.get_fc_default_template_dir() if fc_connected else _template_dir
         logging_debug("template_dir: %s", template_dir)  # this string is intentionally left untranslated
         logging_debug("new_base_dir: %s", new_base_dir)  # this string is intentionally left untranslated
         logging_debug("vehicle_dir: %s", vehicle_dir)  # this string is intentionally left untranslated

--- a/ardupilot_methodic_configurator/frontend_tkinter_template_overview.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_template_overview.py
@@ -16,7 +16,7 @@ from logging import basicConfig as logging_basicConfig
 from logging import getLevelName as logging_getLevelName
 from logging import info as logging_info
 from tkinter import font as tkfont
-from tkinter import ttk
+from tkinter import messagebox, ttk
 from typing import Protocol
 
 from ardupilot_methodic_configurator import _, __version__
@@ -73,12 +73,13 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
 
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         parent: tk.Tk | None = None,
         vehicle_components_provider: VehicleComponentsProviderProtocol | None = None,
         program_settings_provider: ProgramSettingsProviderProtocol | None = None,
         connected_fc_vehicle_type: str | None = None,
+        current_template_dir: str | None = None,
     ) -> None:
         """
         Initialize the TemplateOverviewWindow.
@@ -88,6 +89,7 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
             vehicle_components_provider: Optional provider for vehicle components (for dependency injection)
             program_settings_provider: Optional provider for program settings (for dependency injection)
             connected_fc_vehicle_type: Optional firmware type of connected flight controller for filtering templates
+            current_template_dir: Optional currently selected template directory to preselect in the list
 
         """
         super().__init__(parent)
@@ -99,6 +101,12 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
         self.image_label: ttk.Label
         # Initialize sorting state
         self.sort_column: str = ""
+        # True only when the user confirmed a selection via double-click
+        self.user_made_selection: bool = False
+        # Template that was selected when the window opened (used to revert on cancel)
+        self._original_template_relative_path: str = ""
+        # Last template path highlighted via single-click (empty if none)
+        self._single_click_path: str = ""
 
         # Initialize UI configuration
         self._configure_window()
@@ -106,6 +114,8 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
         self._setup_layout()
         self._configure_treeview(connected_fc_vehicle_type or "")
         self._bind_events()
+        if current_template_dir:
+            self._preselect_current_template(current_template_dir)
 
     def _configure_window(self) -> None:
         """Configure the main window properties."""
@@ -246,6 +256,23 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
                 continue
             self.tree.insert("", "end", text=key, values=values)
 
+    def _preselect_current_template(self, current_template_dir: str) -> None:
+        """
+        Select and scroll to the row that matches the currently active template directory.
+
+        Args:
+            current_template_dir: Absolute or relative path of the currently selected template
+
+        """
+        norm = current_template_dir.replace("\\", "/")
+        for item_id in self.tree.get_children():
+            key = self.tree.item(item_id)["text"].replace("\\", "/")
+            if norm.endswith(key):
+                self._original_template_relative_path = key
+                self.tree.selection_set(item_id)
+                self.tree.see(item_id)
+                break
+
     def _adjust_treeview_column_widths(self) -> None:
         """Adjusts the column widths of the Treeview to fit the contents of each column."""
         # Use the actual Treeview style font so measurements match what is rendered.
@@ -273,6 +300,7 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
         self.tree.bind("<Up>", self._on_row_selection_change)
         self.tree.bind("<Down>", self._on_row_selection_change)
         self.tree.bind("<Double-1>", self._on_row_double_click)
+        self.root.protocol("WM_DELETE_WINDOW", self._on_window_close)
 
         for col in self.tree["columns"]:
             col_str = str(col)
@@ -292,6 +320,7 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
         if selected_item:
             item_id = selected_item[0]
             selected_template_relative_path = self.tree.item(item_id)["text"]
+            self._single_click_path = selected_template_relative_path
             self.store_template_dir(selected_template_relative_path)
             self._display_vehicle_image(selected_template_relative_path)
 
@@ -313,7 +342,21 @@ class TemplateOverviewWindow(BaseWindow):  # pylint: disable=too-many-instance-a
         if item_id:
             selected_template_relative_path = self.tree.item(item_id)["text"]
             self.store_template_dir(selected_template_relative_path)
+            self.user_made_selection = True
             self.close_window()
+
+    def _on_window_close(self) -> None:
+        """Handle window close via the title-bar X button."""
+        if self._single_click_path and not self.user_made_selection:
+            if messagebox.askyesno(
+                _("Confirm template selection"),
+                _("Apply the highlighted template?\n\n{path}").format(path=self._single_click_path),
+            ):
+                self.user_made_selection = True
+            elif self._original_template_relative_path:
+                # Restore the original template since the user declined the highlighted selection
+                self.store_template_dir(self._original_template_relative_path)
+        self.close_window()
 
     def close_window(self) -> None:
         """Close the window - separated for testability."""

--- a/tests/test_data_model_vehicle_project.py
+++ b/tests/test_data_model_vehicle_project.py
@@ -1402,3 +1402,149 @@ class TestCreateNewVehicleFromBinLog:
         assert manager._settings.use_fc_params is True
         # Assert: configuration_template is the leaf directory name of the template path
         assert manager.configuration_template == "empty_4.6.x"
+
+
+class TestGetFcDefaultTemplateDir:
+    """Test VehicleProjectManager.get_fc_default_template_dir."""
+
+    def _make_connected_manager(self, vehicle_type: str = "ArduCopter", fw_version: str = "4.6.0") -> "VehicleProjectManager":
+        """Return a manager whose FC is connected with the given vehicle type and firmware version."""
+        mock_filesystem = MagicMock(spec=LocalFilesystem)
+        mock_fc = MagicMock()
+        mock_fc.master = MagicMock()  # marks as connected
+        mock_fc.info.vehicle_type = vehicle_type
+        mock_fc.info.flight_sw_version = fw_version
+        return VehicleProjectManager(mock_filesystem, mock_fc)
+
+    def test_user_gets_fc_derived_template_when_directory_exists(self) -> None:
+        """
+        User gets a template directory derived from the FC's vehicle type and firmware version.
+
+        GIVEN: An FC is connected reporting ArduCopter 4.6.0
+        AND: The directory ArduCopter/empty_4.6.x exists in the templates base
+        WHEN: get_fc_default_template_dir is called
+        THEN: The path to that directory is returned
+        """
+        manager = self._make_connected_manager("ArduCopter", "4.6.0")
+
+        with (
+            patch.object(LocalFilesystem, "get_templates_base_dir", return_value="/templates"),
+            patch("ardupilot_methodic_configurator.data_model_vehicle_project.Path.is_dir", return_value=True),
+        ):
+            result = manager.get_fc_default_template_dir()
+
+        assert result.replace("\\", "/").endswith("ArduCopter/empty_4.6.x")
+
+    def test_user_gets_fallback_when_fc_derived_directory_does_not_exist(self) -> None:
+        """
+        User gets the recently-used fallback when the FC-derived template directory is missing.
+
+        GIVEN: An FC is connected reporting Rover 4.5.7
+        AND: The directory Rover/empty_4.5.x does NOT exist
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned instead
+        """
+        manager = self._make_connected_manager("Rover", "4.5.7")
+
+        with (
+            patch.object(LocalFilesystem, "get_templates_base_dir", return_value="/templates"),
+            patch("ardupilot_methodic_configurator.data_model_vehicle_project.Path.is_dir", return_value=False),
+            patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")),
+        ):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_fc_vehicle_type_is_empty(self) -> None:
+        """
+        User gets the recently-used fallback when the FC has no vehicle type information.
+
+        GIVEN: An FC is connected but vehicle_type is an empty string
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        manager = self._make_connected_manager(vehicle_type="", fw_version="4.6.0")
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_fc_firmware_version_is_empty(self) -> None:
+        """
+        User gets the recently-used fallback when the FC has no firmware version information.
+
+        GIVEN: An FC is connected but flight_sw_version is an empty string
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        manager = self._make_connected_manager(vehicle_type="ArduCopter", fw_version="")
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_firmware_version_has_no_dot(self) -> None:
+        """
+        User gets the recently-used fallback when the firmware version string is unparseable.
+
+        GIVEN: An FC is connected but flight_sw_version contains no '.' separator
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        manager = self._make_connected_manager(vehicle_type="ArduCopter", fw_version="46")
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_firmware_version_is_non_numeric(self) -> None:
+        """
+        User gets the recently-used fallback when firmware version parts are non-numeric.
+
+        GIVEN: An FC is connected but flight_sw_version contains non-integer parts
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        manager = self._make_connected_manager(vehicle_type="ArduCopter", fw_version="X.Y.Z")
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_fc_is_disconnected(self) -> None:
+        """
+        User gets the recently-used fallback when the FC is present but not connected.
+
+        GIVEN: A project manager with a flight controller whose master is None
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        mock_filesystem = MagicMock(spec=LocalFilesystem)
+        mock_fc = MagicMock()
+        mock_fc.master = None  # disconnected
+        manager = VehicleProjectManager(mock_filesystem, mock_fc)
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"
+
+    def test_user_gets_fallback_when_no_fc_is_present(self) -> None:
+        """
+        User gets the recently-used fallback when no flight controller is attached.
+
+        GIVEN: A project manager initialised without any flight controller
+        WHEN: get_fc_default_template_dir is called
+        THEN: The recently-used template directory is returned
+        """
+        mock_filesystem = MagicMock(spec=LocalFilesystem)
+        manager = VehicleProjectManager(mock_filesystem)
+
+        with patch.object(LocalFilesystem, "get_recently_used_dirs", return_value=("/fallback/template", "/base", "/vehicle")):
+            result = manager.get_fc_default_template_dir()
+
+        assert result == "/fallback/template"

--- a/tests/test_data_model_vehicle_project.py
+++ b/tests/test_data_model_vehicle_project.py
@@ -1487,7 +1487,7 @@ class TestGetFcDefaultTemplateDir:
 
     def test_user_gets_fallback_when_firmware_version_has_no_dot(self) -> None:
         """
-        User gets the recently-used fallback when the firmware version string is unparseable.
+        User gets the recently-used fallback when the firmware version string is unparsable.
 
         GIVEN: An FC is connected but flight_sw_version contains no '.' separator
         WHEN: get_fc_default_template_dir is called
@@ -1548,3 +1548,26 @@ class TestGetFcDefaultTemplateDir:
             result = manager.get_fc_default_template_dir()
 
         assert result == "/fallback/template"
+
+    def test_fallback_uses_manager_wrapper_not_direct_localfilesystem_call(self) -> None:
+        """
+        get_fc_default_template_dir falls back via self.get_recently_used_dirs().
+
+        GIVEN: A subclass of VehicleProjectManager that overrides get_recently_used_dirs
+        AND: No FC is connected (so the FC-derived path is not attempted)
+        WHEN: get_fc_default_template_dir is called
+        THEN: The subclass override is used for the fallback, not the base LocalFilesystem method
+        """
+
+        class _ManagerWithOverride(VehicleProjectManager):
+            def get_recently_used_dirs(self) -> tuple[str, str, str]:
+                return ("/overridden/template", "/base", "/vehicle")
+
+        mock_filesystem = MagicMock(spec=LocalFilesystem)
+        manager = _ManagerWithOverride(mock_filesystem)
+
+        # Ensure the base LocalFilesystem is NOT patched — if the code still calls
+        # LocalFilesystem.get_recently_used_dirs() directly the override would be bypassed.
+        result = manager.get_fc_default_template_dir()
+
+        assert result == "/overridden/template"

--- a/tests/test_frontend_tkinter_template_overview.py
+++ b/tests/test_frontend_tkinter_template_overview.py
@@ -1211,3 +1211,489 @@ class TestSelectionAndSortEdgeCases:
         # Source calls self._sort_by_column(col, not reverse) positionally, so check args tuple
         assert mock_sort.call_count == 1
         assert mock_sort.call_args.args == ("firmware", True)
+
+
+class TestUserMadeSelectionFlag:
+    """Test the user_made_selection flag that tracks whether the user confirmed a choice."""
+
+    def test_user_made_selection_is_false_on_init(self, template_window) -> None:
+        """
+        The user_made_selection flag starts as False when the window opens.
+
+        GIVEN: A newly opened TemplateOverviewWindow
+        WHEN: No user interaction has occurred
+        THEN: user_made_selection should be False
+        """
+        # Arrange / Act: window is freshly created via fixture
+
+        # Assert: flag is False by default
+        assert template_window.user_made_selection is False
+
+    def test_original_template_relative_path_is_empty_on_init(self, template_window) -> None:
+        """
+        _original_template_relative_path starts as an empty string when the window opens.
+
+        GIVEN: A newly opened TemplateOverviewWindow with no current_template_dir
+        WHEN: No preselection has occurred
+        THEN: _original_template_relative_path should be an empty string
+        """
+        # Arrange / Act: window is freshly created via fixture
+
+        # Assert: original path is empty because no preselection happened
+        assert template_window._original_template_relative_path == ""
+
+    def test_double_clicking_sets_user_made_selection_true(self, template_window) -> None:
+        """
+        Double-clicking a row marks the selection as confirmed.
+
+        GIVEN: A user views the template list
+        WHEN: They double-click on a valid template row
+        THEN: user_made_selection should be True
+        """
+        # Arrange
+        template_window.tree.identify_row.return_value = "item_1"
+        template_window.tree.item.return_value = {"text": "ArduCopter/empty_4.7.x"}
+        mock_event = MagicMock(y=50)
+
+        # Act
+        template_window._on_row_double_click(mock_event)
+
+        # Assert
+        assert template_window.user_made_selection is True
+
+    def test_single_click_does_not_set_user_made_selection(self, template_window) -> None:
+        """
+        Single-clicking a row (for preview) does not count as a confirmed selection.
+
+        GIVEN: A user is browsing templates
+        WHEN: They single-click a row to preview its image
+        THEN: user_made_selection should remain False
+        AND: _single_click_path should be updated to the clicked row
+        """
+        # Arrange
+        template_window.tree.selection.return_value = ["item_1"]
+        template_window.tree.item.return_value = {"text": "ArduCopter/empty_4.7.x"}
+
+        with patch.object(template_window, "_display_vehicle_image"):
+            # Act
+            template_window._update_selection()
+
+        # Assert: preview only — not a confirmed selection
+        assert template_window.user_made_selection is False
+        assert template_window._single_click_path == "ArduCopter/empty_4.7.x"
+
+    def test_double_click_on_empty_area_does_not_set_user_made_selection(self, template_window) -> None:
+        """
+        Double-clicking on a blank area of the treeview does not confirm a selection.
+
+        GIVEN: A user double-clicks on an empty part of the list (no row at that position)
+        WHEN: identify_row returns an empty string
+        THEN: user_made_selection should remain False
+        """
+        # Arrange
+        template_window.tree.identify_row.return_value = ""
+        mock_event = MagicMock(y=999)
+
+        # Act
+        template_window._on_row_double_click(mock_event)
+
+        # Assert
+        assert template_window.user_made_selection is False
+
+
+class TestWindowCloseConfirmationDialog:
+    """Test the confirmation dialog shown when closing after a single-click selection."""
+
+    def test_closing_after_single_click_shows_confirmation_dialog(self, template_window) -> None:
+        """
+        Closing the window after a single-click highlights prompts the user to confirm.
+
+        GIVEN: The user single-clicked a template row to preview it
+        WHEN: They close the window without double-clicking
+        THEN: A yes/no dialog should appear asking whether to apply the selection
+        """
+        # Arrange: simulate a prior single-click
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch("ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno") as mock_dlg,
+            patch.object(template_window, "close_window"),
+        ):
+            mock_dlg.return_value = False  # user says No
+
+            # Act
+            template_window._on_window_close()
+
+        # Assert: dialog was shown
+        mock_dlg.assert_called_once()
+
+    def test_answering_yes_sets_user_made_selection_true(self, template_window) -> None:
+        """
+        Answering 'Yes' to the confirmation dialog marks the selection as confirmed.
+
+        GIVEN: The user single-clicked a template and closes the window
+        WHEN: They answer Yes to 'Apply the highlighted template?'
+        THEN: user_made_selection is set to True
+        """
+        # Arrange
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch("ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno", return_value=True),
+            patch.object(template_window, "close_window"),
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert
+        assert template_window.user_made_selection is True
+
+    def test_answering_no_leaves_user_made_selection_false(self, template_window) -> None:
+        """
+        Answering 'No' keeps user_made_selection False so the original template is preserved.
+
+        GIVEN: The user single-clicked a template and closes the window
+        WHEN: They answer No to the confirmation dialog
+        THEN: user_made_selection remains False
+        """
+        # Arrange
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno", return_value=False
+            ),
+            patch.object(template_window, "close_window"),
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert
+        assert template_window.user_made_selection is False
+
+    def test_no_dialog_when_closing_without_any_single_click(self, template_window) -> None:
+        """
+        No dialog appears when the user closes without ever clicking a row.
+
+        GIVEN: The user opened the window but never clicked any row
+        WHEN: They close the window
+        THEN: No confirmation dialog is shown
+        """
+        # Arrange: no single-click happened
+        template_window._single_click_path = ""
+
+        with (
+            patch("ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno") as mock_dlg,
+            patch.object(template_window, "close_window"),
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert
+        mock_dlg.assert_not_called()
+
+    def test_no_dialog_after_double_click_confirmation(self, template_window) -> None:
+        """
+        No dialog appears when the user already confirmed via double-click.
+
+        GIVEN: The user double-clicked a row (user_made_selection is True)
+        WHEN: The window close handler fires (edge case)
+        THEN: No confirmation dialog is shown
+        """
+        # Arrange: double-click was the last action
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+        template_window.user_made_selection = True
+
+        with (
+            patch("ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno") as mock_dlg,
+            patch.object(template_window, "close_window"),
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert: dialog skipped because already confirmed
+        mock_dlg.assert_not_called()
+
+    def test_window_is_always_closed_regardless_of_dialog_answer(self, template_window) -> None:
+        """
+        The window is always closed after the dialog, whether Yes or No was chosen.
+
+        GIVEN: The user single-clicked a row and closes the window
+        WHEN: They answer the confirmation dialog (either way)
+        THEN: close_window() is always called exactly once
+        """
+        # Arrange
+        template_window._single_click_path = "ArduCopter/empty_4.6.x"
+
+        for answer in (True, False):
+            template_window.user_made_selection = False
+            with (
+                patch(
+                    "ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno",
+                    return_value=answer,
+                ),
+                patch.object(template_window, "close_window") as mock_close,
+            ):
+                template_window._on_window_close()
+
+            mock_close.assert_called_once()
+
+    def test_answering_no_restores_original_template_in_settings(self, template_window) -> None:
+        """
+        Answering 'No' restores the original template directory in persisted settings.
+
+        GIVEN: The user preselected ArduCopter/empty_4.6.x (original), then single-clicked ArduCopter/empty_4.7.x
+        AND: The single-click already persisted the new path via store_template_dir
+        WHEN: The user closes the window and answers 'No' to the confirmation dialog
+        THEN: store_template_dir is called with the original path to undo the single-click persistence
+        """
+        # Arrange: simulate preselection followed by a single-click on a different row
+        template_window._original_template_relative_path = "ArduCopter/empty_4.6.x"
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno",
+                return_value=False,  # user says No
+            ),
+            patch.object(template_window, "close_window"),
+            patch.object(template_window, "store_template_dir") as mock_store,
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert: original template is restored in settings
+        mock_store.assert_called_once_with("ArduCopter/empty_4.6.x")
+
+    def test_answering_no_without_original_preselection_does_not_restore(self, template_window) -> None:
+        """
+        Answering 'No' does not attempt to restore when no original preselection was made.
+
+        GIVEN: The user opened the window without a current_template_dir (no preselection)
+        AND: They single-clicked a row, which was persisted
+        WHEN: They close the window and answer 'No' to the confirmation dialog
+        THEN: store_template_dir is NOT called (nothing to restore)
+        """
+        # Arrange: no original path (window opened without current_template_dir)
+        template_window._original_template_relative_path = ""
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno",
+                return_value=False,  # user says No
+            ),
+            patch.object(template_window, "close_window"),
+            patch.object(template_window, "store_template_dir") as mock_store,
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert: no restore attempted because there was no pre-existing original
+        mock_store.assert_not_called()
+
+    def test_answering_yes_does_not_restore_original_template(self, template_window) -> None:
+        """
+        Answering 'Yes' does not restore the original template — the new choice is kept.
+
+        GIVEN: The user preselected ArduCopter/empty_4.6.x, then single-clicked ArduCopter/empty_4.7.x
+        WHEN: They close the window and answer 'Yes' to the confirmation dialog
+        THEN: store_template_dir is NOT called with the original path (the new choice stays)
+        """
+        # Arrange
+        template_window._original_template_relative_path = "ArduCopter/empty_4.6.x"
+        template_window._single_click_path = "ArduCopter/empty_4.7.x"
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.frontend_tkinter_template_overview.messagebox.askyesno",
+                return_value=True,  # user says Yes
+            ),
+            patch.object(template_window, "close_window"),
+            patch.object(template_window, "store_template_dir") as mock_store,
+        ):
+            # Act
+            template_window._on_window_close()
+
+        # Assert: original path is NOT restored; the confirmed single-click selection is kept
+        mock_store.assert_not_called()
+
+
+class TestPreselectionOfCurrentTemplate:
+    """Test that the window preselects and scrolls to the currently active template."""
+
+    def _make_tree_with_items(self, template_window: TemplateOverviewWindow, keys: list[str]) -> None:
+        """Helper: configure the mock tree so get_children returns item IDs and item() returns texts."""
+        item_ids = [f"item_{i}" for i in range(len(keys))]
+        template_window.tree.get_children.return_value = item_ids
+        template_window.tree.item.side_effect = lambda iid, **_: {"text": keys[item_ids.index(iid)]}
+
+    def test_matching_row_is_selected_and_scrolled_into_view(self, template_window) -> None:
+        """
+        The row matching the current template is highlighted and scrolled into view.
+
+        GIVEN: A template list containing ArduCopter/empty_4.7.x
+        AND: The currently active template is the absolute path ending with ArduCopter/empty_4.7.x
+        WHEN: The window opens with that current_template_dir
+        THEN: The matching row is selected and made visible via tree.see()
+        """
+        # Arrange
+        self._make_tree_with_items(
+            template_window,
+            ["ArduCopter/empty_4.5.x", "ArduCopter/empty_4.6.x", "ArduCopter/empty_4.7.x"],
+        )
+
+        # Act
+        template_window._preselect_current_template("/full/path/to/templates/ArduCopter/empty_4.7.x")
+
+        # Assert: correct item selected and scrolled to
+        template_window.tree.selection_set.assert_called_once_with("item_2")
+        template_window.tree.see.assert_called_once_with("item_2")
+
+    def test_no_selection_when_current_template_not_in_list(self, template_window) -> None:
+        """
+        No row is selected when the current template does not appear in the filtered list.
+
+        GIVEN: A template list filtered to ArduCopter entries only
+        AND: The currently active template is an ArduPlane path not shown
+        WHEN: _preselect_current_template is called
+        THEN: selection_set and see are NOT called
+        """
+        # Arrange
+        self._make_tree_with_items(template_window, ["ArduCopter/empty_4.6.x", "ArduCopter/empty_4.7.x"])
+
+        # Act
+        template_window._preselect_current_template("/templates/ArduPlane/empty_4.6.x")
+
+        # Assert
+        template_window.tree.selection_set.assert_not_called()
+        template_window.tree.see.assert_not_called()
+
+    def test_windows_backslash_path_matches_correctly(self, template_window) -> None:
+        """
+        Paths with Windows backslash separators are matched correctly.
+
+        GIVEN: The current template dir uses backslashes (Windows path)
+        WHEN: _preselect_current_template is called
+        THEN: The correct row is still found and selected
+        """
+        # Arrange
+        self._make_tree_with_items(template_window, ["ArduCopter/empty_4.6.x", "ArduCopter/empty_4.7.x"])
+
+        # Act — Windows-style absolute path
+        template_window._preselect_current_template(r"C:\templates\ArduCopter\empty_4.6.x")
+
+        # Assert: backslashes normalised and matched
+        template_window.tree.selection_set.assert_called_once_with("item_0")
+        template_window.tree.see.assert_called_once_with("item_0")
+
+    def test_only_first_matching_row_is_selected(self, template_window) -> None:
+        """
+        Only the first matching row is selected when duplicates exist.
+
+        GIVEN: A treeview containing two rows with identical text (edge case)
+        WHEN: _preselect_current_template is called
+        THEN: Only the first row is selected and scrolled to
+        """
+        # Arrange: two rows with the same key
+        self._make_tree_with_items(template_window, ["ArduCopter/empty_4.6.x", "ArduCopter/empty_4.6.x"])
+
+        # Act
+        template_window._preselect_current_template("/templates/ArduCopter/empty_4.6.x")
+
+        # Assert: only called once (breaks after first match)
+        template_window.tree.selection_set.assert_called_once_with("item_0")
+
+    def test_current_template_dir_parameter_triggers_preselection(self, mock_vehicle_provider, mock_program_provider) -> None:
+        """
+        Passing current_template_dir to __init__ causes the matching row to be preselected.
+
+        GIVEN: A TemplateOverviewWindow is opened with a current_template_dir argument
+        WHEN: The window initialises
+        THEN: _preselect_current_template is called with the provided path
+        """
+        # Arrange: patch all heavy init steps but let _preselect_current_template run
+        with (
+            patch("tkinter.Toplevel"),
+            patch.object(BaseWindow, "__init__", return_value=None),
+            patch.object(TemplateOverviewWindow, "_configure_window"),
+            patch.object(TemplateOverviewWindow, "_initialize_ui_components"),
+            patch.object(TemplateOverviewWindow, "_setup_layout"),
+            patch.object(TemplateOverviewWindow, "_configure_treeview"),
+            patch.object(TemplateOverviewWindow, "_bind_events"),
+            patch.object(TemplateOverviewWindow, "_preselect_current_template") as mock_preselect,
+        ):
+            window = TemplateOverviewWindow(
+                vehicle_components_provider=mock_vehicle_provider,
+                program_settings_provider=mock_program_provider,
+                current_template_dir="/templates/ArduCopter/empty_4.7.x",
+            )
+            window.root = MagicMock()
+
+        # Assert: preselect was called with the provided path
+        mock_preselect.assert_called_once_with("/templates/ArduCopter/empty_4.7.x")
+
+    def test_no_preselection_when_current_template_dir_is_none(self, mock_vehicle_provider, mock_program_provider) -> None:
+        """
+        No pre-selection occurs when current_template_dir is not provided.
+
+        GIVEN: A TemplateOverviewWindow is opened without specifying a current template
+        WHEN: The window initialises
+        THEN: _preselect_current_template is NOT called
+        """
+        with (
+            patch("tkinter.Toplevel"),
+            patch.object(BaseWindow, "__init__", return_value=None),
+            patch.object(TemplateOverviewWindow, "_configure_window"),
+            patch.object(TemplateOverviewWindow, "_initialize_ui_components"),
+            patch.object(TemplateOverviewWindow, "_setup_layout"),
+            patch.object(TemplateOverviewWindow, "_configure_treeview"),
+            patch.object(TemplateOverviewWindow, "_bind_events"),
+            patch.object(TemplateOverviewWindow, "_preselect_current_template") as mock_preselect,
+        ):
+            window = TemplateOverviewWindow(
+                vehicle_components_provider=mock_vehicle_provider,
+                program_settings_provider=mock_program_provider,
+            )
+            window.root = MagicMock()
+
+        # Assert: preselect was never called
+        mock_preselect.assert_not_called()
+
+    def test_preselect_records_original_template_relative_path(self, template_window) -> None:
+        """
+        _preselect_current_template stores the matched key as _original_template_relative_path.
+
+        GIVEN: A template list containing several entries
+        AND: The current template dir ends with one of the keys
+        WHEN: _preselect_current_template is called
+        THEN: _original_template_relative_path is set to the matched relative key
+        """
+        # Arrange
+        self._make_tree_with_items(
+            template_window,
+            ["ArduCopter/empty_4.5.x", "ArduCopter/empty_4.6.x", "ArduCopter/empty_4.7.x"],
+        )
+
+        # Act
+        template_window._preselect_current_template("/full/path/to/templates/ArduCopter/empty_4.6.x")
+
+        # Assert: original path is recorded using the relative tree key
+        assert template_window._original_template_relative_path == "ArduCopter/empty_4.6.x"
+
+    def test_original_template_relative_path_not_set_when_no_match(self, template_window) -> None:
+        """
+        _original_template_relative_path stays empty when no tree row matches.
+
+        GIVEN: A template list that does not contain the current template dir
+        WHEN: _preselect_current_template is called
+        THEN: _original_template_relative_path remains an empty string
+        """
+        # Arrange
+        self._make_tree_with_items(template_window, ["ArduCopter/empty_4.6.x", "ArduCopter/empty_4.7.x"])
+
+        # Act
+        template_window._preselect_current_template("/templates/ArduPlane/empty_4.6.x")
+
+        # Assert: no match found so original path is still empty
+        assert template_window._original_template_relative_path == ""


### PR DESCRIPTION
# Description

When a flight controller is connected, derive the default template directory from the FC's vehicle type and firmware version (e.g. ArduCopter/empty_4.7.x) instead of always using the hardcoded ArduCopter/empty_4.6.x fallback. Falls back to the recently-used/default template dir if the derived path does not exist on disk.

- Add VehicleProjectManager.get_fc_default_template_dir() in data_model_vehicle_project.py
- Use it in VehicleProjectCreatorWindow.__init__ when FC is connected
- Add 8 BDD unit tests covering all fallback scenarios

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [x] Tested on flight controller hardware
