### PR TITLE
 Revert to python 3.13 on macOS build to try to fix a regression

### DIFF
--- a/.github/workflows/build_windows_macos.yml
+++ b/.github/workflows/build_windows_macos.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: 'macos-latest'
     strategy:
       matrix:
-        python-version: ['3.14']
+        python-version: ['3.13']
 
     permissions:
       contents: write


### PR DESCRIPTION
# Description

 Revert to python 3.13 on macOS build to try to fix a regression

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
