### PR TITLE
feat(log-analysis): add Plane flight segmentation

### DIFF
--- a/ardupilot_methodic_configurator/log_analysis/data_model_flight_segment.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_flight_segment.py
@@ -1,0 +1,58 @@
+"""
+Reusable time scope for one operational flight within an ArduPilot log.
+
+SPDX-FileCopyrightText: 2026 Donald Smith
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class FlightSegment:
+    """Inclusive canonical-second bounds for one operational flight."""
+
+    start_s: float
+    end_s: float
+    is_complete: bool
+
+    def __post_init__(self) -> None:
+        """Reject bounds that cannot define a usable time scope."""
+        if not math.isfinite(self.start_s) or not math.isfinite(self.end_s):
+            msg = "Flight segment bounds must be finite"
+            raise ValueError(msg)
+        if self.start_s > self.end_s:
+            msg = "Flight segment start_s must not be after end_s"
+            raise ValueError(msg)
+
+    @property
+    def duration_s(self) -> float:
+        """Return the segment duration in seconds."""
+        return self.end_s - self.start_s
+
+    def contains(self, start_s: float, end_s: float) -> bool:
+        """Return whether inclusive child bounds are valid and contained by this segment."""
+        return self.start_s <= start_s <= end_s <= self.end_s
+
+
+@dataclass(frozen=True, slots=True)
+class FlightSegmentationResult:
+    """Internal result that distinguishes unavailable evidence from no detected flights."""
+
+    available: bool
+    segments: tuple[FlightSegment, ...] = ()
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject contradictory availability, segment, and reason states."""
+        if self.available and self.reason is not None:
+            msg = "Available flight segmentation must not have an unavailable reason"
+            raise ValueError(msg)
+        if not self.available and self.segments:
+            msg = "Unavailable flight segmentation must not contain segments"
+            raise ValueError(msg)
+        if not self.available and not self.reason:
+            msg = "Unavailable flight segmentation requires a non-empty reason"
+            raise ValueError(msg)

--- a/ardupilot_methodic_configurator/log_analysis/data_model_plane_flight_segment.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_plane_flight_segment.py
@@ -22,7 +22,12 @@ from ardupilot_methodic_configurator.log_analysis.data_model_log_data import Log
 
 
 class PlaneFlightSegmentDetector:  # pylint: disable=too-few-public-methods
-    """Detect Plane flights from persistent GPS groundspeed evidence."""
+    """
+    Detect Plane flights from persistent GPS groundspeed evidence.
+
+    When the GPS schema provides the ``U`` flag, only samples from the active
+    receiver are used. Older schemas without that flag use all GPS records.
+    """
 
     MINIMUM_SPEED_M_S: ClassVar[float] = 5.0
     STALL_SPEED_MULTIPLIER: ClassVar[float] = 0.5
@@ -46,6 +51,10 @@ class PlaneFlightSegmentDetector:  # pylint: disable=too-few-public-methods
 
         time_s = log_data.get_field("GPS", "TimeUS")
         speed_m_s = log_data.get_field("GPS", "Spd")
+        if "U" in field_names:
+            active_receiver_samples = log_data.get_field("GPS", "U") == 1
+            time_s = time_s[active_receiver_samples]
+            speed_m_s = speed_m_s[active_receiver_samples]
         if not cls._usable_gps_values(time_s, speed_m_s):
             return FlightSegmentationResult(available=False, reason="GPS time or groundspeed values are unusable")
 

--- a/ardupilot_methodic_configurator/log_analysis/data_model_plane_flight_segment.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_plane_flight_segment.py
@@ -1,0 +1,132 @@
+"""
+ArduPlane operational-flight segmentation over AMC-native scaled log data.
+
+The thresholds are inherited reference heuristics from ArduPilotTools. They
+are not universal ArduPlane flight semantics.
+
+SPDX-FileCopyrightText: 2026 Donald Smith
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import math
+from typing import ClassVar
+
+import numpy as np
+
+from ardupilot_methodic_configurator.log_analysis.data_model_flight_segment import (
+    FlightSegment,
+    FlightSegmentationResult,
+)
+from ardupilot_methodic_configurator.log_analysis.data_model_log_data import LogData
+
+
+class PlaneFlightSegmentDetector:  # pylint: disable=too-few-public-methods
+    """Detect Plane flights from persistent GPS groundspeed evidence."""
+
+    MINIMUM_SPEED_M_S: ClassVar[float] = 5.0
+    STALL_SPEED_MULTIPLIER: ClassVar[float] = 0.5
+    START_PERSISTENCE_S: ClassVar[float] = 2.0
+    GROUND_PERSISTENCE_S: ClassVar[float] = 30.0
+
+    @classmethod
+    def detect(cls, log_data: LogData, parameters: dict[str, float]) -> FlightSegmentationResult:
+        """Return operational Plane segments, using scaled GPS times in seconds."""
+        gps = log_data.get_message_columns("GPS")
+        if gps is None or len(gps) == 0:
+            return FlightSegmentationResult(available=False, reason="GPS messages are unavailable")
+
+        field_names = gps.dtype.names or ()
+        missing_fields = [field_name for field_name in ("TimeUS", "Spd") if field_name not in field_names]
+        if missing_fields:
+            return FlightSegmentationResult(
+                available=False,
+                reason=f"GPS fields are unavailable: {', '.join(missing_fields)}",
+            )
+
+        time_s = log_data.get_field("GPS", "TimeUS")
+        speed_m_s = log_data.get_field("GPS", "Spd")
+        if not cls._usable_gps_values(time_s, speed_m_s):
+            return FlightSegmentationResult(available=False, reason="GPS time or groundspeed values are unusable")
+
+        threshold_m_s = cls._effective_speed_threshold(parameters)
+        segments = cls._detect_segments(time_s, speed_m_s, threshold_m_s)
+        return FlightSegmentationResult(available=True, segments=tuple(segments))
+
+    @staticmethod
+    def _usable_gps_values(time_s: np.ndarray, speed_m_s: np.ndarray) -> bool:
+        """Check required GPS evidence without inventing replacements for invalid samples."""
+        return (
+            len(time_s) == len(speed_m_s)
+            and len(time_s) > 0
+            and np.issubdtype(time_s.dtype, np.number)
+            and np.issubdtype(speed_m_s.dtype, np.number)
+            and bool(np.isfinite(time_s).all())
+            and bool(np.isfinite(speed_m_s).all())
+        )
+
+    @classmethod
+    def _effective_speed_threshold(cls, parameters: dict[str, float]) -> float:
+        """Return the minimum threshold, raised by half stall speed when usable."""
+        stall_speed = parameters.get("AIRSPEED_STALL")
+        if stall_speed is None or not math.isfinite(stall_speed):
+            return cls.MINIMUM_SPEED_M_S
+        return max(cls.MINIMUM_SPEED_M_S, cls.STALL_SPEED_MULTIPLIER * stall_speed)
+
+    @classmethod
+    def _detect_segments(
+        cls,
+        time_s: np.ndarray,
+        speed_m_s: np.ndarray,
+        threshold_m_s: float,
+    ) -> list[FlightSegment]:
+        """Apply the reference Plane persistence state machine."""
+        segments: list[FlightSegment] = []
+        flight_start_index: int | None = None
+        start_candidate_index: int | None = None
+        ground_candidate_index: int | None = None
+
+        for index, (timestamp_s, speed) in enumerate(zip(time_s, speed_m_s, strict=True)):
+            above_threshold = speed > threshold_m_s
+
+            if flight_start_index is None:
+                if above_threshold:
+                    if start_candidate_index is None:
+                        start_candidate_index = index
+                    if timestamp_s - time_s[start_candidate_index] >= cls.START_PERSISTENCE_S:
+                        flight_start_index = start_candidate_index
+                        start_candidate_index = None
+                        ground_candidate_index = None
+                else:
+                    start_candidate_index = None
+                continue
+
+            if above_threshold:
+                ground_candidate_index = None
+                continue
+
+            if ground_candidate_index is None:
+                ground_candidate_index = index
+
+            if timestamp_s - time_s[ground_candidate_index] >= cls.GROUND_PERSISTENCE_S:
+                segments.append(
+                    FlightSegment(
+                        start_s=float(time_s[flight_start_index]),
+                        end_s=float(time_s[ground_candidate_index - 1]),
+                        is_complete=True,
+                    )
+                )
+                flight_start_index = None
+                start_candidate_index = None
+                ground_candidate_index = None
+
+        if flight_start_index is not None:
+            segments.append(
+                FlightSegment(
+                    start_s=float(time_s[flight_start_index]),
+                    end_s=float(time_s[-1]),
+                    is_complete=False,
+                )
+            )
+
+        return segments

--- a/tests/test_data_model_plane_flight_segment.py
+++ b/tests/test_data_model_plane_flight_segment.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 
-"""Tests for reusable flight segments and ArduPlane flight segmentation."""
+"""
+Tests for reusable flight segments and ArduPlane flight segmentation.
+
+This file is part of ArduPilot Methodic Configurator. https://github.com/ArduPilot/MethodicConfigurator
+
+SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
 
 import numpy as np
 import pytest
@@ -204,6 +212,30 @@ def test_elapsed_timestamp_gaps_count_toward_persistence() -> None:
     result = _detect([(0.0, 6.0), (10.0, 6.0), (11.0, 0.0), (50.0, 0.0)])
 
     assert result.segments == (FlightSegment(start_s=0.0, end_s=10.0, is_complete=True),)
+
+
+def test_detector_uses_only_active_receiver_when_gps_use_flag_is_available() -> None:
+    log_data = LogData()
+    log_data.add_message_columns(
+        "GPS",
+        np.array(
+            [
+                (0.0, 6.0, 0, 1),
+                (0.1, 0.0, 1, 0),
+                (2.0, 6.0, 0, 1),
+                (2.1, 0.0, 1, 0),
+                (3.0, 0.0, 0, 1),
+                (3.1, 0.0, 1, 0),
+                (33.0, 0.0, 0, 1),
+                (33.1, 0.0, 1, 0),
+            ],
+            dtype=[("TimeUS", "f8"), ("Spd", "f8"), ("I", "u1"), ("U", "u1")],
+        ),
+    )
+
+    result = PlaneFlightSegmentDetector.detect(log_data, {})
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=2.0, is_complete=True),)
 
 
 def test_detector_uses_log_data_scaled_seconds() -> None:

--- a/tests/test_data_model_plane_flight_segment.py
+++ b/tests/test_data_model_plane_flight_segment.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+"""Tests for reusable flight segments and ArduPlane flight segmentation."""
+
+import numpy as np
+import pytest
+
+from ardupilot_methodic_configurator.log_analysis.data_model_flight_segment import FlightSegment, FlightSegmentationResult
+from ardupilot_methodic_configurator.log_analysis.data_model_log_data import LogData, MessageSchema
+from ardupilot_methodic_configurator.log_analysis.data_model_plane_flight_segment import PlaneFlightSegmentDetector
+
+
+def _gps_log(samples: list[tuple[float, float]], *, scaled_from_microseconds: bool = False) -> LogData:
+    log_data = LogData()
+    if scaled_from_microseconds:
+        columns = np.array(samples, dtype=[("TimeUS", "u8"), ("Spd", "f8")])
+        schema = MessageSchema(
+            name="GPS",
+            msg_type=1,
+            length=0,
+            format="Qf",
+            fields=["TimeUS", "Spd"],
+            stored_units=["µs", "m/s"],
+            scaled_units=["s", "m/s"],
+            multipliers=[1e-6, 1.0],
+            multipliers_applied_at_ingest=[False, False],
+            records=len(samples),
+        )
+    else:
+        columns = np.array(samples, dtype=[("TimeUS", "f8"), ("Spd", "f8")])
+        schema = None
+    log_data.add_message_columns("GPS", columns, schema)
+    return log_data
+
+
+def _detect(samples: list[tuple[float, float]], parameters: dict[str, float] | None = None) -> FlightSegmentationResult:
+    return PlaneFlightSegmentDetector.detect(_gps_log(samples), parameters or {})
+
+
+def test_flight_segment_accepts_valid_bounds_and_derives_duration() -> None:
+    segment = FlightSegment(start_s=10.0, end_s=15.5, is_complete=True)
+
+    assert segment.duration_s == 5.5
+
+
+def test_flight_segment_rejects_reversed_bounds() -> None:
+    with pytest.raises(ValueError, match="start_s must not be after end_s"):
+        FlightSegment(start_s=2.0, end_s=1.0, is_complete=True)
+
+
+def test_flight_segment_containment_is_inclusive() -> None:
+    segment = FlightSegment(start_s=10.0, end_s=20.0, is_complete=True)
+
+    assert segment.contains(10.0, 20.0)
+    assert segment.contains(12.0, 18.0)
+    assert not segment.contains(9.0, 18.0)
+    assert not segment.contains(12.0, 21.0)
+    assert not segment.contains(18.0, 12.0)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        FlightSegmentationResult(available=True),
+        FlightSegmentationResult(
+            available=True,
+            segments=(FlightSegment(start_s=1.0, end_s=2.0, is_complete=True),),
+        ),
+        FlightSegmentationResult(available=False, reason="GPS messages are unavailable"),
+    ],
+)
+def test_flight_segmentation_result_accepts_consistent_states(result: FlightSegmentationResult) -> None:
+    assert isinstance(result, FlightSegmentationResult)
+
+
+@pytest.mark.parametrize(
+    ("available", "segments", "reason", "error"),
+    [
+        (True, (), "unexpected reason", "must not have an unavailable reason"),
+        (
+            False,
+            (FlightSegment(start_s=1.0, end_s=2.0, is_complete=True),),
+            "GPS messages are unavailable",
+            "must not contain segments",
+        ),
+        (False, (), None, "requires a non-empty reason"),
+        (False, (), "", "requires a non-empty reason"),
+    ],
+)
+def test_flight_segmentation_result_rejects_contradictory_states(
+    available: bool,
+    segments: tuple[FlightSegment, ...],
+    reason: str | None,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        FlightSegmentationResult(available=available, segments=segments, reason=reason)
+
+
+def test_one_clear_flight_uses_first_motion_sample_and_last_sample_before_ground_run() -> None:
+    result = _detect([(0.0, 0.0), (5.0, 6.0), (7.0, 6.0), (9.0, 6.0), (10.0, 0.0), (40.0, 0.0)])
+
+    assert result.available is True
+    assert result.reason is None
+    assert result.segments == (FlightSegment(start_s=5.0, end_s=9.0, is_complete=True),)
+
+
+def test_two_flights_are_detected_after_persistent_ground_separation() -> None:
+    result = _detect(
+        [
+            (0.0, 6.0),
+            (2.0, 6.0),
+            (3.0, 0.0),
+            (33.0, 0.0),
+            (40.0, 6.0),
+            (42.0, 6.0),
+            (43.0, 0.0),
+            (73.0, 0.0),
+        ]
+    )
+
+    assert result.segments == (
+        FlightSegment(start_s=0.0, end_s=2.0, is_complete=True),
+        FlightSegment(start_s=40.0, end_s=42.0, is_complete=True),
+    )
+
+
+def test_short_low_speed_interval_does_not_split_flight() -> None:
+    result = _detect([(0.0, 6.0), (2.0, 6.0), (3.0, 0.0), (20.0, 6.0), (21.0, 0.0), (51.0, 0.0)])
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=20.0, is_complete=True),)
+
+
+def test_motion_run_shorter_than_start_persistence_does_not_create_flight() -> None:
+    result = _detect([(0.0, 6.0), (1.9, 6.0), (2.0, 0.0), (40.0, 0.0)])
+
+    assert result.available is True
+    assert not result.segments
+
+
+def test_interrupted_start_candidate_resets_to_next_motion_run() -> None:
+    result = _detect([(0.0, 6.0), (1.0, 0.0), (5.0, 6.0), (7.0, 6.0), (8.0, 0.0), (38.0, 0.0)])
+
+    assert result.segments == (FlightSegment(start_s=5.0, end_s=7.0, is_complete=True),)
+
+
+def test_final_open_flight_is_explicitly_incomplete() -> None:
+    result = _detect([(0.0, 6.0), (2.0, 6.0), (3.0, 0.0), (10.0, 0.0)])
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=10.0, is_complete=False),)
+
+
+@pytest.mark.parametrize(
+    ("log_data", "reason"),
+    [
+        (LogData(), "GPS messages are unavailable"),
+        (LogData(_raw_messages={"GPS": np.array([(1.0,)], dtype=[("Spd", "f8")])}), "GPS fields are unavailable: TimeUS"),
+        (
+            LogData(_raw_messages={"GPS": np.array([(1.0,)], dtype=[("TimeUS", "f8")])}),
+            "GPS fields are unavailable: Spd",
+        ),
+    ],
+)
+def test_missing_required_gps_evidence_makes_segmentation_unavailable(log_data: LogData, reason: str) -> None:
+    result = PlaneFlightSegmentDetector.detect(log_data, {})
+
+    assert result.available is False
+    assert not result.segments
+    assert result.reason == reason
+
+
+def test_non_finite_required_gps_evidence_makes_segmentation_unavailable() -> None:
+    result = _detect([(0.0, 6.0), (2.0, np.nan)])
+
+    assert result.available is False
+    assert result.reason == "GPS time or groundspeed values are unusable"
+
+
+def test_missing_stall_speed_uses_five_metre_per_second_threshold() -> None:
+    result = _detect([(0.0, 6.0), (2.0, 6.0)])
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=2.0, is_complete=False),)
+
+
+def test_stall_speed_raises_effective_threshold() -> None:
+    result = _detect([(0.0, 6.0), (2.0, 6.0), (3.0, 11.0), (5.0, 11.0)], {"AIRSPEED_STALL": 20.0})
+
+    assert result.segments == (FlightSegment(start_s=3.0, end_s=5.0, is_complete=False),)
+
+
+def test_speed_exactly_at_threshold_does_not_qualify() -> None:
+    result = _detect([(0.0, 5.0), (2.0, 5.0)])
+
+    assert not result.segments
+
+
+def test_exact_start_and_ground_persistence_boundaries_qualify() -> None:
+    result = _detect([(0.0, 6.0), (2.0, 6.0), (3.0, 5.0), (33.0, 5.0)])
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=2.0, is_complete=True),)
+
+
+def test_elapsed_timestamp_gaps_count_toward_persistence() -> None:
+    result = _detect([(0.0, 6.0), (10.0, 6.0), (11.0, 0.0), (50.0, 0.0)])
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=10.0, is_complete=True),)
+
+
+def test_detector_uses_log_data_scaled_seconds() -> None:
+    log_data = _gps_log(
+        [(0, 6.0), (2_000_000, 6.0), (3_000_000, 0.0), (33_000_000, 0.0)],
+        scaled_from_microseconds=True,
+    )
+
+    result = PlaneFlightSegmentDetector.detect(log_data, {})
+
+    assert result.segments == (FlightSegment(start_s=0.0, end_s=2.0, is_complete=True),)


### PR DESCRIPTION
## Summary

Adds reusable flight-segment data-model infrastructure and an AMC-native
ArduPlane flight-segment detector.

`FlightSegment` represents an operational flight interval independently of the
method used to detect it. `PlaneFlightSegmentDetector` contains the
Plane-specific detection heuristic.

The Plane detector operates directly on AMC's scaled `LogData` and logged
parameters. No separate parsing or extraction path is introduced.

## Plane detection

The initial detector preserves the behaviour of the existing ArduPilotTools
implementation:

- GPS ground speed is used as the flight evidence.
- Effective speed threshold is:
  `max(5.0 m/s, 0.5 * AIRSPEED_STALL)`.
- Flight start requires speed above the threshold for 2 seconds.
- Flight end requires speed at or below the threshold for 30 seconds.
- Short low-speed intervals therefore remain within the same operational
  flight.
- If the log ends before the final ground-persistence condition is satisfied,
  the segment ends at the final GPS sample and is marked `is_complete=False`.

These thresholds are inherited migration behaviour and are not intended to
represent universal ArduPlane flight-state semantics.

## Architecture

This is data-model infrastructure below the log-analysis subsystem registry.

It deliberately does not add:

- a new extraction/backend path;
- analysis or quality-model registry entries;
- frontend/reporting changes;
- APT parser or pandas dependencies;
- companion `.params` parsing;
- APT YAML configuration;
- landing detection or landing metrics.

Future Plane landing analysis can consume `FlightSegment` while following the
existing AMC quality-model / analysis-model architecture using `LogData` and
`LogAnalysisContext`.

## Validation

Focused tests:

- 26 passed.

Full non-SITL test suite:

- 4793 passed
- 6 skipped
- 53 deselected
- 4 xfailed

Ruff, mypy, Pyright and Pylint checks pass.

A real ArduPlane 4.7.0 BIN (`log_17.bin`) was also processed through AMC's
normal extraction and parameter paths. It produced four operational flight
segments, including an incomplete trailing segment.

The same BIN was independently processed by the existing ArduPilotTools
production path. AMC and APT detected the same four flights with matching
start/end boundaries and durations. The maximum observed boundary difference
was approximately 4.55e-13 seconds, attributable only to floating-point
normalization of `TimeUS`.

This provides behavioural parity with the existing APT detector while moving
the implementation onto AMC-native `LogData` and parameter infrastructure.