### PR TITLE
Temporarly disable some plugins that require a bit more hardening

### DIFF
--- a/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
+++ b/ardupilot_methodic_configurator/configuration_steps_ArduCopter.json
@@ -173,11 +173,7 @@
             "derived_parameters": {
                 "FRAME_CLASS": { "New Value": "vehicle_components['Frame']['Specifications']['Frame class']", "Change Reason": "Selected in the component editor" }
             },
-            "old_filenames": ["04_board_orientation.param"],
-            "plugin": {
-                "name": "accelerometer_calibration",
-                "placement": "left"
-            }
+            "old_filenames": ["04_board_orientation.param"]
         },
         "06_remote_controller_receiver.param": {
             "why": "Remote controller is mandatory in the initial configuration and tuning phases. Later might be required for operation and/or safety",
@@ -409,10 +405,6 @@
                 "ATC_RAT_YAW_FLTT": { "New Value": "max(20, (round(289.22*vehicle_components['Propellers']['Specifications']['Diameter_inches']**-0.838, 0))) / 2", "Change Reason": "INS_GYRO_FILTER / 2" },
                 "INS_GYRO_FILTER":  { "New Value": "max(20, (round(289.22*vehicle_components['Propellers']['Specifications']['Diameter_inches']**-0.838, 0)))", "Change Reason": "Derived from vehicle component editor propeller size" },
                 "MOT_THST_EXPO":    { "New Value": "min(0.8, round(0.15686*log(vehicle_components['Propellers']['Specifications']['Diameter_inches'])+0.23693, 2))", "Change Reason": "Derived from vehicle component editor propeller size" }
-            },
-            "plugin": {
-                "name": "compass_calibration",
-                "placement": "top"
             },
             "old_filenames": ["11_initial_atc.param"]
         },


### PR DESCRIPTION
# Description

Temporarlly disable some plugins that require a bit more hardening.
We will re-enable them after the 4.3.1 release.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Tested on flight controller hardware
