### PR TITLE
test(settings): fix recent-dirs limit test after MAX_RECENT_DIRS 5->10 (main is red)

### DIFF
--- a/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
+++ b/ardupilot_methodic_configurator/backend_filesystem_program_settings.py
@@ -394,7 +394,7 @@ class ProgramSettings:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def store_recently_used_vehicle_dir(vehicle_dir: str) -> None:
-        """Store a vehicle directory in recent history (most recent first, max 5 entries)."""
+        """Store a vehicle directory in recent history (most recent first, capped at MAX_RECENT_DIRS entries)."""
         settings = ProgramSettings._get_settings_as_dict()
         settings = ProgramSettings._recent_vehicle_history.store_item(vehicle_dir, settings)
         ProgramSettings._set_settings_from_dict(settings)

--- a/tests/acceptance_recent_vehicle_directories_history.py
+++ b/tests/acceptance_recent_vehicle_directories_history.py
@@ -4,7 +4,7 @@
 Acceptance tests for Recent Vehicle Directories History feature.
 
 This file contains BDD-style acceptance tests that validate the requirements
-for maintaining a history of the 5 most recently opened vehicle directories.
+for maintaining a history of the most recently opened vehicle directories.
 
 This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
 
@@ -111,51 +111,37 @@ class TestRecentVehicleDirectoriesHistorySelection:
 
 
 class TestRecentVehicleDirectoriesHistoryLimit:
-    """AC3: History Maintains Maximum of 5 Entries."""
+    """AC3: History Maintains Maximum of MAX_RECENT_DIRS Entries."""
 
-    def test_history_maintains_maximum_of_five_entries(self) -> None:
+    def test_history_maintains_maximum_entries(self) -> None:
         """
-        History is limited to 5 entries, oldest is removed when adding 6th.
+        History is limited to MAX_RECENT_DIRS entries; the oldest is removed when one more is added.
 
-        GIVEN: User already has 5 directories in history [Dir_A, Dir_B, Dir_C, Dir_D, Dir_E]
-        WHEN: User successfully opens a new directory Dir_F
-        THEN: The history should contain [Dir_F, Dir_A, Dir_B, Dir_C, Dir_D]
-        AND: The oldest entry (Dir_E) should be removed
+        GIVEN: User already has MAX_RECENT_DIRS directories in history (at capacity)
+        WHEN: User successfully opens one more new directory
+        THEN: The history is still capped at MAX_RECENT_DIRS, the new directory is first,
+              and the previously-oldest entry has been dropped.
         """
-        # Arrange: Use platform-appropriate paths
-        if platform_system() == "Windows":
-            test_paths = [
-                "C:\\path\\to\\Dir_A",  # Most recent
-                "C:\\path\\to\\Dir_B",
-                "C:\\path\\to\\Dir_C",
-                "C:\\path\\to\\Dir_D",
-                "C:\\path\\to\\Dir_E",  # Oldest - should be removed
-            ]
-            new_path = "C:\\path\\to\\Dir_F"
-        else:
-            test_paths = [
-                "/path/to/Dir_A",  # Most recent
-                "/path/to/Dir_B",
-                "/path/to/Dir_C",
-                "/path/to/Dir_D",
-                "/path/to/Dir_E",  # Oldest - should be removed
-            ]
-            new_path = "/path/to/Dir_F"
+        # Arrange: fill the history exactly to capacity with platform-appropriate paths
+        max_dirs = ProgramSettings.MAX_RECENT_DIRS
+        prefix = "C:\\path\\to\\Dir_" if platform_system() == "Windows" else "/path/to/Dir_"
+        test_paths = [f"{prefix}{i}" for i in range(max_dirs)]  # index 0 = most recent, last = oldest
+        new_path = f"{prefix}new"
 
-        # Arrange: Mock settings with 5 directories (at max capacity)
+        # Arrange: Mock settings with the history at max capacity
         with (
             patch.object(ProgramSettings, "_get_settings_as_dict") as mock_get_settings,
             patch.object(ProgramSettings, "_set_settings_from_dict") as mock_set_settings,
         ):
             mock_get_settings.return_value = {"recent_vehicle_history": test_paths.copy()}
 
-            # Act: User opens a new directory Dir_F
+            # Act: User opens a new directory
             ProgramSettings.store_recently_used_vehicle_dir(new_path)
 
-            # Assert: History limited to MAX_RECENT_DIRS, oldest removed
+            # Assert: History capped at MAX_RECENT_DIRS, new entry first, oldest removed
             mock_set_settings.assert_called_once()
             saved_settings = mock_set_settings.call_args[0][0]
-            assert len(saved_settings["recent_vehicle_history"]) <= ProgramSettings.MAX_RECENT_DIRS
+            assert len(saved_settings["recent_vehicle_history"]) == max_dirs
             assert normalize_for_comparison(saved_settings["recent_vehicle_history"][0]) == normalize_for_comparison(new_path)
             assert not path_in_list(test_paths[-1], saved_settings["recent_vehicle_history"])
 


### PR DESCRIPTION
## Problem

`main` is red: `test_history_maintains_maximum_of_five_entries` fails in CI (Docker, Windows/macOS pytest).

```
assert not path_in_list(test_paths[-1], saved_settings["recent_vehicle_history"])
E   AssertionError: assert not True
    +  where True = path_in_list('/path/to/Dir_E',
       ['/path/to/Dir_F','/path/to/Dir_A','Dir_B','Dir_C','Dir_D','Dir_E'])
```

## Root cause

Commit fb4f99e `feat(open-project): Increase recent projects limit from 5 to 10` bumped `ProgramSettings.MAX_RECENT_DIRS` from 5 to 10, but the acceptance test (and two docstrings) still assert the old limit of 5. With a 10-entry cap, adding a 6th directory no longer evicts the oldest, so the test's `not path_in_list(oldest, ...)` assertion fails. This is a test/doc lag, not a behaviour regression — 10 is the intended new limit.

## Fix

Make the test independent of the constant's value so it can't drift again:
- Fill the history to exactly `MAX_RECENT_DIRS` entries, add one more, then assert the list stays capped at `MAX_RECENT_DIRS`, the new entry is first, and the previously-oldest entry was dropped.
- Remove the stale "5 most recently" / "max 5 entries" wording from the module docstring and `store_recently_used_vehicle_dir`.

## Verification (local, Python 3.11)

- `pytest tests/acceptance_recent_vehicle_directories_history.py` — **24 passed**
- `ruff check` — clean

No production behaviour change; only the test and docstrings are updated to match the current `MAX_RECENT_DIRS = 10`.
