### PR TITLE
refactor(log_analysis): dedupe VER/MSG firmware parsing to fix pylint R0801 on master

### DIFF
--- a/ardupilot_methodic_configurator/log_analysis/backend_firmware_version.py
+++ b/ardupilot_methodic_configurator/log_analysis/backend_firmware_version.py
@@ -10,8 +10,8 @@ from typing import Any
 
 from ardupilot_methodic_configurator.log_analysis.backend_log_extraction import close_log, open_log
 from ardupilot_methodic_configurator.log_analysis.data_model_firmware_version import (
-    parse_first_msg_version,
-    parse_ver_fields,
+    extract_msg_identity,
+    extract_ver_identity,
 )
 
 
@@ -21,13 +21,7 @@ def _process_ver(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
 
     Returns (vehicle_type, major, minor, patch) or None if any field is missing.
     """
-    fws = getattr(msg, "FWS", None)
-    if isinstance(fws, bytes):
-        fws = fws.decode("utf-8", errors="replace")
-    elif not isinstance(fws, str):
-        return None
-
-    return parse_ver_fields(fws, getattr(msg, "Maj", None), getattr(msg, "Min", None), getattr(msg, "Pat", None))
+    return extract_ver_identity(msg)
 
 
 def _parse_msg_version(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
@@ -37,16 +31,7 @@ def _parse_msg_version(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: A
     Returns (vehicle_type, major, minor, patch) or None if the entry is not parseable.
     The caller is responsible for not calling this once a result has already been found.
     """
-    message = getattr(msg, "Message", "")
-    if isinstance(message, bytes):
-        message = message.decode("utf-8", errors="replace")
-    elif not isinstance(message, str):
-        return None
-    parsed = parse_first_msg_version([message])
-    if parsed is None:
-        return None
-    vehicle_type, major, minor, patch, _firm_hash = parsed
-    return vehicle_type, major, minor, patch
+    return extract_msg_identity(msg)
 
 
 def extract_firmware_version_and_vehicle_type(logfile: str) -> tuple[str, int, int, int]:

--- a/ardupilot_methodic_configurator/log_analysis/backend_log_extraction.py
+++ b/ardupilot_methodic_configurator/log_analysis/backend_log_extraction.py
@@ -22,7 +22,7 @@ from pymavlink import mavutil
 
 from ardupilot_methodic_configurator import _
 from ardupilot_methodic_configurator.log_analysis import data_model_log_data
-from ardupilot_methodic_configurator.log_analysis.data_model_firmware_version import parse_first_msg_version, parse_ver_fields
+from ardupilot_methodic_configurator.log_analysis.data_model_firmware_version import extract_msg_identity, extract_ver_identity
 
 _NO_ID_ASSIGNED = "-"  # ArduPilot's FMTU convention: '-' marks a field with no unit/multiplier ID assigned
 
@@ -174,26 +174,12 @@ def _validate_message_fields(schema: data_model_log_data.MessageSchema, payload:
 
 def _process_ver_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
     """Extract firmware identity from a VER message, if possible."""
-    fws = getattr(msg, "FWS", None)
-    if isinstance(fws, bytes):
-        fws = fws.decode("utf-8", errors="replace")
-    elif not isinstance(fws, str):
-        return None
-    return parse_ver_fields(fws, getattr(msg, "Maj", None), getattr(msg, "Min", None), getattr(msg, "Pat", None))
+    return extract_ver_identity(msg)
 
 
 def _process_msg_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
     """Extract firmware identity from an old-style MSG firmware line, if possible."""
-    message = getattr(msg, "Message", "")
-    if isinstance(message, bytes):
-        message = message.decode("utf-8", errors="replace")
-    elif not isinstance(message, str):
-        return None
-    parsed = parse_first_msg_version([message])
-    if parsed is None:
-        return None
-    vehicle_type, major, minor, patch, _firmware_hash = parsed
-    return vehicle_type, major, minor, patch
+    return extract_msg_identity(msg)
 
 
 def _set_log_identity(log_data: data_model_log_data.LogData, identity: tuple[str, int, int, int]) -> None:

--- a/ardupilot_methodic_configurator/log_analysis/data_model_firmware_version.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_firmware_version.py
@@ -66,3 +66,49 @@ def parse_first_msg_version(messages: Iterable[str]) -> tuple[str, int, int, int
         if parsed is not None:
             return parsed
     return None
+
+
+def _decode_field(value: Any, default: str = "") -> str | None:  # noqa: ANN401
+    """
+    Normalise a DataFlash log field to str.
+
+    Returns the decoded string for bytes/str values (replacing invalid bytes),
+    or None when the field is neither bytes nor str.
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    if value is None and default:
+        return default
+    return None
+
+
+def extract_ver_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
+    """
+    Extract (vehicle_type, major, minor, patch) from a VER DataFlash log message.
+
+    Reads the FWS/Maj/Min/Pat attributes, decoding FWS if needed, and returns
+    None when the message is missing fields or not parseable.
+    """
+    fws = _decode_field(getattr(msg, "FWS", None))
+    if fws is None:
+        return None
+    return parse_ver_fields(fws, getattr(msg, "Maj", None), getattr(msg, "Min", None), getattr(msg, "Pat", None))
+
+
+def extract_msg_identity(msg: Any) -> tuple[str, int, int, int] | None:  # noqa: ANN401
+    """
+    Extract (vehicle_type, major, minor, patch) from an old-style MSG firmware line.
+
+    Reads the Message attribute, decoding it if needed, and returns None when the
+    line is missing or not a parseable firmware version string.
+    """
+    message = _decode_field(getattr(msg, "Message", ""), default="")
+    if message is None:
+        return None
+    parsed = parse_first_msg_version([message])
+    if parsed is None:
+        return None
+    vehicle_type, major, minor, patch, _firmware_hash = parsed
+    return vehicle_type, major, minor, patch

--- a/tests/test_data_model_firmware_version.py
+++ b/tests/test_data_model_firmware_version.py
@@ -8,7 +8,11 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+from types import SimpleNamespace
+
 from ardupilot_methodic_configurator.log_analysis.data_model_firmware_version import (
+    extract_msg_identity,
+    extract_ver_identity,
     parse_first_msg_version,
     parse_msg_ver_string,
     parse_ver_fields,
@@ -30,3 +34,27 @@ def test_parse_first_msg_version_skips_unrelated_messages() -> None:
     messages = ["Booting", "Frame: QUAD", "ArduCopter V4.5.5 (abcdef01)", "ArduPlane V4.5.5"]
 
     assert parse_first_msg_version(messages) == ("ArduCopter", 4, 5, 5, "abcdef01")
+
+
+def test_extract_ver_identity_decodes_bytes_fws() -> None:
+    """A VER message with a bytes FWS field is decoded before parsing."""
+    msg = SimpleNamespace(FWS=b"ArduCopter V4.6.3", Maj=4, Min=6, Pat=3)
+
+    assert extract_ver_identity(msg) == ("ArduCopter", 4, 6, 3)
+
+
+def test_extract_ver_identity_returns_none_without_fws() -> None:
+    """A VER message missing the FWS field yields no identity."""
+    assert extract_ver_identity(SimpleNamespace(Maj=4, Min=6, Pat=3)) is None
+
+
+def test_extract_msg_identity_decodes_bytes_message() -> None:
+    """An old-style MSG firmware line as bytes is decoded before parsing."""
+    msg = SimpleNamespace(Message=b"ArduPlane V4.5.5 (abcdef01)")
+
+    assert extract_msg_identity(msg) == ("ArduPlane", 4, 5, 5)
+
+
+def test_extract_msg_identity_returns_none_for_unrelated_message() -> None:
+    """A non-firmware MSG line yields no identity."""
+    assert extract_msg_identity(SimpleNamespace(Message="Booting")) is None


### PR DESCRIPTION
## Summary

The `pylint` CI job is currently failing on `master` (exit code 8) because of a `R0801: Similar lines in 2 files` report between two log-analysis backends:

```
==ardupilot_methodic_configurator.log_analysis.backend_firmware_version:[23:47]
==ardupilot_methodic_configurator.log_analysis.backend_log_extraction:[176:194]
```

Both files independently reimplemented the same "read a DataFlash field, decode bytes to `utf-8`, then hand off to the shared parser" logic for the `VER` and `MSG` firmware-identity messages.

## Change

- Add two thin helpers to the pure `data_model_firmware_version` module:
  - `extract_ver_identity(msg)` — VER message → `(vehicle_type, major, minor, patch)`
  - `extract_msg_identity(msg)` — old-style MSG firmware line → same tuple
  - plus a small private `_decode_field` used by both.
- `backend_firmware_version` and `backend_log_extraction` now delegate to these instead of duplicating the getattr/decode dance.

Net: the duplicated block is gone, the shared parsing logic lives in one place (the module that already owns `parse_ver_fields` / `parse_first_msg_version`), and the pylint duplicate-code report disappears.

## Tests

Added unit tests for the new helpers (bytes decoding, missing-`FWS`, unrelated-`MSG` paths) in `tests/test_data_model_firmware_version.py`.

Verified locally (Python 3.11):
- `pytest` on all affected modules — **36 passed** (4 new)
- `pylint` on the two backends — **R0801 no longer reported**, rated 10.00/10
- `ruff` — all checks passed
- `mypy` — no issues found

No behaviour change: the helpers preserve the exact decoding and None-handling semantics of the original inline code.
