### PR TITLE
Be more resilient when there are mavftp parameter inconsistencies and errors

### DIFF
--- a/ardupilot_methodic_configurator/backend_flightcontroller_params.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_params.py
@@ -33,6 +33,26 @@ if TYPE_CHECKING:
     )
 
 
+class _ProgressReporter:  # pylint: disable=too-few-public-methods
+    """Safely report progress and disable a callback after its first failure."""
+
+    def __init__(self, callback: Callable[[int, int], None] | None) -> None:
+        self.callback = callback
+
+    def __call__(self, current: int, total: int) -> None:
+        """Report progress without allowing callback failures to interrupt a transfer."""
+        if self.callback is None:
+            return
+        try:
+            self.callback(current, total)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging_warning(
+                _("Parameter download progress update failed: %(error)s"),
+                {"error": str(error)},
+            )
+            self.callback = None
+
+
 class FlightControllerParams:
     """
     Manages flight controller parameter operations.
@@ -117,19 +137,22 @@ class FlightControllerParams:
         if self.master is None:
             return {}, ParDict()
 
+        progress_reporter = _ProgressReporter(progress_callback)
+
         # Check if MAVFTP is supported
         if self.info.is_mavftp_supported:
             logging_info(_("MAVFTP is supported by the %s flight controller"), self.comport_device)
 
             param_dict, default_param_dict = self._download_params_via_mavftp(
-                progress_callback, parameter_values_filename, parameter_defaults_filename
+                progress_reporter, parameter_values_filename, parameter_defaults_filename
             )
             if param_dict:
                 self.fc_parameters = param_dict
                 return param_dict, default_param_dict
-
-        logging_info(_("MAVFTP is not supported by the %s flight controller, fallback to MAVLink"), self.comport_device)
-        param_dict, download_complete = self._download_params_via_mavlink(progress_callback)
+            logging_info(_("MAVFTP parameter download failed on the %s, fallback to MAVLink"), self.comport_device)
+        else:
+            logging_info(_("MAVFTP is not supported by the %s flight controller, fallback to MAVLink"), self.comport_device)
+        param_dict, download_complete = self._download_params_via_mavlink(progress_reporter)
         if not download_complete:
             logging_error(_("Incomplete parameter download from the %s flight controller"), self.comport_device)
             return {}, ParDict()
@@ -154,6 +177,9 @@ class FlightControllerParams:
             parameters were received.
 
         """
+        progress_reporter = (
+            progress_callback if isinstance(progress_callback, _ProgressReporter) else _ProgressReporter(progress_callback)
+        )
         logging_debug(_("Will fetch all parameters from the %s flight controller"), self.comport_device)
 
         # Dictionary to store parameters
@@ -176,9 +202,7 @@ class FlightControllerParams:
                 param_value = message["param_value"]
                 parameters[param_id] = param_value
                 logging_debug(_("Received parameter: %s = %s"), param_id, param_value)
-                # Call the progress callback with the current progress
-                if progress_callback:
-                    progress_callback(len(parameters), m.param_count)
+                progress_reporter(len(parameters), m.param_count)
                 if m.param_count == len(parameters):
                     logging_debug(
                         _("Fetched %d parameter values from the %s flight controller"), m.param_count, self.comport_device
@@ -210,12 +234,15 @@ class FlightControllerParams:
         """
         if self.master is None:
             return {}, ParDict()
+        progress_reporter = (
+            progress_callback if isinstance(progress_callback, _ProgressReporter) else _ProgressReporter(progress_callback)
+        )
         try:
             mavftp = create_mavftp(self.master)
 
             def get_params_progress_callback(completion: float) -> None:
                 if progress_callback is not None and completion is not None:
-                    progress_callback(int(completion * 100), 100)
+                    progress_reporter(int(completion * 100), 100)
 
             complete_param_filename = str(parameter_values_filename) if parameter_values_filename else "complete.param"
             default_param_filename = str(parameter_defaults_filename) if parameter_defaults_filename else "00_default.param"
@@ -236,22 +263,16 @@ class FlightControllerParams:
             else:
                 ret.display_message()
 
+            if pdict:
+                progress_reporter(100, 100)
             return pdict, defdict
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging_warning(
                 _("MAVFTP parameter download failed; falling back to MAVLink: %(error)s"),
                 {"error": str(error)},
+                exc_info=True,
             )
             return {}, ParDict()
-        finally:
-            if progress_callback is not None:
-                try:
-                    progress_callback(100, 100)
-                except Exception as error:  # pylint: disable=broad-exception-caught
-                    logging_warning(
-                        _("MAVFTP parameter download progress update failed: %(error)s"),
-                        {"error": str(error)},
-                    )
 
     def set_param(self, param_name: str, param_value: float) -> tuple[bool, str]:
         """

--- a/ardupilot_methodic_configurator/backend_flightcontroller_params.py
+++ b/ardupilot_methodic_configurator/backend_flightcontroller_params.py
@@ -210,34 +210,48 @@ class FlightControllerParams:
         """
         if self.master is None:
             return {}, ParDict()
-        mavftp = create_mavftp(self.master)
+        try:
+            mavftp = create_mavftp(self.master)
 
-        def get_params_progress_callback(completion: float) -> None:
-            if progress_callback is not None and completion is not None:
-                progress_callback(int(completion * 100), 100)
+            def get_params_progress_callback(completion: float) -> None:
+                if progress_callback is not None and completion is not None:
+                    progress_callback(int(completion * 100), 100)
 
-        complete_param_filename = str(parameter_values_filename) if parameter_values_filename else "complete.param"
-        default_param_filename = str(parameter_defaults_filename) if parameter_defaults_filename else "00_default.param"
-        mavftp.cmd_getparams([complete_param_filename, default_param_filename], progress_callback=get_params_progress_callback)
-        # on slow links parameter download might take a long time
-        ret = mavftp.process_ftp_reply("getparams", timeout=self.MAVFTP_GETPARAMS_TIMEOUT)
-        pdict: dict[str, float] = {}
-        defdict: ParDict = ParDict()
+            complete_param_filename = str(parameter_values_filename) if parameter_values_filename else "complete.param"
+            default_param_filename = str(parameter_defaults_filename) if parameter_defaults_filename else "00_default.param"
+            mavftp.cmd_getparams(
+                [complete_param_filename, default_param_filename], progress_callback=get_params_progress_callback
+            )
+            # On slow links parameter download might take a long time.
+            ret = mavftp.process_ftp_reply("getparams", timeout=self.MAVFTP_GETPARAMS_TIMEOUT)
+            pdict: dict[str, float] = {}
+            defdict = ParDict()
 
-        # add a file sync operation to ensure the file is completely written
-        time_sleep(self.FILE_SYNC_DELAY)
-        if ret.error_code == 0:
-            # load the parameters from the file
-            par_dict = ParDict.from_file(complete_param_filename)
-            pdict = {name: data.value for name, data in par_dict.items()}
-            defdict = ParDict.from_file(default_param_filename)
-        else:
-            ret.display_message()
+            # Add a file sync operation to ensure the file is completely written.
+            time_sleep(self.FILE_SYNC_DELAY)
+            if ret.error_code == 0:
+                par_dict = ParDict.from_file(complete_param_filename)
+                pdict = {name: data.value for name, data in par_dict.items()}
+                defdict = ParDict.from_file(default_param_filename)
+            else:
+                ret.display_message()
 
-        if progress_callback is not None:
-            progress_callback(100, 100)
-
-        return pdict, defdict
+            return pdict, defdict
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging_warning(
+                _("MAVFTP parameter download failed; falling back to MAVLink: %(error)s"),
+                {"error": str(error)},
+            )
+            return {}, ParDict()
+        finally:
+            if progress_callback is not None:
+                try:
+                    progress_callback(100, 100)
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    logging_warning(
+                        _("MAVFTP parameter download progress update failed: %(error)s"),
+                        {"error": str(error)},
+                    )
 
     def set_param(self, param_name: str, param_value: float) -> tuple[bool, str]:
         """

--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -1322,16 +1322,17 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def __decode_param_record(  # pylint: disable=too-many-locals
         data: bytes,
+        offset: int,
         last_name: bytes,
         with_defaults: bool,
         pdata: ParamData,
-    ) -> tuple[bytes, bytes] | None:
+    ) -> tuple[bytes, int] | None:
         """Decode one packed-parameter record and append it to ``pdata``."""
-        if len(data) < 2:
+        if len(data) - offset < 2:
             logging.error("paramftp: truncated parameter header")
             return None
 
-        ptype, plen = struct.unpack("<BB", data[0:2])
+        ptype, plen = struct.unpack_from("<BB", data, offset)
         flags = (ptype >> 4) & 0x0F
         has_default = with_defaults and (flags & 1) != 0
         ptype &= 0x0F
@@ -1344,26 +1345,28 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         common_len = plen & 0x0F
         value_len = type_len * (2 if has_default else 1)
         record_len = 2 + name_len + value_len
-        if len(data) < record_len:
+        record_end = offset + record_len
+        if len(data) < record_end:
             logging.error("paramftp: truncated parameter record")
             return None
         if common_len > len(last_name):
             logging.error("paramftp: invalid shared parameter name prefix length %u", common_len)
             return None
 
-        name = last_name[:common_len] + data[2 : 2 + name_len]
-        vdata = data[2 + name_len : record_len]
+        name_start = offset + 2
+        value_start = name_start + name_len
+        name = last_name[:common_len] + data[name_start:value_start]
         unpack_format = "<" + type_format
         if has_default:
-            value, default = struct.unpack("<" + type_format * 2, vdata)
+            value, default = struct.unpack_from("<" + type_format * 2, data, value_start)
             pdata.add_param(name, value, ptype)
             pdata.add_default(name, default, ptype)
         else:
-            (value,) = struct.unpack(unpack_format, vdata)
+            (value,) = struct.unpack_from(unpack_format, data, value_start)
             pdata.add_param(name, value, ptype)
             if with_defaults:
                 pdata.add_default(name, value, ptype)
-        return name, data[record_len:]
+        return name, record_end
 
     @staticmethod
     def ftp_param_decode(data: bytes) -> ParamData | None:
@@ -1376,20 +1379,20 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.error("paramftp: bad magic 0x%x expected 0x%x", magic, PARAM_MAGIC)
             return None
         with_defaults = magic == PARAM_MAGIC_WITH_DEFAULTS
-        data = data[PARAM_HEADER_STRUCT.size :]
         pdata = ParamData()
 
         count = 0
         last_name = b""
-        while data:
-            while data and data[0] == 0:
-                data = data[1:]
-            if not data:
+        offset = PARAM_HEADER_STRUCT.size
+        while offset < len(data):
+            while offset < len(data) and data[offset] == 0:
+                offset += 1
+            if offset == len(data):
                 break
-            decoded = MAVFTP.__decode_param_record(data, last_name, with_defaults, pdata)
+            decoded = MAVFTP.__decode_param_record(data, offset, last_name, with_defaults, pdata)
             if decoded is None:
                 return None
-            last_name, data = decoded
+            last_name, offset = decoded
             count += 1
 
         if count != total_params:

--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -1311,7 +1311,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         )
 
     @staticmethod
-    def ftp_param_decode(data: bytes) -> ParamData | None:  # pylint: disable=too-many-locals
+    def ftp_param_decode(data: bytes) -> ParamData | None:  # pylint: disable=too-many-locals  # noqa: PLR0911,PLR0915
         """Decode parameter data, returning ParamData."""
         pdata = ParamData()
 
@@ -1344,6 +1344,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
             if len(data) == 0:
                 break
+            if len(data) < 2:
+                logging.error("paramftp: truncated parameter header")
+                return None
 
             ptype, plen = struct.unpack("<BB", data[0:2])
             flags = (ptype >> 4) & 0x0F
@@ -1359,10 +1362,15 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
             name_len = ((plen >> 4) & 0x0F) + 1
             common_len = plen & 0x0F
+            value_len = type_len + default_len
+            record_len = 2 + name_len + value_len
+            if len(data) < record_len:
+                logging.error("paramftp: truncated parameter record")
+                return None
             name = last_name[0:common_len] + data[2 : 2 + name_len]
-            vdata = data[2 + name_len : 2 + name_len + type_len + default_len]
+            vdata = data[2 + name_len : record_len]
             last_name = name
-            data = data[2 + name_len + type_len + default_len :]
+            data = data[record_len:]
             if with_defaults:
                 if has_default:
                     (
@@ -1456,10 +1464,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 data = fh.read()
             except OSError as exp:
                 logging.error("FTP: Failed to read file param.pck: %s", exp)
-                sys.exit(1)
+                return MAVFTPReturn("GetParams", ERR_Fail)
             pdata = MAVFTP.ftp_param_decode(data)
             if pdata is None:
-                sys.exit(1)
+                logging.error("FTP: Failed to decode parameter file param.pck")
+                return MAVFTPReturn("GetParams", ERR_Fail)
 
             param_values = MAVFTP.extract_params(pdata.params, sort_type)
             param_defaults = MAVFTP.extract_params(pdata.defaults, sort_type)

--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -394,6 +394,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.fh: SIO | BufferedReader | BufferedWriter | None = None
         self.filename: str | None = None
         self.callback: Callable[..., Any] | None = None
+        self.callback_failure: MAVFTPReturn | None = None
         self.callback_progress: Callable[..., Any] | None = None
         self.put_callback: Callable[..., Any] | None = None
         self.put_callback_progress: Callable[..., Any] | None = None
@@ -599,6 +600,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info("Getting %s to %s", fname, self.filename)
         self.op_start = time.time()
         self.callback = callback
+        self.callback_failure = None
         self.callback_progress = progress_callback
         self.read_retries = 0
         self.duplicates = 0
@@ -653,7 +655,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             rate = (ofs / dt) / 1024.0
             if self.callback is not None:
                 self.fh.seek(0)
-                self.callback(self.fh)
+                callback_result = self.callback(self.fh)
+                if isinstance(callback_result, MAVFTPReturn) and callback_result.error_code != ERR_None:
+                    self.callback_failure = callback_result
                 self.callback = None
             elif self.filename == "-":
                 self.fh.seek(0)
@@ -1247,6 +1251,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     ret = MAVFTPReturn(operation_name, ERR_None)
                 else:
                     ret = self.__mavlink_packet(m)
+                if self.callback_failure is not None:
+                    ret = self.callback_failure
+                    break
             if self.__idle_task():
                 break
             if timeout > 0 and time.time() - start_time > timeout:  # pylint: disable=chained-comparison

--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -83,6 +83,15 @@ ERR_RemoteReplyTimeout = 73
 
 HDR_Len = 12
 MAX_Payload = 239
+PARAM_HEADER_STRUCT = struct.Struct("<HHH")
+PARAM_MAGIC = 0x671B
+PARAM_MAGIC_WITH_DEFAULTS = 0x671C
+PARAM_TYPE_FORMATS = {
+    1: (1, "b"),
+    2: (2, "h"),
+    3: (4, "i"),
+    4: (4, "f"),
+}
 # pylint: enable=invalid-name
 
 
@@ -1311,81 +1320,76 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         )
 
     @staticmethod
-    def ftp_param_decode(data: bytes) -> ParamData | None:  # pylint: disable=too-many-locals  # noqa: PLR0911,PLR0915
-        """Decode parameter data, returning ParamData."""
-        pdata = ParamData()
+    def __decode_param_record(  # pylint: disable=too-many-locals
+        data: bytes,
+        last_name: bytes,
+        with_defaults: bool,
+        pdata: ParamData,
+    ) -> tuple[bytes, bytes] | None:
+        """Decode one packed-parameter record and append it to ``pdata``."""
+        if len(data) < 2:
+            logging.error("paramftp: truncated parameter header")
+            return None
 
-        magic = 0x671B
-        magic_defaults = 0x671C
-        if len(data) < 6:
+        ptype, plen = struct.unpack("<BB", data[0:2])
+        flags = (ptype >> 4) & 0x0F
+        has_default = with_defaults and (flags & 1) != 0
+        ptype &= 0x0F
+        if ptype not in PARAM_TYPE_FORMATS:
+            logging.error("paramftp: bad type 0x%x", ptype)
+            return None
+
+        type_len, type_format = PARAM_TYPE_FORMATS[ptype]
+        name_len = ((plen >> 4) & 0x0F) + 1
+        common_len = plen & 0x0F
+        value_len = type_len * (2 if has_default else 1)
+        record_len = 2 + name_len + value_len
+        if len(data) < record_len:
+            logging.error("paramftp: truncated parameter record")
+            return None
+        if common_len > len(last_name):
+            logging.error("paramftp: invalid shared parameter name prefix length %u", common_len)
+            return None
+
+        name = last_name[:common_len] + data[2 : 2 + name_len]
+        vdata = data[2 + name_len : record_len]
+        unpack_format = "<" + type_format
+        if has_default:
+            value, default = struct.unpack("<" + type_format * 2, vdata)
+            pdata.add_param(name, value, ptype)
+            pdata.add_default(name, default, ptype)
+        else:
+            (value,) = struct.unpack(unpack_format, vdata)
+            pdata.add_param(name, value, ptype)
+            if with_defaults:
+                pdata.add_default(name, value, ptype)
+        return name, data[record_len:]
+
+    @staticmethod
+    def ftp_param_decode(data: bytes) -> ParamData | None:
+        """Decode parameter data, returning ParamData."""
+        if len(data) < PARAM_HEADER_STRUCT.size:
             logging.error("paramftp: Not enough data do decode, only %u bytes", len(data))
             return None
-        magic2, _num_params, total_params = struct.unpack("<HHH", data[0:6])
-        if magic2 not in {magic, magic_defaults}:
-            logging.error("paramftp: bad magic 0x%x expected 0x%x", magic2, magic)
+        magic, _num_params, total_params = PARAM_HEADER_STRUCT.unpack_from(data)
+        if magic not in {PARAM_MAGIC, PARAM_MAGIC_WITH_DEFAULTS}:
+            logging.error("paramftp: bad magic 0x%x expected 0x%x", magic, PARAM_MAGIC)
             return None
-        with_defaults = magic2 == magic_defaults
-        data = data[6:]
-
-        # mapping of data type to type length and format
-        data_types = {
-            1: (1, "b"),
-            2: (2, "h"),
-            3: (4, "i"),
-            4: (4, "f"),
-        }
+        with_defaults = magic == PARAM_MAGIC_WITH_DEFAULTS
+        data = data[PARAM_HEADER_STRUCT.size :]
+        pdata = ParamData()
 
         count = 0
-        pad_byte = 0
         last_name = b""
-        while True:
-            while len(data) > 0 and data[0] == pad_byte:
-                data = data[1:]  # skip pad bytes
-
-            if len(data) == 0:
+        while data:
+            while data and data[0] == 0:
+                data = data[1:]
+            if not data:
                 break
-            if len(data) < 2:
-                logging.error("paramftp: truncated parameter header")
+            decoded = MAVFTP.__decode_param_record(data, last_name, with_defaults, pdata)
+            if decoded is None:
                 return None
-
-            ptype, plen = struct.unpack("<BB", data[0:2])
-            flags = (ptype >> 4) & 0x0F
-            has_default = with_defaults and (flags & 1) != 0
-            ptype &= 0x0F
-
-            if ptype not in data_types:
-                logging.error("paramftp: bad type 0x%x", ptype)
-                return None
-
-            (type_len, type_format) = data_types[ptype]
-            default_len = type_len if has_default else 0
-
-            name_len = ((plen >> 4) & 0x0F) + 1
-            common_len = plen & 0x0F
-            value_len = type_len + default_len
-            record_len = 2 + name_len + value_len
-            if len(data) < record_len:
-                logging.error("paramftp: truncated parameter record")
-                return None
-            name = last_name[0:common_len] + data[2 : 2 + name_len]
-            vdata = data[2 + name_len : record_len]
-            last_name = name
-            data = data[record_len:]
-            if with_defaults:
-                if has_default:
-                    (
-                        v1,
-                        v2,
-                    ) = struct.unpack("<" + type_format + type_format, vdata)
-                    pdata.add_param(name, v1, ptype)
-                    pdata.add_default(name, v2, ptype)
-                else:
-                    (v,) = struct.unpack("<" + type_format, vdata)
-                    pdata.add_param(name, v, ptype)
-                    pdata.add_default(name, v, ptype)
-            else:
-                (v,) = struct.unpack("<" + type_format, vdata)
-                pdata.add_param(name, v, ptype)
+            last_name, data = decoded
             count += 1
 
         if count != total_params:

--- a/ardupilot_methodic_configurator/backend_mavftp.py
+++ b/ardupilot_methodic_configurator/backend_mavftp.py
@@ -1374,7 +1374,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if len(data) < PARAM_HEADER_STRUCT.size:
             logging.error("paramftp: Not enough data do decode, only %u bytes", len(data))
             return None
-        magic, _num_params, total_params = PARAM_HEADER_STRUCT.unpack_from(data)
+        magic, num_params, _total_params = PARAM_HEADER_STRUCT.unpack_from(data)
         if magic not in {PARAM_MAGIC, PARAM_MAGIC_WITH_DEFAULTS}:
             logging.error("paramftp: bad magic 0x%x expected 0x%x", magic, PARAM_MAGIC)
             return None
@@ -1395,8 +1395,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             last_name, offset = decoded
             count += 1
 
-        if count != total_params:
-            logging.error("paramftp: bad count %u should be %u", count, total_params)
+        if count != num_params:
+            logging.error("paramftp: bad count %u should be %u", count, num_params)
             return None
 
         return pdata

--- a/tests/test_backend_flightcontroller_params.py
+++ b/tests/test_backend_flightcontroller_params.py
@@ -658,13 +658,27 @@ class TestFlightControllerParamsDownload:
         assert params == {}
         assert isinstance(defaults, ParDict)
         mock_warning.assert_called_once()
-        progress.assert_called_once_with(100, 100)
+        progress.assert_not_called()
 
-    def test_mavftp_download_ignores_progress_callback_errors_during_fallback(self) -> None:
+    def test_download_params_ignores_progress_callback_errors_during_fallback(self) -> None:
         """A broken progress callback must not prevent the MAVLink fallback."""
+        mock_master = MagicMock()
+        mock_master.target_system = 1
+        mock_master.target_component = 1
+        mock_master.mav = MagicMock()
+        mavlink_message = MagicMock()
+        mavlink_message.param_count = 2
+        mavlink_message.to_dict.return_value = {"param_id": "AHRS_EKF_TYPE", "param_value": 10.0}
+        second_mavlink_message = MagicMock()
+        second_mavlink_message.param_count = 2
+        second_mavlink_message.to_dict.return_value = {"param_id": "ATC_RATE_RLL_FF", "param_value": 0.12}
+        mock_master.recv_match.side_effect = [mavlink_message, second_mavlink_message]
+
         mock_conn_mgr = Mock()
-        mock_conn_mgr.master = MagicMock()
+        mock_conn_mgr.master = mock_master
+        mock_conn_mgr.comport_device = "tcp:127.0.0.1:5760"
         mock_conn_mgr.info = FlightControllerInfo()
+        mock_conn_mgr.info.is_mavftp_supported = True
         params_mgr = FlightControllerParams(connection_manager=mock_conn_mgr)
 
         progress = Mock(side_effect=RuntimeError("UI unavailable"))
@@ -672,11 +686,12 @@ class TestFlightControllerParamsDownload:
             "ardupilot_methodic_configurator.backend_flightcontroller_params.create_mavftp",
             side_effect=ValueError("paramftp: bad count 999 should be 989"),
         ):
-            params, defaults = params_mgr._download_params_via_mavftp(progress)  # pylint: disable=protected-access
+            params, defaults = params_mgr.download_params(progress)
 
-        assert params == {}
+        mock_master.mav.param_request_list_send.assert_called_once_with(1, 1)
+        assert params == {"AHRS_EKF_TYPE": 10.0, "ATC_RATE_RLL_FF": 0.12}
         assert isinstance(defaults, ParDict)
-        progress.assert_called_once_with(100, 100)
+        progress.assert_called_once_with(1, 2)
 
     def test_download_params_falls_back_to_mavlink_after_mavftp_exception(self) -> None:
         """
@@ -707,7 +722,7 @@ class TestFlightControllerParamsDownload:
             params, defaults = params_mgr.download_params()
 
         # Assert (Then): MAVLink completes the download after the recoverable FTP failure
-        mock_mavlink.assert_called_once_with(None)
+        mock_mavlink.assert_called_once()
         assert params == fallback_params
         assert isinstance(defaults, ParDict)
         assert params_mgr.fc_parameters == fallback_params

--- a/tests/test_backend_flightcontroller_params.py
+++ b/tests/test_backend_flightcontroller_params.py
@@ -638,6 +638,80 @@ class TestFlightControllerParamsDownload:
         assert params == {}
         assert isinstance(defaults, ParDict)
 
+    def test_mavftp_download_converts_transfer_exception_to_empty_result(self) -> None:
+        """A malformed MAVFTP parameter transfer should trigger the normal fallback."""
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = MagicMock()
+        mock_conn_mgr.info = FlightControllerInfo()
+        params_mgr = FlightControllerParams(connection_manager=mock_conn_mgr)
+
+        progress = Mock()
+        with (
+            patch(
+                "ardupilot_methodic_configurator.backend_flightcontroller_params.create_mavftp",
+                side_effect=ValueError("paramftp: bad count 999 should be 989"),
+            ),
+            patch("ardupilot_methodic_configurator.backend_flightcontroller_params.logging_warning") as mock_warning,
+        ):
+            params, defaults = params_mgr._download_params_via_mavftp(progress)  # pylint: disable=protected-access
+
+        assert params == {}
+        assert isinstance(defaults, ParDict)
+        mock_warning.assert_called_once()
+        progress.assert_called_once_with(100, 100)
+
+    def test_mavftp_download_ignores_progress_callback_errors_during_fallback(self) -> None:
+        """A broken progress callback must not prevent the MAVLink fallback."""
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = MagicMock()
+        mock_conn_mgr.info = FlightControllerInfo()
+        params_mgr = FlightControllerParams(connection_manager=mock_conn_mgr)
+
+        progress = Mock(side_effect=RuntimeError("UI unavailable"))
+        with patch(
+            "ardupilot_methodic_configurator.backend_flightcontroller_params.create_mavftp",
+            side_effect=ValueError("paramftp: bad count 999 should be 989"),
+        ):
+            params, defaults = params_mgr._download_params_via_mavftp(progress)  # pylint: disable=protected-access
+
+        assert params == {}
+        assert isinstance(defaults, ParDict)
+        progress.assert_called_once_with(100, 100)
+
+    def test_download_params_falls_back_to_mavlink_after_mavftp_exception(self) -> None:
+        """
+        A MAVFTP exception automatically continues the parameter-download workflow.
+
+        GIVEN: A connected controller that supports MAVFTP but the FTP transfer raises
+        WHEN: The user downloads its parameters
+        THEN: MAVLink retrieves the parameters and the local cache is updated
+        """
+        # Arrange (Given): A controller whose MAVFTP factory fails
+        mock_conn_mgr = Mock()
+        mock_conn_mgr.master = MagicMock()
+        mock_conn_mgr.comport_device = "tcp:127.0.0.1:5760"
+        mock_info = FlightControllerInfo()
+        mock_info.is_mavftp_supported = True
+        mock_conn_mgr.info = mock_info
+        params_mgr = FlightControllerParams(connection_manager=mock_conn_mgr)
+        fallback_params = {"AHRS_EKF_TYPE": 10.0}
+
+        with (
+            patch(
+                "ardupilot_methodic_configurator.backend_flightcontroller_params.create_mavftp",
+                side_effect=ValueError("paramftp: bad count 999 should be 989"),
+            ),
+            patch.object(params_mgr, "_download_params_via_mavlink", return_value=(fallback_params, True)) as mock_mavlink,
+        ):
+            # Act (When): Download parameters through the preferred MAVFTP path
+            params, defaults = params_mgr.download_params()
+
+        # Assert (Then): MAVLink completes the download after the recoverable FTP failure
+        mock_mavlink.assert_called_once_with(None)
+        assert params == fallback_params
+        assert isinstance(defaults, ParDict)
+        assert params_mgr.fc_parameters == fallback_params
+
     def test_user_can_download_parameters_over_mavlink_with_progress(self) -> None:
         """
         MAVLink downloads iterate until all parameters are received.

--- a/tests/test_backend_mavftp.py
+++ b/tests/test_backend_mavftp.py
@@ -116,6 +116,16 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         assert result.params == [(b"TEST", 12.5, 4)]
         assert result.defaults is None
 
+    def test_param_decode_accepts_subset_response(self) -> None:
+        """A subset response has fewer transmitted parameters than the total count."""
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 1, 2)
+        payload += b"\x04\x30TEST" + struct.pack("<f", 12.5)
+
+        result = MAVFTP.ftp_param_decode(payload)
+
+        assert result is not None
+        assert result.params == [(b"TEST", 12.5, 4)]
+
     def test_param_decode_decodes_explicit_default_value(self) -> None:
         """A defaults record keeps the transmitted default value."""
         payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC_WITH_DEFAULTS, 1, 1)

--- a/tests/test_backend_mavftp.py
+++ b/tests/test_backend_mavftp.py
@@ -18,7 +18,7 @@ import unittest
 
 # from unittest.mock import patch
 from io import BytesIO, StringIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pymavlink import mavutil
 
@@ -98,6 +98,22 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         result = self.mav_ftp.cmd_getparams(["values.param", "defaults.param"])
 
         assert result.error_code == ERR_Fail
+
+    def test_process_ftp_reply_propagates_getparams_callback_failure(self) -> None:
+        """A parameter-decoding callback failure makes the transfer fail, enabling fallback."""
+        callback_failure = MAVFTPReturn("GetParams", ERR_Fail)
+        packet_result = MAVFTPReturn("BurstReadFile", ERR_None)
+        self.mav_ftp.master = Mock()
+        self.mav_ftp.master.recv_match.return_value = Mock()
+
+        def simulate_finished_transfer(_message: object) -> MAVFTPReturn:
+            self.mav_ftp.callback_failure = callback_failure
+            return packet_result
+
+        with patch.object(self.mav_ftp, "_MAVFTP__mavlink_packet", side_effect=simulate_finished_transfer):
+            result = self.mav_ftp.process_ftp_reply("getparams", timeout=5)
+
+        assert result is callback_failure
 
     def test_param_decode_rejects_truncated_parameter_record(self) -> None:
         """A packed parameter record missing its value must return no data."""

--- a/tests/test_backend_mavftp.py
+++ b/tests/test_backend_mavftp.py
@@ -53,6 +53,10 @@ from ardupilot_methodic_configurator.backend_mavftp import (
     OP_ReadFile,
 )
 
+PARAM_HEADER_STRUCT = struct.Struct("<HHH")
+PARAM_MAGIC = 0x671B
+PARAM_MAGIC_WITH_DEFAULTS = 0x671C
+
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):
     """Test MAVFTP payload decoding."""
@@ -97,7 +101,46 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
 
     def test_param_decode_rejects_truncated_parameter_record(self) -> None:
         """A packed parameter record missing its value must return no data."""
-        payload = struct.pack("<HHH", 0x671B, 1, 1) + b"\x01\x00A"
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 1, 1) + b"\x01\x00A"
+
+        assert MAVFTP.ftp_param_decode(payload) is None
+
+    def test_param_decode_decodes_plain_parameter_value(self) -> None:
+        """A packed parameter record is decoded into its name, value, and type."""
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 1, 1)
+        payload += b"\x04\x30TEST" + struct.pack("<f", 12.5)
+
+        result = MAVFTP.ftp_param_decode(payload)
+
+        assert result is not None
+        assert result.params == [(b"TEST", 12.5, 4)]
+        assert result.defaults is None
+
+    def test_param_decode_decodes_explicit_default_value(self) -> None:
+        """A defaults record keeps the transmitted default value."""
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC_WITH_DEFAULTS, 1, 1)
+        payload += b"\x14\x30RATE" + struct.pack("<ff", 12.5, 10.0)
+
+        result = MAVFTP.ftp_param_decode(payload)
+
+        assert result is not None
+        assert result.params == [(b"RATE", 12.5, 4)]
+        assert result.defaults == [(b"RATE", 10.0, 4)]
+
+    def test_param_decode_handles_shared_names_and_padding(self) -> None:
+        """Padding and a shared name prefix are ignored and reconstructed correctly."""
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 2, 2)
+        payload += b"\x01\x20FOO" + struct.pack("<b", 1)
+        payload += b"\x00\x00\x01\x02B" + struct.pack("<b", 2)
+
+        result = MAVFTP.ftp_param_decode(payload)
+
+        assert result is not None
+        assert result.params == [(b"FOO", 1, 1), (b"FOB", 2, 1)]
+
+    def test_param_decode_rejects_invalid_shared_name_prefix(self) -> None:
+        """A record cannot reference more prefix bytes than its predecessor contains."""
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 1, 1) + b"\x01\x0fA\x05"
 
         assert MAVFTP.ftp_param_decode(payload) is None
 
@@ -110,7 +153,7 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         THEN: It returns no data instead of attempting to unpack an incomplete header
         """
         # Arrange (Given): A header followed by only the parameter type byte
-        payload = struct.pack("<HHH", 0x671B, 1, 1) + b"\x01"
+        payload = PARAM_HEADER_STRUCT.pack(PARAM_MAGIC, 1, 1) + b"\x01"
 
         # Act (When): Decode the incomplete packed parameter data
         result = MAVFTP.ftp_param_decode(payload)

--- a/tests/test_backend_mavftp.py
+++ b/tests/test_backend_mavftp.py
@@ -13,10 +13,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import struct
 import unittest
 
 # from unittest.mock import patch
-from io import StringIO
+from io import BytesIO, StringIO
+from unittest.mock import Mock
 
 from pymavlink import mavutil
 
@@ -83,6 +85,58 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
 
         # Assert to check if the expected log is in log_output
         assert "This is a test log message" in log_output
+
+    def test_getparams_decode_failure_returns_ftp_error_instead_of_exiting(self) -> None:
+        """A malformed packed parameter file must be reported without terminating the app."""
+        self.mav_ftp.cmd_get = Mock()
+        self.mav_ftp.cmd_get.side_effect = lambda _args, callback, **_kwargs: callback(BytesIO(b"bad"))
+
+        result = self.mav_ftp.cmd_getparams(["values.param", "defaults.param"])
+
+        assert result.error_code == ERR_Fail
+
+    def test_param_decode_rejects_truncated_parameter_record(self) -> None:
+        """A packed parameter record missing its value must return no data."""
+        payload = struct.pack("<HHH", 0x671B, 1, 1) + b"\x01\x00A"
+
+        assert MAVFTP.ftp_param_decode(payload) is None
+
+    def test_param_decode_rejects_truncated_parameter_header(self) -> None:
+        """
+        A packed parameter file with an incomplete record header is rejected.
+
+        GIVEN: A valid packed-parameter file header followed by one record-header byte
+        WHEN: MAVFTP decodes the parameter data
+        THEN: It returns no data instead of attempting to unpack an incomplete header
+        """
+        # Arrange (Given): A header followed by only the parameter type byte
+        payload = struct.pack("<HHH", 0x671B, 1, 1) + b"\x01"
+
+        # Act (When): Decode the incomplete packed parameter data
+        result = MAVFTP.ftp_param_decode(payload)
+
+        # Assert (Then): The invalid file is rejected safely
+        assert result is None
+
+    def test_getparams_read_error_returns_ftp_error_instead_of_exiting(self) -> None:
+        """
+        A packed parameter file read error is returned to the caller.
+
+        GIVEN: MAVFTP supplies a parameter file handler whose read fails
+        WHEN: The parameter download callback processes the file
+        THEN: It returns an FTP failure rather than terminating the application
+        """
+        # Arrange (Given): A file handler that cannot be read
+        unreadable_file = Mock()
+        unreadable_file.read.side_effect = OSError("read failed")
+        self.mav_ftp.cmd_get = Mock()
+        self.mav_ftp.cmd_get.side_effect = lambda _args, callback, **_kwargs: callback(unreadable_file)
+
+        # Act (When): Request the packed parameters
+        result = self.mav_ftp.cmd_getparams(["values.param", "defaults.param"])
+
+        # Assert (Then): The caller receives a recoverable FTP failure
+        assert result.error_code == ERR_Fail
 
     @staticmethod
     def ftp_operation(seq: int, opcode: int, req_opcode: int, payload: bytearray) -> FTP_OP:


### PR DESCRIPTION
# Description

Improves robustness of MAVFTP parameter downloads by handling malformed/truncated packed parameter payloads and converting failures into clean error returns / fallbacks instead of terminating.

- Add bounds checks in ftp_param_decode() to detect truncated headers/records and fail gracefully.
- Replace sys.exit(1) during parameter file read/decode with MAVFTPReturn(ERR_Fail) so callers can recover.
- Wrap MAVFTP download path in FlightControllerParams with exception handling and add regression tests for the fallback behavior.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing performed
- [x] Tested on flight controller hardware
