### PR TITLE
fix(windows): bundle Tcl/Tk data in PyInstaller builds

### DIFF
--- a/.github/workflows/build_windows_macos.yml
+++ b/.github/workflows/build_windows_macos.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: 'windows-latest'
     strategy:
       matrix:
-        python-version: ['3.14']
+        # An exact version keeps the packaged Windows artifact reproducible.
+        python-version: ['3.14.6']
 
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -85,6 +86,10 @@ jobs:
           cd ardupilot_methodic_configurator
           copy ..\\windows\\ardupilot_methodic_configurator.spec
           pyinstaller --clean ardupilot_methodic_configurator.spec
+          if (-not (Test-Path "dist\\ardupilot_methodic_configurator\\_internal\\_tcl_data\\init.tcl") -or
+              -not (Test-Path "dist\\ardupilot_methodic_configurator\\_internal\\_tk_data\\tk.tcl")) {
+            throw "PyInstaller did not bundle the Tcl/Tk library data."
+          }
           del ardupilot_methodic_configurator.spec
 
       - name: Write the git commit hash to file
@@ -192,6 +197,8 @@ jobs:
         run: |
           python - <<'PY'
           import tkinter
+          interpreter = tkinter.Tcl()
+          print(f"Tcl library={interpreter.eval('info library')}")
           print(f"tkinter OK, TkVersion={tkinter.TkVersion}")
           PY
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,18 +103,21 @@ win_dist = [
     "pip==26.2",
     "pywin32==312",
     "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.2",
 ]
 
 mac_dist = [
     "pip==26.2",
     "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.2",
 ]
 
 linux_dist = [
     "pip==26.2",
     "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.2",
 ]
 
@@ -143,7 +146,7 @@ download = "https://github.com/ArduPilot/MethodicConfigurator/releases"
 changelog = "https://github.com/ArduPilot/MethodicConfigurator/releases"
 
 [tool.uv]
-required-version = ">=0.10.9"
+required-version = "==0.12.5"
 
 [tool.setuptools]
 # Rely on discovery for just the top-level package and specify data via package-data

--- a/windows/ardupilot_methodic_configurator.spec
+++ b/windows/ardupilot_methodic_configurator.spec
@@ -4,6 +4,28 @@
 from PyInstaller.utils.hooks import collect_submodules
 import certifi
 import os
+from pathlib import Path
+import sys
+
+
+def _find_tcl_tk_library(directory: Path, prefix: str) -> Path:
+    """Return the Tcl/Tk library directory shipped with the build Python."""
+    library_file = "init.tcl" if prefix == "tcl" else "tk.tcl"
+    candidates = sorted(
+        (path for path in directory.glob(f"{prefix}*") if path.is_dir() and (path / library_file).is_file()),
+        reverse=True,
+    )
+    if not candidates:
+        raise SystemExit(f"Could not find {prefix} library data below {directory}")
+    return candidates[0]
+
+
+# Set both variables before PyInstaller analyses tkinter so its built-in hook
+# collects the library data into _tcl_data and _tk_data. Without this, the
+# frozen application contains the DLLs but fails during the tkinter runtime hook.
+tcl_root = Path(sys.base_prefix) / "tcl"
+os.environ["TCL_LIBRARY"] = str(_find_tcl_tk_library(tcl_root, "tcl"))
+os.environ["TK_LIBRARY"] = str(_find_tcl_tk_library(tcl_root, "tk"))
 
 # Path to certifi's CA bundle
 certifi_cacert = certifi.where()


### PR DESCRIPTION
# Description

Pin the Windows build toolchain and verify bundled Tcl/Tk data to prevent the configurator from failing at startup.

## Checklist

- [x] Run pre-commit checks locally
- [x] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
