### PR TITLE
Log analysis button crash on MacOS

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
@@ -146,7 +146,7 @@ class ProgramSettings:  # pylint: disable=too-many-public-methods
     validation of directory names according to specific rules.
     """
 
-    MAX_RECENT_DIRS = 5  # Maximum number of recent vehicle directories to store
+    MAX_RECENT_DIRS = 10  # Maximum number of recent vehicle directories to store
     MAX_CONNECTION_HISTORY = 10  # Maximum number of connection strings to store
 
     def __init__(self) -> None:

--- a/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_parameter_editor.py
@@ -640,20 +640,39 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
         finally:
             progress.destroy()
 
-    @staticmethod
-    def _set_log_analysis_progress_mode(progress: ProgressWindow) -> Callable[[int, int], None]:
-        """Return a callback that turns the indeterminate scan into a determinate parse progress bar."""
-        is_determinate = False
+    def _set_log_analysis_progress_mode(
+        self, progress: ProgressWindow
+    ) -> tuple[Callable[[int, int], None], Callable[[], None]]:
+        """Return a thread-safe recorder and a main-thread flush callable."""
+        state: dict[str, object] = {"pct": -1, "current": 0, "total": 0, "is_determinate": False}
+        lock = threading.Lock()
 
-        def update_progress(current: int, total: int) -> None:
-            nonlocal is_determinate
-            if not is_determinate:
+        def record_progress(current: int, total: int) -> None:
+            """Background thread only — zero Tk calls."""
+            if total == 0:
+                return
+            pct = int(current * 100 / total)
+            with lock:
+                if pct != state["pct"]:
+                    state.update({"pct": pct, "current": current, "total": total})
+
+        def flush_to_ui() -> None:
+            """Main thread only — reads state and updates widgets."""
+            with lock:
+                pct = int(state["pct"])  # type: ignore[arg-type]
+                current = int(state["current"])  # type: ignore[arg-type]
+                total = int(state["total"])  # type: ignore[arg-type]
+                is_det = bool(state["is_determinate"])
+            if pct < 0:
+                return
+            if not is_det:
                 progress.progress_bar.stop()
                 progress.progress_bar.configure(mode="determinate")
-                is_determinate = True
+                with lock:
+                    state["is_determinate"] = True
             progress.update_progress_bar(current, total)
 
-        return update_progress
+        return record_progress, flush_to_ui
 
     def on_analyse_log_click(self) -> None:
         """Handle the analyse log button click."""
@@ -671,10 +690,11 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
             return
 
         progress = self._create_log_analysis_progress(_("Reading flight log, please wait..."))
-        progress_callback = self._set_log_analysis_progress_mode(progress)
 
         result_container: list = []
         error_container: list = []
+
+        progress_callback, flush_progress = self._set_log_analysis_progress_mode(progress)
 
         def run_extraction() -> None:
             try:
@@ -683,6 +703,7 @@ class ParameterEditorWindow(BaseWindow):  # pylint: disable=too-many-instance-at
                 error_container.append(e)
 
         def check_done() -> None:
+            flush_progress()
             if thread.is_alive():
                 self.root.after(100, check_done)
                 return

--- a/ardupilot_methodic_configurator/log_analysis/backend_firmware_version.py
+++ b/ardupilot_methodic_configurator/log_analysis/backend_firmware_version.py
@@ -6,47 +6,12 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-from typing import Any
-
-from ardupilot_methodic_configurator.log_analysis.backend_log_extraction import close_log, open_log
-from ardupilot_methodic_configurator.log_analysis.data_model_firmware_version import (
-    parse_first_msg_version,
-    parse_ver_fields,
+from ardupilot_methodic_configurator.log_analysis.backend_log_extraction import (
+    close_log,
+    open_log,
+    process_msg_identity,
+    process_ver_identity,
 )
-
-
-def _process_ver(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
-    """
-    Extract firmware version from a VER DataFlash log entry.
-
-    Returns (vehicle_type, major, minor, patch) or None if any field is missing.
-    """
-    fws = getattr(msg, "FWS", None)
-    if isinstance(fws, bytes):
-        fws = fws.decode("utf-8", errors="replace")
-    elif not isinstance(fws, str):
-        return None
-
-    return parse_ver_fields(fws, getattr(msg, "Maj", None), getattr(msg, "Min", None), getattr(msg, "Pat", None))
-
-
-def _parse_msg_version(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
-    """
-    Parse firmware version from a MSG DataFlash log entry.
-
-    Returns (vehicle_type, major, minor, patch) or None if the entry is not parseable.
-    The caller is responsible for not calling this once a result has already been found.
-    """
-    message = getattr(msg, "Message", "")
-    if isinstance(message, bytes):
-        message = message.decode("utf-8", errors="replace")
-    elif not isinstance(message, str):
-        return None
-    parsed = parse_first_msg_version([message])
-    if parsed is None:
-        return None
-    vehicle_type, major, minor, patch, _firm_hash = parsed
-    return vehicle_type, major, minor, patch
 
 
 def extract_firmware_version_and_vehicle_type(logfile: str) -> tuple[str, int, int, int]:
@@ -77,11 +42,11 @@ def extract_firmware_version_and_vehicle_type(logfile: str) -> tuple[str, int, i
             if m is None:
                 break
             if m.get_type() == "VER":
-                result = _process_ver(m)
+                result = process_ver_identity(m)
                 if result is not None:
                     return result
             elif m.get_type() == "MSG" and msg_fallback_result is None:
-                msg_fallback_result = _parse_msg_version(m)
+                msg_fallback_result = process_msg_identity(m)
 
         if msg_fallback_result is not None:
             return msg_fallback_result

--- a/ardupilot_methodic_configurator/log_analysis/backend_log_analysis.py
+++ b/ardupilot_methodic_configurator/log_analysis/backend_log_analysis.py
@@ -23,7 +23,7 @@ from ardupilot_methodic_configurator.log_analysis.data_model_log_data import Log
 from ardupilot_methodic_configurator.log_analysis.utils import APMDoc
 
 
-def analyze_log_data(  # pylint: disable=too-many-arguments, too-many-locals
+def analyze_log_data(  # pylint: disable=too-many-arguments
     log_data: LogData,
     *,
     project_vehicle_type: object,
@@ -59,7 +59,7 @@ def analyze_log_data(  # pylint: disable=too-many-arguments, too-many-locals
     return analyze_log(log_data, context)
 
 
-def analyze_log_file(  # noqa: PLR0913 # pylint: disable=too-many-arguments, too-many-locals
+def analyze_log_file(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     filepath: str,
     *,
     project_vehicle_type: object,

--- a/ardupilot_methodic_configurator/log_analysis/backend_log_extraction.py
+++ b/ardupilot_methodic_configurator/log_analysis/backend_log_extraction.py
@@ -172,7 +172,7 @@ def _validate_message_fields(schema: data_model_log_data.MessageSchema, payload:
         raise ValueError(msg)
 
 
-def _process_ver_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
+def process_ver_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
     """Extract firmware identity from a VER message, if possible."""
     fws = getattr(msg, "FWS", None)
     if isinstance(fws, bytes):
@@ -182,7 +182,7 @@ def _process_ver_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa
     return parse_ver_fields(fws, getattr(msg, "Maj", None), getattr(msg, "Min", None), getattr(msg, "Pat", None))
 
 
-def _process_msg_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
+def process_msg_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
     """Extract firmware identity from an old-style MSG firmware line, if possible."""
     message = getattr(msg, "Message", "")
     if isinstance(message, bytes):
@@ -218,11 +218,11 @@ def _record_message_counts_fields_and_identity(mlog: mavutil.mavfile, log_data: 
         if msg_type == "FMTU":
             mult_ids_by_type[int(msg.FmtType)] = msg.MultIds
         elif msg_type == "VER" and log_data.vehicle_type is None:
-            identity = _process_ver_identity(msg)
+            identity = process_ver_identity(msg)
             if identity is not None:
                 _set_log_identity(log_data, identity)
         elif msg_type == "MSG" and msg_fallback_identity is None:
-            msg_fallback_identity = _process_msg_identity(msg)
+            msg_fallback_identity = process_msg_identity(msg)
 
     if log_data.vehicle_type is None and msg_fallback_identity is not None:
         _set_log_identity(log_data, msg_fallback_identity)

--- a/tests/test_frontend_tkinter_parameter_editor.py
+++ b/tests/test_frontend_tkinter_parameter_editor.py
@@ -733,7 +733,10 @@ class TestAnalyseLogClick:
             parameter_editor_window.ui.analyze_log_data = MagicMock(return_value=fake_summary)
             parameter_editor_window.on_analyse_log_click()
             captured_targets[0]()
-            check_done = parameter_editor_window.root.after.call_args_list[-1].args[1]
+
+            check_done = next(
+                c.args[1] for c in reversed(parameter_editor_window.root.after.call_args_list) if c.args[0] == 100
+            )
             check_done()
 
         progress = parameter_editor_window._test_progress_windows[0]  # type: ignore[attr-defined]


### PR DESCRIPTION
# Description

```
2026-08-06 09:37:30,904 - ERROR - Updating progress widgets: invalid command name ".!toplevel.!frame.!progressbar"
Exception ignored in: <function Image.__del__ at 0x102d32c00>
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tkinter/__init__.py", line 4119, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Variable.__del__ at 0x102c70680>
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tkinter/__init__.py", line 414, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop
Exception ignored in: <function Image.__del__ at 0x102d32c00>
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tkinter/__init__.py", line 4119, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop
Exception ignored in: <function Variable.__del__ at 0x102c70680>
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tkinter/__init__.py", line 414, in __del__
    if self._tk.getboolean(self._tk.call("info", "exists", self._name)):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: main thread is not in main loop

```
## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [ ] Tested on flight controller hardware
