### PR TITLE
feat(log-analysis): add Plane landing analysis

### DIFF
--- a/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
@@ -1,0 +1,454 @@
+"""
+Availability and objective analysis for ArduPlane landing attempts.
+
+SPDX-FileCopyrightText: 2026 Donald Smith
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.log_analysis.data_model_availability_base import (
+    BaseLogAnalysisModel,
+    BaseLogAvailabilityModel,
+)
+from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_result import LogAnalysis, LogAnalysisResult
+from ardupilot_methodic_configurator.log_analysis.data_model_log_availability import (
+    AvailabilityIssue,
+    LogAvailabilityResult,
+    LogAvailabilityState,
+)
+from ardupilot_methodic_configurator.log_analysis.data_model_plane_flight_segment import PlaneFlightSegmentDetector
+from ardupilot_methodic_configurator.log_analysis.data_model_plane_landing import (
+    PlaneLandingAttempt,
+    PlaneLandingAttemptDetector,
+    PlaneLandingEndReason,
+    PlaneLandingEvidenceExtractor,
+    PlaneLandingFirmwareEvidence,
+    PlaneLandingFirmwareFlareEvidence,
+    PlaneLandingFirmwareMessageExtractor,
+    PlaneLandingMissionTargetExtractor,
+    PlaneLandingRangefinderEvidence,
+    PlaneLandingStage,
+    PlaneLandingStageEvidence,
+)
+
+if TYPE_CHECKING:
+    from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_context import LogAnalysisContext
+    from ardupilot_methodic_configurator.log_analysis.data_model_log_data import LogData
+    from ardupilot_methodic_configurator.log_analysis.data_model_parameter_history import ParameterHistory
+
+_REQUIRED_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("GPS", ("TimeUS", "Spd")),
+    ("BARO", ("TimeUS", "Alt")),
+    ("LAND", ("TimeUS", "stage")),
+    ("MODE", ("TimeUS", "ModeNum")),
+)
+
+_RFND_STATUS_NAMES: dict[int, str] = {
+    0: "NotConnected",
+    1: "NoData",
+    2: "OutOfRangeLow",
+    3: "OutOfRangeHigh",
+    4: "Good",
+}
+
+
+class PlaneLandingAvailabilityModel(BaseLogAvailabilityModel):
+    """Limit landing analysis to ArduPlane 4.7.x logs with required evidence."""
+
+    def check(self) -> LogAvailabilityResult:
+        """Validate identity, firmware, required fields, and operational-flight scope."""
+        if self.log_data.vehicle_type != "ArduPlane":
+            return self._unavailable(
+                _("Plane landing analysis is available only for ArduPlane logs"),
+                _("Log vehicle type is not ArduPlane"),
+            )
+
+        firmware_version = self.log_data.firmware_version
+        if firmware_version is None or firmware_version[:2] != (4, 7):
+            return self._unavailable(
+                _("Plane landing analysis currently supports ArduPlane 4.7.x only"),
+                _("Log firmware is not ArduPlane 4.7.x"),
+            )
+
+        issues = self._required_evidence_issues()
+        if issues:
+            return LogAvailabilityResult(
+                available=False,
+                state=LogAvailabilityState.WARNING,
+                reason=_("Required Plane landing-attempt evidence is unavailable"),
+                issues=issues,
+                name=_("Plane Landing"),
+            )
+
+        segmentation = PlaneFlightSegmentDetector.detect(self.log_data, self.parameters)
+        if not segmentation.available:
+            return self._unavailable(
+                _("Operational Plane flight segmentation is unavailable: {reason}").format(reason=segmentation.reason),
+                _("No usable operational Plane flight scope"),
+            )
+        if not segmentation.segments:
+            return self._unavailable(
+                _("No operational Plane flight segments were detected"),
+                _("No operational Plane flight scope contains landing evidence"),
+            )
+
+        return LogAvailabilityResult(
+            available=True,
+            state=LogAvailabilityState.INFO,
+            reason=_("Plane landing-attempt data present and good for analysis"),
+            issues=[],
+            name=_("Plane Landing"),
+        )
+
+    def _required_evidence_issues(self) -> list[AvailabilityIssue]:
+        issues: list[AvailabilityIssue] = []
+        for message_name, field_names in _REQUIRED_FIELDS:
+            records = self.log_data.get_message_columns(message_name)
+            if records is None or len(records) == 0:
+                issues.append(AvailabilityIssue(_("No {message} messages found").format(message=message_name)))
+                continue
+            issues.extend(self.check_fields_present(message_name, field_names))
+        return issues
+
+    @staticmethod
+    def _unavailable(reason: str, issue: str) -> LogAvailabilityResult:
+        return LogAvailabilityResult(
+            available=False,
+            state=LogAvailabilityState.WARNING,
+            reason=reason,
+            issues=[AvailabilityIssue(issue)],
+            name=_("Plane Landing"),
+        )
+
+
+class PlaneLandingAnalysis(BaseLogAnalysisModel):
+    """Report objective landing-attempt boundaries and time-scoped parameters."""
+
+    def __init__(self, log_data: LogData, context: LogAnalysisContext) -> None:
+        super().__init__(log_data, context)
+        self.parameter_history: ParameterHistory = context.parameter_history
+
+    def analyse(self) -> LogAnalysisResult:
+        """Detect attempts within every operational flight and flatten them into AMC results."""
+        segmentation = PlaneFlightSegmentDetector.detect(self.log_data, self.parameters)
+        if not segmentation.available:
+            return LogAnalysisResult(
+                available=False,
+                outcomes=[],
+                name=_("Plane Landing Analysis"),
+                reason=_("Operational Plane flight segmentation is unavailable"),
+            )
+
+        attempts = tuple(
+            attempt
+            for flight_segment in segmentation.segments
+            for attempt in PlaneLandingAttemptDetector.detect(self.log_data, flight_segment)
+        )
+        evidence_by_attempt = PlaneLandingEvidenceExtractor.extract_attempts(
+            self.log_data,
+            attempts,
+            self.parameter_history,
+        )
+        outcomes: list[LogAnalysis] = []
+        for attempt_number, (attempt, attempt_evidence) in enumerate(
+            zip(attempts, evidence_by_attempt, strict=True),
+            start=1,
+        ):
+            stage_evidence_items, rangefinder_evidence = attempt_evidence
+            outcomes.append(self._attempt_outcome(attempt_number, attempt))
+            for stage_evidence in stage_evidence_items:
+                outcomes.extend(self._stage_outcomes(attempt_number, stage_evidence))
+            for firmware_evidence in PlaneLandingFirmwareMessageExtractor.extract(self.log_data, attempt):
+                outcomes.extend(self._firmware_message_outcomes(attempt_number, firmware_evidence))
+            if rangefinder_evidence is not None:
+                outcomes.extend(self._rangefinder_outcomes(attempt_number, rangefinder_evidence))
+            target_distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(self.log_data, attempt)
+            if target_distance is not None:
+                outcomes.append(
+                    self._measurement_outcome(
+                        attempt_number,
+                        _("GPS-stop"),
+                        round(target_distance.time_s * 1_000_000),
+                        (_("computed distance to mission LAND target"), target_distance.distance_m, _("m")),
+                    )
+                )
+        reason = (
+            _("Detected {count} Plane landing attempt(s)").format(count=len(attempts))
+            if attempts
+            else _("No Plane landing attempts detected")
+        )
+        return LogAnalysisResult(
+            available=True,
+            outcomes=outcomes,
+            name=_("Plane Landing Analysis"),
+            reason=reason,
+        )
+
+    def _attempt_outcome(self, attempt_number: int, attempt: PlaneLandingAttempt) -> LogAnalysis:
+        flare_altitude_m = self._finite_parameter_value(self.parameter_history.value_at("LAND_FLARE_ALT", attempt.start_s))
+        mode_name = self._mode_name(attempt.mode_number)
+        parameter_evidence = (
+            _("LAND_FLARE_ALT at attempt start: {value:.2f} m").format(value=flare_altitude_m)
+            if flare_altitude_m is not None
+            else _("LAND_FLARE_ALT was unavailable at attempt start")
+        )
+        return LogAnalysis(
+            message=_(
+                "{mode_name} landing attempt {number}: {start:.3f} s to {end:.3f} s; "
+                "termination evidence: {end_reason}; {parameter_evidence}"
+            ).format(
+                mode_name=mode_name,
+                number=attempt_number,
+                start=attempt.start_s,
+                end=attempt.end_s,
+                end_reason=self._end_reason_text(attempt.end_reason),
+                parameter_evidence=parameter_evidence,
+            ),
+            timestamp_us=round(attempt.start_s * 1_000_000),
+            value=flare_altitude_m,
+        )
+
+    def _stage_outcomes(self, attempt_number: int, evidence: PlaneLandingStageEvidence) -> list[LogAnalysis]:
+        stage_name = _("preflare") if evidence.stage is PlaneLandingStage.PREFLARE else _("flare")
+        timestamp_us = round(evidence.time_s * 1_000_000)
+        outcomes = [
+            LogAnalysis(
+                message=_("Attempt {number}: LAND stage {stage} ({stage_name}) entered").format(
+                    number=attempt_number,
+                    stage=int(evidence.stage),
+                    stage_name=stage_name,
+                ),
+                timestamp_us=timestamp_us,
+                value=float(evidence.stage),
+            )
+        ]
+        measurements = (
+            (evidence.flight_height_m, _("LAND flight height"), _("m")),
+            (evidence.airspeed_m_s, _("ARSP airspeed"), _("m/s")),
+            (evidence.gps_ground_speed_m_s, _("GPS groundspeed"), _("m/s")),
+            (evidence.barometric_altitude_m, _("BARO altitude"), _("m")),
+            (evidence.barometric_sink_rate_m_s, _("BARO sink rate"), _("m/s")),
+            (evidence.rangefinder_distance_m, _("RFND distance"), _("m")),
+            (evidence.flare_to_gps_stop_s, _("Flare to GPS stop"), _("s")),
+        )
+        for value, measurement_name, unit in measurements:
+            if value is not None:
+                outcomes.append(
+                    self._measurement_outcome(
+                        attempt_number,
+                        stage_name,
+                        timestamp_us,
+                        (measurement_name, value, unit),
+                    )
+                )
+        if evidence.rangefinder_status is not None and not (
+            evidence.rangefinder_status == 4 and evidence.rangefinder_distance_m is not None
+        ):
+            outcomes.append(
+                self._rangefinder_status_outcome(
+                    attempt_number,
+                    stage_name,
+                    timestamp_us,
+                    evidence.rangefinder_status,
+                )
+            )
+        for parameter_name, value in evidence.parameter_values.items():
+            if value is not None:
+                outcomes.append(
+                    LogAnalysis(
+                        message=_("Attempt {number} {stage_name}: {parameter} effective value {value:g}").format(
+                            number=attempt_number,
+                            stage_name=stage_name,
+                            parameter=parameter_name,
+                            value=value,
+                        ),
+                        timestamp_us=timestamp_us,
+                        value=value,
+                    )
+                )
+        return outcomes
+
+    @staticmethod
+    def _rangefinder_status_outcome(
+        attempt_number: int,
+        stage_name: str,
+        timestamp_us: int,
+        status: int,
+    ) -> LogAnalysis:
+        """Report selected RFND firmware status without conflating it with lifecycle evidence."""
+        status_name = _RFND_STATUS_NAMES.get(status)
+        if status_name is None:
+            status_evidence = _("RFND status {status}").format(status=status)
+        elif status == 4:
+            status_evidence = _("RFND status {status_name} ({status}) — distance unavailable").format(
+                status_name=status_name,
+                status=status,
+            )
+        elif status in {2, 3}:
+            status_evidence = _("RFND status {status_name} ({status}) — not usable as Plane landing-height evidence").format(
+                status_name=status_name, status=status
+            )
+        else:
+            status_evidence = _("RFND status {status_name} ({status}) — no current range measurement").format(
+                status_name=status_name,
+                status=status,
+            )
+        return LogAnalysis(
+            message=_("Attempt {number} {stage_name}: {status_evidence}").format(
+                number=attempt_number,
+                stage_name=stage_name,
+                status_evidence=status_evidence,
+            ),
+            timestamp_us=timestamp_us,
+            value=float(status),
+        )
+
+    @staticmethod
+    def _finite_parameter_value(value: float | None) -> float | None:
+        """Treat non-finite event-time parameter values as unavailable evidence."""
+        return value if value is not None and math.isfinite(value) else None
+
+    def _firmware_message_outcomes(
+        self,
+        attempt_number: int,
+        evidence: PlaneLandingFirmwareEvidence,
+    ) -> list[LogAnalysis]:
+        timestamp_us = round(evidence.time_s * 1_000_000)
+        if isinstance(evidence, PlaneLandingFirmwareFlareEvidence):
+            measurements = (
+                (_("altitude"), evidence.altitude_m, _("m")),
+                (_("sink rate"), evidence.sink_rate_m_s, _("m/s")),
+                (_("groundspeed"), evidence.groundspeed_m_s, _("m/s")),
+                (_("distance to target"), evidence.distance_to_target_m, _("m")),
+            )
+            return [
+                self._measurement_outcome(attempt_number, _("firmware flare"), timestamp_us, measurement)
+                for measurement in measurements
+            ]
+        return [
+            self._measurement_outcome(
+                attempt_number,
+                _("firmware landing"),
+                timestamp_us,
+                (_("glide slope"), evidence.glide_slope_degrees, _("degrees")),
+            )
+        ]
+
+    def _rangefinder_outcomes(
+        self,
+        attempt_number: int,
+        evidence: PlaneLandingRangefinderEvidence,
+    ) -> list[LogAnalysis]:
+        """Flatten optional RFND lifecycle evidence into objective findings."""
+        outcomes: list[LogAnalysis] = []
+        timed_measurements = (
+            (
+                evidence.first_nonzero_time_s,
+                evidence.first_nonzero_distance_m,
+                _("first non-zero distance"),
+                _("m"),
+            ),
+            (
+                evidence.first_in_range_time_s,
+                evidence.first_in_range_distance_m,
+                _("first in-range distance"),
+                _("m"),
+            ),
+            (
+                evidence.continuous_time_s,
+                evidence.continuous_samples,
+                _("continuous acquisition sample count"),
+                _("samples"),
+            ),
+            (
+                evidence.last_disengagement_time_s,
+                evidence.last_disengagement_distance_m,
+                _("last disengagement distance"),
+                _("m"),
+            ),
+        )
+        for timestamp_s, value, measurement_name, unit in timed_measurements:
+            if timestamp_s is not None and value is not None:
+                outcomes.append(
+                    self._measurement_outcome(
+                        attempt_number,
+                        _("RFND lifecycle"),
+                        round(timestamp_s * 1_000_000),
+                        (measurement_name, float(value), unit),
+                    )
+                )
+        if (
+            evidence.last_disengagement_time_s is not None
+            and evidence.last_disengagement_distance_m is None
+            and evidence.last_disengagement_status is not None
+        ):
+            outcomes.append(
+                LogAnalysis(
+                    message=_(
+                        "Attempt {number} RFND lifecycle: last disengagement status {status_name} ({status}); "
+                        "distance unavailable"
+                    ).format(
+                        number=attempt_number,
+                        status_name=_RFND_STATUS_NAMES.get(
+                            evidence.last_disengagement_status,
+                            _("Unknown"),
+                        ),
+                        status=evidence.last_disengagement_status,
+                    ),
+                    timestamp_us=round(evidence.last_disengagement_time_s * 1_000_000),
+                    value=float(evidence.last_disengagement_status),
+                )
+            )
+        outcomes.append(
+            self._measurement_outcome(
+                attempt_number,
+                _("RFND lifecycle"),
+                round(evidence.attempt.end_s * 1_000_000),
+                (_("disengagement count"), float(evidence.disengagement_count), _("events")),
+            )
+        )
+        return outcomes
+
+    @staticmethod
+    def _measurement_outcome(
+        attempt_number: int,
+        stage_name: str,
+        timestamp_us: int,
+        measurement: tuple[str, float, str],
+    ) -> LogAnalysis:
+        measurement_name, value, unit = measurement
+        return LogAnalysis(
+            message=_("Attempt {number} {stage_name}: {measurement} {value:.3f} {unit}").format(
+                number=attempt_number,
+                stage_name=stage_name,
+                measurement=measurement_name,
+                value=value,
+                unit=unit,
+            ),
+            timestamp_us=timestamp_us,
+            value=value,
+        )
+
+    @staticmethod
+    def _end_reason_text(end_reason: PlaneLandingEndReason) -> str:
+        return {
+            PlaneLandingEndReason.ABORT: _("landing abort message"),
+            PlaneLandingEndReason.DISARM: _("throttle disarm message"),
+            PlaneLandingEndReason.MODE_EXIT: _("transition away from landing mode"),
+            PlaneLandingEndReason.GPS_STOP: _("sustained GPS low-speed rollout completion"),
+            PlaneLandingEndReason.STAGE_RESTART: _("new LAND active-stage transition"),
+            PlaneLandingEndReason.FLIGHT_SEGMENT_END: _("operational flight-segment boundary"),
+        }[end_reason]
+
+    @staticmethod
+    def _mode_name(mode_number: int) -> str:
+        return {
+            PlaneLandingAttemptDetector.AUTO_MODE_NUMBER: "AUTO",
+            PlaneLandingAttemptDetector.AUTOLAND_MODE_NUMBER: "AUTOLAND",
+        }[mode_number]

--- a/ardupilot_methodic_configurator/log_analysis/data_model_log_analysis.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_log_analysis.py
@@ -29,6 +29,10 @@ from ardupilot_methodic_configurator.log_analysis.data_model_availability_fft im
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_gnss import GPSLogAvailabilityModel
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_imu import ImuLogAnalysis, ImuLogAvailabilityModel
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_mode import ModeLogAvailabilityModel
+from ardupilot_methodic_configurator.log_analysis.data_model_availability_plane_landing import (
+    PlaneLandingAnalysis,
+    PlaneLandingAvailabilityModel,
+)
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_pm import PmLogAvailabilityModel
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_vibe import VibeLogAnalysis, VibeLogAvailabilityModel
 from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_context import LogAnalysisContext
@@ -72,6 +76,7 @@ LOG_ANALYSIS_SUBSYSTEMS: tuple[LogAnalysisModelSpec, ...] = (
     LogAnalysisModelSpec("pm", PmLogAvailabilityModel),
     LogAnalysisModelSpec("arm", ArmLogAvailabilityModel),
     LogAnalysisModelSpec("mode", ModeLogAvailabilityModel),
+    LogAnalysisModelSpec("plane_landing", PlaneLandingAvailabilityModel, PlaneLandingAnalysis),
 )
 
 ResolvedModel = tuple[type[BaseLogAvailabilityModel], type[BaseLogAnalysisModel] | None, str]

--- a/ardupilot_methodic_configurator/log_analysis/data_model_plane_landing.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_plane_landing.py
@@ -1,0 +1,1609 @@
+"""
+AMC-native ArduPlane landing-attempt detection within operational flights.
+
+SPDX-FileCopyrightText: 2026 Donald Smith
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# pylint: disable=too-many-lines
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum, IntEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, ClassVar
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from ardupilot_methodic_configurator.log_analysis.data_model_flight_segment import FlightSegment
+    from ardupilot_methodic_configurator.log_analysis.data_model_log_data import LogData
+    from ardupilot_methodic_configurator.log_analysis.data_model_parameter_history import ParameterHistory
+
+
+def _active_gps_fields(log_data: LogData, *field_names: str) -> tuple[np.ndarray, ...] | None:
+    """Return scaled GPS fields, restricted to the active receiver when ``U`` is available."""
+    gps = log_data.get_message_columns("GPS")
+    if gps is None:
+        return None
+    names = gps.dtype.names or ()
+    if not set(field_names).issubset(names):
+        return None
+
+    values = tuple(log_data.get_field("GPS", field_name) for field_name in field_names)
+    if "U" not in names:
+        return values
+
+    active_receiver_samples = log_data.get_field("GPS", "U") == 1
+    return tuple(field_values[active_receiver_samples] for field_values in values)
+
+
+def _instance_zero_fields(
+    log_data: LogData,
+    message_name: str,
+    instance_field: str,
+    *field_names: str,
+) -> tuple[np.ndarray, ...] | None:
+    """Return message fields restricted to instance zero when the selector exists."""
+    records = log_data.get_message_columns(message_name)
+    if records is None:
+        return None
+    names = records.dtype.names or ()
+    if not set(field_names).issubset(names):
+        return None
+
+    values = tuple(log_data.get_field(message_name, field_name) for field_name in field_names)
+    if instance_field not in names:
+        return values
+
+    instance_zero_samples = log_data.get_field(message_name, instance_field) == 0
+    return tuple(field_values[instance_zero_samples] for field_values in values)
+
+
+def _owns_attempt_observation(attempt: PlaneLandingAttempt, timestamp_s: float) -> bool:
+    """Return whether an observational record belongs to ``attempt``."""
+    if attempt.end_reason is PlaneLandingEndReason.STAGE_RESTART:
+        return attempt.start_s <= timestamp_s < attempt.end_s
+    return attempt.start_s <= timestamp_s <= attempt.end_s
+
+
+_FIRMWARE_FLARE_PREFIX = "Flare "
+
+
+def _finite_float(value: object) -> float | None:
+    """Return a finite float, or ``None`` when conversion is unsafe."""
+    try:
+        converted = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return converted if math.isfinite(converted) else None
+
+
+def _prefixed_value(text: str, prefix: str, suffix: str) -> float | None:
+    """Parse a finite value between a required prefix and suffix."""
+    if not text.startswith(prefix):
+        return None
+    value_text = text[len(prefix) :]
+    suffix_index = value_text.find(suffix)
+    if suffix_index < 0:
+        return None
+    return _finite_float(value_text[:suffix_index].strip())
+
+
+def _named_value(text: str, name: str) -> float | None:
+    """Parse a finite whitespace-delimited named value."""
+    name_index = text.find(name)
+    if name_index < 0:
+        return None
+    value_parts = text[name_index + len(name) :].split()
+    return _finite_float(value_parts[0]) if value_parts else None
+
+
+def _firmware_flare_values(message: str) -> tuple[float, float, float, float] | None:
+    """Return all values from a complete finite firmware Flare message."""
+    altitude_m = _prefixed_value(message, _FIRMWARE_FLARE_PREFIX, "m")
+    sink_rate_m_s = _named_value(message, "sink=")
+    groundspeed_m_s = _named_value(message, "speed=")
+    distance_to_target_m = _named_value(message, "dist=")
+    if altitude_m is None or sink_rate_m_s is None or groundspeed_m_s is None or distance_to_target_m is None:
+        return None
+    return altitude_m, sink_rate_m_s, groundspeed_m_s, distance_to_target_m
+
+
+class PlaneLandingEndReason(str, Enum):
+    """Objective evidence that bounded a detected Plane landing attempt."""
+
+    ABORT = "abort"
+    DISARM = "disarm"
+    MODE_EXIT = "mode"
+    GPS_STOP = "gps"
+    STAGE_RESTART = "stage_restart"
+    FLIGHT_SEGMENT_END = "flight_segment_end"
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingAttempt:
+    """One landing attempt contained by an operational Plane flight."""
+
+    flight_segment: FlightSegment
+    start_s: float
+    end_s: float
+    end_reason: PlaneLandingEndReason
+    mode_number: int
+    start_stage: int = 1
+    previous_attempt_end_s: float | None = None
+
+    def __post_init__(self) -> None:
+        """Require a non-empty attempt fully contained by its parent flight."""
+        if self.start_s >= self.end_s:
+            msg = "Plane landing attempt start_s must be before end_s"
+            raise ValueError(msg)
+        if not self.flight_segment.contains(self.start_s, self.end_s):
+            msg = "Plane landing attempt must be contained by its flight segment"
+            raise ValueError(msg)
+        if self.start_stage not in {1, 2, 3}:
+            msg = "Plane landing attempt start_stage must be an active LAND stage"
+            raise ValueError(msg)
+
+    @property
+    def duration_s(self) -> float:
+        """Return the attempt duration in seconds."""
+        return self.end_s - self.start_s
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaneLandingAttemptNeighbors:
+    """Attempt boundaries immediately adjacent to one landing start."""
+
+    next_start_s: float | None
+    previous_end_s: float | None
+
+
+class PlaneLandingAttemptDetector:  # pylint: disable=too-few-public-methods
+    """Detect APT-compatible landing-attempt boundaries in one flight."""
+
+    AUTO_MODE_NUMBER: ClassVar[int] = 10
+    AUTOLAND_MODE_NUMBER: ClassVar[int] = 26
+    LANDING_MODE_NUMBERS: ClassVar[frozenset[int]] = frozenset({AUTO_MODE_NUMBER, AUTOLAND_MODE_NUMBER})
+    GPS_STOP_SPEED_M_S: ClassVar[float] = 3.0
+    GPS_STOP_PERSISTENCE_S: ClassVar[float] = 2.0
+
+    @classmethod
+    def detect(cls, log_data: LogData, flight_segment: FlightSegment) -> tuple[PlaneLandingAttempt, ...]:
+        """Return all landing-mode-gated active LAND sequences within ``flight_segment``."""
+        land = log_data.get_message_columns("LAND")
+        mode = log_data.get_message_columns("MODE")
+        if (
+            land is None
+            or mode is None
+            or not {"TimeUS", "stage"}.issubset(land.dtype.names or ())
+            or not {"TimeUS", "ModeNum"}.issubset(mode.dtype.names or ())
+        ):
+            return ()
+
+        starts = cls._landing_starts(log_data, flight_segment)
+        attempts: list[PlaneLandingAttempt] = []
+        for index, start in enumerate(starts):
+            next_start_s = starts[index + 1][0] if index + 1 < len(starts) else None
+            previous_attempt_end_s = attempts[-1].end_s if attempts else None
+            attempt = cls._attempt_for_start(
+                log_data,
+                flight_segment,
+                start,
+                _PlaneLandingAttemptNeighbors(next_start_s, previous_attempt_end_s),
+            )
+            if attempt is not None:
+                attempts.append(attempt)
+        return tuple(attempts)
+
+    @classmethod
+    def _landing_starts(  # pylint: disable=too-many-locals
+        cls, log_data: LogData, flight_segment: FlightSegment
+    ) -> list[tuple[float, int, int]]:
+        """Find the first active stage of each LAND sequence in a supported mode."""
+        land_time_s = log_data.get_field("LAND", "TimeUS")
+        land_stage = log_data.get_field("LAND", "stage")
+        mode_time_s = log_data.get_field("MODE", "TimeUS")
+        mode_number = log_data.get_field("MODE", "ModeNum")
+
+        starts: list[tuple[float, int, int]] = []
+        previous_stage: int | None = None
+        for timestamp, stage_value in zip(land_time_s, land_stage, strict=True):
+            stage = int(stage_value)
+            timestamp_s = float(timestamp)
+            if not flight_segment.start_s <= timestamp_s <= flight_segment.end_s:
+                continue
+
+            entered_active_sequence = stage in {1, 2, 3} and previous_stage in {None, 0}
+            restarted_active_sequence = stage == 1 and previous_stage in {2, 3}
+            previous_stage = stage
+            if not entered_active_sequence and not restarted_active_sequence:
+                continue
+            landing_mode = cls._landing_mode_at(mode_time_s, mode_number, timestamp_s)
+            if landing_mode is not None:
+                starts.append((timestamp_s, landing_mode, stage))
+        return starts
+
+    @classmethod
+    def _attempt_for_start(  # pylint: disable=too-many-locals
+        cls,
+        log_data: LogData,
+        flight_segment: FlightSegment,
+        start: tuple[float, int, int],
+        neighbors: _PlaneLandingAttemptNeighbors,
+    ) -> PlaneLandingAttempt | None:
+        start_s, mode_number, start_stage = start
+        candidates = cls._message_termination_events(log_data, flight_segment, start_s)
+        mode_exit = cls._first_mode_exit(log_data, flight_segment, start_s, mode_number)
+        if mode_exit is not None:
+            candidates.append(mode_exit)
+        if neighbors.next_start_s is not None:
+            candidates.append((neighbors.next_start_s, PlaneLandingEndReason.STAGE_RESTART))
+
+        if candidates:
+            provisional_end_s, provisional_end_reason = min(
+                candidates,
+                key=lambda item: (item[0], item[1] is not PlaneLandingEndReason.STAGE_RESTART),
+            )
+        else:
+            provisional_end_s = flight_segment.end_s
+            provisional_end_reason = PlaneLandingEndReason.FLIGHT_SEGMENT_END
+
+        if provisional_end_s <= start_s:
+            return None
+        provisional_attempt = PlaneLandingAttempt(
+            flight_segment=flight_segment,
+            start_s=start_s,
+            end_s=provisional_end_s,
+            end_reason=provisional_end_reason,
+            mode_number=mode_number,
+            start_stage=start_stage,
+            previous_attempt_end_s=neighbors.previous_end_s,
+        )
+        corroboration_s = cls._first_final_evidence(log_data, provisional_attempt)
+        if corroboration_s is not None:
+            gps_stop_s = cls._first_gps_stop(log_data, provisional_attempt, max(start_s, corroboration_s))
+            if gps_stop_s is not None:
+                candidates.append((gps_stop_s, PlaneLandingEndReason.GPS_STOP))
+
+        if candidates:
+            end_s, end_reason = min(
+                candidates,
+                key=lambda item: (item[0], item[1] is not PlaneLandingEndReason.STAGE_RESTART),
+            )
+        else:
+            end_s, end_reason = provisional_end_s, provisional_end_reason
+        if end_s <= start_s:
+            # The earliest supported termination leaves no positive-duration attempt; do not substitute a later one.
+            return None
+        return PlaneLandingAttempt(
+            flight_segment=flight_segment,
+            start_s=start_s,
+            end_s=end_s,
+            end_reason=end_reason,
+            mode_number=mode_number,
+            start_stage=start_stage,
+            previous_attempt_end_s=neighbors.previous_end_s,
+        )
+
+    @classmethod
+    def _first_final_evidence(cls, log_data: LogData, attempt: PlaneLandingAttempt) -> float | None:
+        """Return earliest valid LAND-stage-3 or associated firmware Flare evidence."""
+        candidates: list[float] = []
+        for timestamp, stage_value in zip(
+            log_data.get_field("LAND", "TimeUS"),
+            log_data.get_field("LAND", "stage"),
+            strict=True,
+        ):
+            timestamp_s = _finite_float(timestamp)
+            if timestamp_s is not None and int(stage_value) == 3 and _owns_attempt_observation(attempt, timestamp_s):
+                candidates.append(timestamp_s)
+        candidates.extend(
+            evidence.time_s
+            for evidence in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+            if isinstance(evidence, PlaneLandingFirmwareFlareEvidence)
+        )
+        return min(candidates) if candidates else None
+
+    @classmethod
+    def _landing_mode_at(cls, time_s: np.ndarray, mode_number: np.ndarray, timestamp_s: float) -> int | None:
+        current_mode: int | None = None
+        for mode_timestamp, number in zip(time_s, mode_number, strict=True):
+            if float(mode_timestamp) > timestamp_s:
+                break
+            current_mode = int(number)
+        return current_mode if current_mode in cls.LANDING_MODE_NUMBERS else None
+
+    @classmethod
+    def _message_termination_events(
+        cls,
+        log_data: LogData,
+        flight_segment: FlightSegment,
+        start_s: float,
+    ) -> list[tuple[float, PlaneLandingEndReason]]:
+        messages = log_data.get_message_columns("MSG")
+        if messages is None or not {"TimeUS", "Message"}.issubset(messages.dtype.names or ()):
+            return []
+
+        events: list[tuple[float, PlaneLandingEndReason]] = []
+        for timestamp, message in zip(
+            log_data.get_field("MSG", "TimeUS"),
+            log_data.get_field("MSG", "Message"),
+            strict=True,
+        ):
+            timestamp_s = float(timestamp)
+            if not start_s < timestamp_s <= flight_segment.end_s:
+                continue
+            text = str(message).lower()
+            if "landing aborted" in text:
+                events.append((timestamp_s, PlaneLandingEndReason.ABORT))
+            elif "throttle disarmed" in text:
+                events.append((timestamp_s, PlaneLandingEndReason.DISARM))
+        return events
+
+    @classmethod
+    def _first_mode_exit(
+        cls,
+        log_data: LogData,
+        flight_segment: FlightSegment,
+        start_s: float,
+        start_mode_number: int,
+    ) -> tuple[float, PlaneLandingEndReason] | None:
+        for timestamp, new_mode_number in zip(
+            log_data.get_field("MODE", "TimeUS"),
+            log_data.get_field("MODE", "ModeNum"),
+            strict=True,
+        ):
+            timestamp_s = float(timestamp)
+            if start_s < timestamp_s <= flight_segment.end_s and int(new_mode_number) != start_mode_number:
+                return timestamp_s, PlaneLandingEndReason.MODE_EXIT
+        return None
+
+    @classmethod
+    def _first_gps_stop(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        evaluation_start_s: float,
+    ) -> float | None:
+        gps_fields = _active_gps_fields(log_data, "TimeUS", "Spd")
+        if gps_fields is None:
+            return None
+        time_s, speed_m_s = gps_fields
+
+        below_since_s: float | None = None
+        for timestamp, speed in zip(time_s, speed_m_s, strict=True):
+            timestamp_s = float(timestamp)
+            if timestamp_s < evaluation_start_s:
+                continue
+            if not _owns_attempt_observation(attempt, timestamp_s):
+                break
+            if float(speed) < cls.GPS_STOP_SPEED_M_S:
+                if below_since_s is None:
+                    below_since_s = timestamp_s
+                elif timestamp_s - below_since_s >= cls.GPS_STOP_PERSISTENCE_S:
+                    return below_since_s
+            else:
+                below_since_s = None
+        return None
+
+
+class PlaneLandingStage(IntEnum):
+    """ArduPlane LAND controller stages used by the first evidence slice."""
+
+    PREFLARE = 2
+    FLARE = 3
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingStageEvidence:  # pylint: disable=too-many-instance-attributes
+    """Objective measurements associated with one LAND stage transition."""
+
+    attempt: PlaneLandingAttempt
+    stage: PlaneLandingStage
+    time_s: float
+    flight_height_m: float | None = None
+    airspeed_m_s: float | None = None
+    gps_ground_speed_m_s: float | None = None
+    barometric_altitude_m: float | None = None
+    barometric_sink_rate_m_s: float | None = None
+    rangefinder_distance_m: float | None = None
+    rangefinder_status: int | None = None
+    flare_to_gps_stop_s: float | None = None
+    parameter_values: Mapping[str, float | None] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Require the event to lie inside its attempt and freeze parameter evidence."""
+        if not _owns_attempt_observation(self.attempt, self.time_s):
+            msg = "Plane landing stage evidence must be contained by its landing attempt"
+            raise ValueError(msg)
+        object.__setattr__(self, "parameter_values", MappingProxyType(dict(self.parameter_values)))
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingFirmwareFlareEvidence:
+    """Objective values reported by one complete attempt-scoped firmware Flare message."""
+
+    attempt: PlaneLandingAttempt
+    time_s: float
+    altitude_m: float
+    sink_rate_m_s: float
+    groundspeed_m_s: float
+    distance_to_target_m: float
+    associated_before_attempt_start: bool = False
+
+    def __post_init__(self) -> None:
+        """Require the firmware message to lie inside its landing attempt."""
+        ordinary_evidence = not self.associated_before_attempt_start and _owns_attempt_observation(self.attempt, self.time_s)
+        left_truncated_evidence = (
+            self.associated_before_attempt_start
+            and self.attempt.start_stage == 3
+            and self.attempt.flight_segment.start_s <= self.time_s < self.attempt.start_s
+        )
+        if not ordinary_evidence and not left_truncated_evidence:
+            msg = "Plane firmware flare evidence must be contained by its landing attempt"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingFirmwareGlideSlopeEvidence:
+    """Objective glide-slope value reported by one attempt-scoped firmware message."""
+
+    attempt: PlaneLandingAttempt
+    time_s: float
+    glide_slope_degrees: float
+
+    def __post_init__(self) -> None:
+        """Require the firmware message to lie inside its landing attempt."""
+        if not _owns_attempt_observation(self.attempt, self.time_s):
+            msg = "Plane firmware glide-slope evidence must be contained by its landing attempt"
+            raise ValueError(msg)
+
+
+PlaneLandingFirmwareEvidence = PlaneLandingFirmwareFlareEvidence | PlaneLandingFirmwareGlideSlopeEvidence
+
+
+class PlaneLandingFirmwareMessageExtractor:  # pylint: disable=too-few-public-methods
+    """Parse the first complete APT-recognized firmware messages inside one attempt."""
+
+    _FLARE_PREFIX: ClassVar[str] = _FIRMWARE_FLARE_PREFIX
+    _GLIDE_SLOPE_PREFIX: ClassVar[str] = "Landing glide slope "
+
+    @classmethod
+    def extract(cls, log_data: LogData, attempt: PlaneLandingAttempt) -> tuple[PlaneLandingFirmwareEvidence, ...]:
+        """Return chronological, complete firmware flare and glide-slope evidence."""
+        messages = log_data.get_message_columns("MSG")
+        if messages is None or not {"TimeUS", "Message"}.issubset(messages.dtype.names or ()):
+            return ()
+
+        candidates: list[tuple[float, str]] = []
+        for timestamp, message in zip(
+            log_data.get_field("MSG", "TimeUS"),
+            log_data.get_field("MSG", "Message"),
+            strict=True,
+        ):
+            timestamp_s = _finite_float(timestamp)
+            if timestamp_s is not None and _owns_attempt_observation(attempt, timestamp_s):
+                candidates.append((timestamp_s, str(message)))
+
+        evidence: list[PlaneLandingFirmwareEvidence] = []
+        flare_found = False
+        glide_slope_found = False
+        for timestamp_s, message in sorted(candidates, key=lambda item: item[0]):
+            if not flare_found and message.startswith(cls._FLARE_PREFIX):
+                flare = cls._parse_flare(attempt, timestamp_s, message)
+                if flare is not None:
+                    evidence.append(flare)
+                    flare_found = True
+            elif not glide_slope_found and message.startswith(cls._GLIDE_SLOPE_PREFIX):
+                glide_slope = cls._parse_glide_slope(attempt, timestamp_s, message)
+                if glide_slope is not None:
+                    evidence.append(glide_slope)
+                    glide_slope_found = True
+        if not flare_found:
+            left_truncated_flare = cls._left_truncated_flare(log_data, attempt)
+            if left_truncated_flare is not None:
+                evidence.append(left_truncated_flare)
+        return tuple(sorted(evidence, key=lambda item: item.time_s))
+
+    @classmethod
+    def _parse_flare(
+        cls,
+        attempt: PlaneLandingAttempt,
+        timestamp_s: float,
+        message: str,
+    ) -> PlaneLandingFirmwareFlareEvidence | None:
+        values = _firmware_flare_values(message)
+        if values is None:
+            return None
+        altitude_m, sink_rate_m_s, groundspeed_m_s, distance_to_target_m = values
+        return PlaneLandingFirmwareFlareEvidence(
+            attempt=attempt,
+            time_s=timestamp_s,
+            altitude_m=altitude_m,
+            sink_rate_m_s=sink_rate_m_s,
+            groundspeed_m_s=groundspeed_m_s,
+            distance_to_target_m=distance_to_target_m,
+        )
+
+    @classmethod
+    def _left_truncated_flare(  # noqa: PLR0911  # pylint: disable=too-many-locals,too-many-return-statements
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+    ) -> PlaneLandingFirmwareFlareEvidence | None:
+        """Return the narrowly associated pre-start Flare for a stage-3-opened attempt."""
+        if attempt.start_stage != 3:
+            return None
+        messages = log_data.get_message_columns("MSG")
+        land = log_data.get_message_columns("LAND")
+        if messages is None or land is None:
+            return None
+
+        complete_candidates: list[tuple[float, str]] = []
+        for timestamp, message in zip(
+            log_data.get_field("MSG", "TimeUS"),
+            log_data.get_field("MSG", "Message"),
+            strict=True,
+        ):
+            timestamp_s = _finite_float(timestamp)
+            text = str(message)
+            if (
+                timestamp_s is not None
+                and attempt.flight_segment.start_s <= timestamp_s < attempt.start_s
+                and _firmware_flare_values(text) is not None
+            ):
+                complete_candidates.append((timestamp_s, text))
+        if not complete_candidates:
+            return None
+        timestamp_s, message = max(complete_candidates, key=lambda item: item[0])
+
+        if attempt.previous_attempt_end_s is not None and timestamp_s <= attempt.previous_attempt_end_s:
+            return None
+
+        preceding_land_times = [
+            land_time_s
+            for timestamp in log_data.get_field("LAND", "TimeUS")
+            if (land_time_s := _finite_float(timestamp)) is not None and land_time_s < attempt.start_s
+        ]
+        if not preceding_land_times or timestamp_s <= max(preceding_land_times):
+            return None
+        if cls._association_is_invalidated(log_data, attempt, timestamp_s):
+            return None
+
+        values = _firmware_flare_values(message)
+        if values is None:  # pragma: no cover - guarded while collecting candidates
+            return None
+        altitude_m, sink_rate_m_s, groundspeed_m_s, distance_to_target_m = values
+        return PlaneLandingFirmwareFlareEvidence(
+            attempt=attempt,
+            time_s=timestamp_s,
+            altitude_m=altitude_m,
+            sink_rate_m_s=sink_rate_m_s,
+            groundspeed_m_s=groundspeed_m_s,
+            distance_to_target_m=distance_to_target_m,
+            associated_before_attempt_start=True,
+        )
+
+    @classmethod
+    def _association_is_invalidated(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        flare_time_s: float,
+    ) -> bool:
+        """Return whether termination or mode evidence breaks a pre-start association."""
+        flare_mode = PlaneLandingAttemptDetector._landing_mode_at(  # noqa: SLF001  # pylint: disable=protected-access
+            log_data.get_field("MODE", "TimeUS"),
+            log_data.get_field("MODE", "ModeNum"),
+            flare_time_s,
+        )
+        if flare_mode is not None and flare_mode != attempt.mode_number:
+            return True
+        for timestamp, message in zip(
+            log_data.get_field("MSG", "TimeUS"),
+            log_data.get_field("MSG", "Message"),
+            strict=True,
+        ):
+            timestamp_s = _finite_float(timestamp)
+            if timestamp_s is None or not flare_time_s < timestamp_s < attempt.start_s:
+                continue
+            text = str(message).lower()
+            if "landing aborted" in text or "throttle disarmed" in text:
+                return True
+        for timestamp, mode_number in zip(
+            log_data.get_field("MODE", "TimeUS"),
+            log_data.get_field("MODE", "ModeNum"),
+            strict=True,
+        ):
+            timestamp_s = _finite_float(timestamp)
+            if (
+                timestamp_s is not None
+                and flare_time_s < timestamp_s < attempt.start_s
+                and int(mode_number) != attempt.mode_number
+            ):
+                return True
+        return False
+
+    @classmethod
+    def _parse_glide_slope(
+        cls,
+        attempt: PlaneLandingAttempt,
+        timestamp_s: float,
+        message: str,
+    ) -> PlaneLandingFirmwareGlideSlopeEvidence | None:
+        glide_slope_degrees = _prefixed_value(message, cls._GLIDE_SLOPE_PREFIX, " degrees")
+        if glide_slope_degrees is None:
+            return None
+        return PlaneLandingFirmwareGlideSlopeEvidence(
+            attempt=attempt,
+            time_s=timestamp_s,
+            glide_slope_degrees=glide_slope_degrees,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaneLandingRangefinderSample:
+    """One firmware-selected landing rangefinder sample."""
+
+    time_s: float
+    distance_m: float | None
+    instance: int
+    status: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaneLandingRangefinderBreak:
+    """One logged RFND frame unusable for deterministic landing selection."""
+
+    time_s: float
+
+
+_RangefinderSelectionEvent = _PlaneLandingRangefinderSample | _PlaneLandingRangefinderBreak
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaneLandingRangefinderSelection:
+    """Ordered selected observations and explicit acquisition-continuity breaks."""
+
+    events: tuple[_RangefinderSelectionEvent, ...]
+
+    @property
+    def samples(self) -> tuple[_PlaneLandingRangefinderSample, ...]:
+        """Return only valid observations for stage-point evidence."""
+        return tuple(event for event in self.events if isinstance(event, _PlaneLandingRangefinderSample))
+
+
+_RangefinderRow = tuple[float, float | None, int, int | None, int]
+_RangefinderFrame = tuple[_RangefinderRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaneLandingRangefinderData:
+    """Immutable RFND representation prepared once for one analysis request."""
+
+    frames: tuple[_RangefinderFrame, ...] | None = None
+    legacy_samples: tuple[_PlaneLandingRangefinderSample, ...] | None = None
+
+
+class _PlaneLandingRangefinderSelector:  # pylint: disable=too-many-locals
+    """Select Plane's configured landing rangefinder from RFND update frames."""
+
+    LANDING_ORIENTATION_PARAMETER: ClassVar[str] = "RNGFND_LND_ORNT"
+    GOOD_STATUS: ClassVar[int] = 4
+    CURRENT_DATA_STATUSES: ClassVar[frozenset[int]] = frozenset({2, 3, 4})
+    MAX_RANGE_PARAMETERS: ClassVar[tuple[str, ...]] = (
+        "RNGFND1_MAX",
+        "RNGFND2_MAX",
+        "RNGFND3_MAX",
+        "RNGFND4_MAX",
+        "RNGFND5_MAX",
+        "RNGFND6_MAX",
+        "RNGFND7_MAX",
+        "RNGFND8_MAX",
+        "RNGFND9_MAX",
+        "RNGFNDA_MAX",
+    )
+
+    @classmethod
+    def select(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+    ) -> _PlaneLandingRangefinderSelection | None:
+        """Return selected attempt-scoped samples from request-local prepared RFND data."""
+        prepared = cls.prepare(log_data)
+        return cls.select_prepared(prepared, attempt, parameter_history) if prepared is not None else None
+
+    @classmethod
+    def prepare(cls, log_data: LogData) -> _PlaneLandingRangefinderData | None:
+        """Build immutable logical frames or legacy samples once for the complete log."""
+        records = log_data.get_message_columns("RFND")
+        if records is None or not {"TimeUS", "Dist"}.issubset(records.dtype.names or ()):
+            return None
+        names = records.dtype.names or ()
+        if "Orient" not in names:
+            return _PlaneLandingRangefinderData(legacy_samples=cls._legacy_samples(log_data))
+        if "Instance" not in names:
+            return None
+
+        rows = cls._rows(log_data)
+        if not rows:
+            return None
+        return _PlaneLandingRangefinderData(frames=cls._frames(rows))
+
+    @classmethod
+    def select_prepared(
+        cls,
+        prepared: _PlaneLandingRangefinderData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+    ) -> _PlaneLandingRangefinderSelection | None:
+        """Select causally configured samples, degrading ambiguous frames locally."""
+        if prepared.legacy_samples is not None:
+            return _PlaneLandingRangefinderSelection(
+                tuple(sample for sample in prepared.legacy_samples if _owns_attempt_observation(attempt, sample.time_s))
+            )
+        if prepared.frames is None:
+            return None
+
+        orientation_by_instance = {row[2]: row[4] for frame in prepared.frames for row in frame if row[0] < attempt.start_s}
+        events: list[_RangefinderSelectionEvent] = []
+        for frame in prepared.frames:
+            scoped_rows = [row for row in frame if _owns_attempt_observation(attempt, row[0])]
+            if not scoped_rows:
+                continue
+            for row in scoped_rows:
+                orientation_by_instance[row[2]] = row[4]
+            frame_time_s = scoped_rows[0][0]
+            required_orientation = cls._integer(parameter_history.value_at(cls.LANDING_ORIENTATION_PARAMETER, frame_time_s))
+            if required_orientation is None:
+                events.append(_PlaneLandingRangefinderBreak(frame_time_s))
+                continue
+
+            configured_instances = {
+                instance for instance, orientation in orientation_by_instance.items() if orientation == required_orientation
+            }
+            matching_rows = [row for row in scoped_rows if row[4] == required_orientation]
+            matching_instances = {row[2] for row in matching_rows}
+            if not matching_rows or matching_instances != configured_instances:
+                events.append(_PlaneLandingRangefinderBreak(frame_time_s))
+                continue
+            if len(matching_rows) != len(matching_instances):
+                events.append(_PlaneLandingRangefinderBreak(frame_time_s))
+                continue
+
+            if len(matching_rows) > 1:
+                if any(row[3] is None for row in matching_rows):
+                    events.append(_PlaneLandingRangefinderBreak(frame_time_s))
+                    continue
+                good_rows = [row for row in matching_rows if row[3] == cls.GOOD_STATUS]
+                selected_row = min(good_rows or matching_rows, key=lambda row: row[2])
+            else:
+                selected_row = matching_rows[0]
+            events.append(
+                _PlaneLandingRangefinderSample(
+                    time_s=selected_row[0],
+                    distance_m=selected_row[1],
+                    instance=selected_row[2],
+                    status=selected_row[3],
+                )
+            )
+        return _PlaneLandingRangefinderSelection(tuple(events))
+
+    @classmethod
+    def maximum_range_parameter(cls, instance: int) -> str | None:
+        """Return the bounded ArduPlane 4.7 MAX parameter for ``instance``."""
+        return cls.MAX_RANGE_PARAMETERS[instance] if 0 <= instance < len(cls.MAX_RANGE_PARAMETERS) else None
+
+    @classmethod
+    def _legacy_samples(
+        cls,
+        log_data: LogData,
+    ) -> tuple[_PlaneLandingRangefinderSample, ...]:
+        """Preserve instance-zero or single-stream behavior when Orient is absent."""
+        records = log_data.get_message_columns("RFND")
+        if records is None:
+            return ()
+        names = records.dtype.names or ()
+        samples: list[_PlaneLandingRangefinderSample] = []
+        for index, (timestamp, distance) in enumerate(
+            zip(log_data.get_field("RFND", "TimeUS"), log_data.get_field("RFND", "Dist"), strict=True)
+        ):
+            instance = cls._integer(records["Instance"][index]) if "Instance" in names else 0
+            if instance != 0:
+                continue
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is None:
+                continue
+            status = cls._integer(records["Stat"][index]) if "Stat" in names else None
+            samples.append(
+                _PlaneLandingRangefinderSample(
+                    time_s=timestamp_s,
+                    distance_m=cls._finite_float(distance),
+                    instance=0,
+                    status=status,
+                )
+            )
+        return tuple(samples)
+
+    @classmethod
+    def _rows(cls, log_data: LogData) -> list[_RangefinderRow]:
+        """Return finite-timestamp RFND rows in logged order."""
+        records = log_data.get_message_columns("RFND")
+        if records is None:
+            return []
+        names = records.dtype.names or ()
+        rows: list[_RangefinderRow] = []
+        for index, (timestamp, distance) in enumerate(
+            zip(log_data.get_field("RFND", "TimeUS"), log_data.get_field("RFND", "Dist"), strict=True)
+        ):
+            timestamp_s = cls._finite_float(timestamp)
+            instance = cls._integer(records["Instance"][index])
+            orientation = cls._integer(records["Orient"][index])
+            status = cls._integer(records["Stat"][index]) if "Stat" in names else None
+            if timestamp_s is None or instance is None or orientation is None:
+                continue
+            rows.append((timestamp_s, cls._finite_float(distance), instance, status, orientation))
+        return rows
+
+    @staticmethod
+    def _frames(rows: list[_RangefinderRow]) -> tuple[_RangefinderFrame, ...]:
+        """Group sequential instance-ordered RFND rows emitted by one firmware update."""
+        frames: list[_RangefinderFrame] = []
+        current: list[_RangefinderRow] = []
+        for row in rows:
+            if current and row[2] <= current[-1][2]:
+                frames.append(tuple(current))
+                current = []
+            current.append(row)
+        if current:
+            frames.append(tuple(current))
+        return tuple(frames)
+
+    @staticmethod
+    def _finite_float(value: object) -> float | None:
+        try:
+            converted = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return converted if math.isfinite(converted) else None
+
+    @classmethod
+    def _integer(cls, value: object) -> int | None:
+        converted = cls._finite_float(value)
+        return int(converted) if converted is not None and converted.is_integer() else None
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingRangefinderEvidence:  # pylint: disable=too-many-instance-attributes
+    """APT-compatible RFND lifecycle evidence scoped to one landing attempt."""
+
+    attempt: PlaneLandingAttempt
+    first_nonzero_time_s: float | None
+    first_nonzero_distance_m: float | None
+    first_in_range_time_s: float | None
+    first_in_range_distance_m: float | None
+    continuous_time_s: float | None
+    continuous_samples: int | None
+    disengagement_count: int
+    last_disengagement_time_s: float | None
+    last_disengagement_distance_m: float | None
+    last_disengagement_status: int | None = None
+
+
+class PlaneLandingRangefinderEvidenceExtractor:  # pylint: disable=too-few-public-methods,too-many-boolean-expressions,too-many-locals
+    """Extract the optional attempt-scoped RFND lifecycle used by APT."""
+
+    ZERO_THRESHOLD_M: ClassVar[float] = 0.05
+    CONTINUOUS_SECONDS: ClassVar[float] = 1.0
+
+    @classmethod
+    def extract(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+    ) -> PlaneLandingRangefinderEvidence | None:
+        """Return RFND lifecycle evidence, or ``None`` when scoped RFND is unusable."""
+        selection = _PlaneLandingRangefinderSelector.select(log_data, attempt, parameter_history)
+        return cls._extract_selected(attempt, parameter_history, selection)
+
+    @classmethod
+    def _extract_selected(  # noqa: PLR0915  # pylint: disable=too-many-statements
+        cls,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+        selection: _PlaneLandingRangefinderSelection | None,
+    ) -> PlaneLandingRangefinderEvidence | None:
+        """Build lifecycle evidence from the same selected sequence used by stage evidence."""
+        if selection is None:
+            return None
+        selected_samples = selection.samples
+        if not selected_samples or not any(sample.distance_m is not None for sample in selected_samples):
+            return None
+
+        events = tuple(sorted(selection.events, key=lambda event: event.time_s))
+        required_samples = cls._required_continuous_samples(tuple(sample.time_s for sample in selected_samples))
+        first_nonzero_time_s: float | None = None
+        first_nonzero_distance_m: float | None = None
+        first_in_range_time_s: float | None = None
+        first_in_range_distance_m: float | None = None
+        continuous_time_s: float | None = None
+        continuous_samples: int | None = None
+        disengagement_count = 0
+        last_disengagement_time_s: float | None = None
+        last_disengagement_distance_m: float | None = None
+        last_disengagement_status: int | None = None
+        run_timestamps_s: list[float] = []
+        rangefinder_active = False
+
+        for event in events:
+            if isinstance(event, _PlaneLandingRangefinderBreak):
+                rangefinder_active = False
+                run_timestamps_s.clear()
+                continue
+            sample = event
+            timestamp_s = sample.time_s
+            distance_m = sample.distance_m
+            has_current_data = sample.status is None or sample.status in _PlaneLandingRangefinderSelector.CURRENT_DATA_STATUSES
+            if not has_current_data or distance_m is None or distance_m <= cls.ZERO_THRESHOLD_M:
+                if rangefinder_active:
+                    disengagement_count += 1
+                    last_disengagement_time_s = timestamp_s
+                    last_disengagement_distance_m = None if sample.status in {0, 1} else cls._apt_distance(distance_m)
+                    last_disengagement_status = sample.status
+                    rangefinder_active = False
+                run_timestamps_s.clear()
+                continue
+
+            rangefinder_active = True
+            if first_nonzero_time_s is None:
+                first_nonzero_time_s = timestamp_s
+                first_nonzero_distance_m = cls._apt_distance(distance_m)
+
+            maximum_range_parameter = _PlaneLandingRangefinderSelector.maximum_range_parameter(sample.instance)
+            maximum_range_m = (
+                parameter_history.value_at(maximum_range_parameter, timestamp_s)
+                if maximum_range_parameter is not None
+                else None
+            )
+            if (
+                first_in_range_time_s is None
+                and (sample.status is None or sample.status == _PlaneLandingRangefinderSelector.GOOD_STATUS)
+                and maximum_range_m is not None
+                and math.isfinite(maximum_range_m)
+                and distance_m <= maximum_range_m
+            ):
+                first_in_range_time_s = timestamp_s
+                first_in_range_distance_m = cls._apt_distance(distance_m)
+
+            if not run_timestamps_s or timestamp_s > run_timestamps_s[-1]:
+                run_timestamps_s.append(timestamp_s)
+            if continuous_time_s is not None or required_samples is None or len(run_timestamps_s) < required_samples:
+                continue
+            qualifying_timestamps_s = run_timestamps_s[-required_samples:]
+            if qualifying_timestamps_s[-1] - qualifying_timestamps_s[0] <= cls.CONTINUOUS_SECONDS:
+                continuous_time_s = qualifying_timestamps_s[0]
+                continuous_samples = required_samples
+
+        return PlaneLandingRangefinderEvidence(
+            attempt=attempt,
+            first_nonzero_time_s=first_nonzero_time_s,
+            first_nonzero_distance_m=first_nonzero_distance_m,
+            first_in_range_time_s=first_in_range_time_s,
+            first_in_range_distance_m=first_in_range_distance_m,
+            continuous_time_s=continuous_time_s,
+            continuous_samples=continuous_samples,
+            disengagement_count=disengagement_count,
+            last_disengagement_time_s=last_disengagement_time_s,
+            last_disengagement_distance_m=last_disengagement_distance_m,
+            last_disengagement_status=last_disengagement_status,
+        )
+
+    @classmethod
+    def _required_continuous_samples(cls, timestamps_s: tuple[float, ...]) -> int | None:
+        """Return a cadence-derived count that requires multiple observations."""
+        if len(timestamps_s) < 2:
+            return None
+        timestamp_deltas_s = np.diff(np.asarray(timestamps_s))
+        usable_deltas_s = timestamp_deltas_s[np.isfinite(timestamp_deltas_s) & (timestamp_deltas_s > 0.0)]
+        if usable_deltas_s.size == 0:
+            return None
+        median_delta_s = float(np.median(usable_deltas_s))
+        sample_rate_hz = 1.0 / median_delta_s
+        return max(2, round(sample_rate_hz * cls.CONTINUOUS_SECONDS))
+
+    @staticmethod
+    def _apt_distance(distance_m: float | None) -> float | None:
+        """Preserve APT's two-decimal event-detail round trip for distances."""
+        return None if distance_m is None else float(f"{distance_m:.2f}")
+
+    @staticmethod
+    def _finite_float(value: object) -> float | None:
+        try:
+            converted = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return converted if math.isfinite(converted) else None
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingMissionTarget:
+    """One unambiguous mission LAND target applicable to a landing attempt."""
+
+    attempt: PlaneLandingAttempt
+    snapshot_completed_s: float
+    latitude_deg: float
+    longitude_deg: float
+
+    def __post_init__(self) -> None:
+        """Require the mission snapshot to have completed before the attempt began."""
+        if self.snapshot_completed_s > self.attempt.start_s:
+            msg = "Plane mission target snapshot must complete at or before the landing attempt"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class PlaneLandingTargetDistanceEvidence:
+    """Distance from the scoped GPS-stop position to the applicable mission LAND target."""
+
+    attempt: PlaneLandingAttempt
+    time_s: float
+    aircraft_position_time_s: float
+    aircraft_latitude_deg: float
+    aircraft_longitude_deg: float
+    target: PlaneLandingMissionTarget
+    distance_m: float
+
+    def __post_init__(self) -> None:
+        """Require GPS-stop and position evidence to remain inside the associated attempt."""
+        if self.attempt.end_reason is not PlaneLandingEndReason.GPS_STOP or self.time_s != self.attempt.end_s:
+            msg = "Plane target-distance evidence requires the authoritative GPS-stop attempt end"
+            raise ValueError(msg)
+        if not self.attempt.start_s <= self.aircraft_position_time_s <= self.attempt.end_s:
+            msg = "Plane target-distance position must be contained by its landing attempt"
+            raise ValueError(msg)
+        if self.target.attempt is not self.attempt:
+            msg = "Plane mission target must be associated with the same landing attempt"
+            raise ValueError(msg)
+
+
+_MissionCommandRecord = tuple[float, object, object, object, object, object]
+
+
+class PlaneLandingMissionTargetExtractor:
+    """Reconstruct APT-compatible mission targets and GPS-stop distance evidence."""
+
+    MAV_CMD_NAV_LAND: ClassVar[int] = 21
+    EARTH_RADIUS_M: ClassVar[float] = 6_371_000.0
+    _CMD_FIELDS: ClassVar[set[str]] = {"TimeUS", "CTot", "CNum", "CId", "Lat", "Lng"}
+
+    @classmethod
+    def target_for_attempt(cls, log_data: LogData, attempt: PlaneLandingAttempt) -> PlaneLandingMissionTarget | None:
+        """Return the single LAND target from the latest complete applicable CMD snapshot."""
+        snapshots = cls._complete_cmd_snapshots(log_data)
+        applicable = [snapshot for snapshot in snapshots if snapshot[-1][0] <= attempt.start_s]
+        if not applicable:
+            return None
+
+        snapshot = applicable[-1]
+        land_rows: list[_MissionCommandRecord] = []
+        for row in snapshot:
+            command_id = cls._integer(row[3])
+            if command_id is None:
+                return None
+            if command_id == cls.MAV_CMD_NAV_LAND:
+                land_rows.append(row)
+        if len(land_rows) != 1:
+            return None
+
+        latitude_deg = cls._finite_float(land_rows[0][4])
+        longitude_deg = cls._finite_float(land_rows[0][5])
+        if latitude_deg is None or longitude_deg is None or (latitude_deg == 0.0 and longitude_deg == 0.0):
+            return None
+        return PlaneLandingMissionTarget(
+            attempt=attempt,
+            snapshot_completed_s=snapshot[-1][0],
+            latitude_deg=latitude_deg,
+            longitude_deg=longitude_deg,
+        )
+
+    @classmethod
+    def distance_at_gps_stop(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+    ) -> PlaneLandingTargetDistanceEvidence | None:
+        """Return target distance when mission and attempt-scoped GPS-stop position are available."""
+        if attempt.end_reason is not PlaneLandingEndReason.GPS_STOP:
+            return None
+        target = cls.target_for_attempt(log_data, attempt)
+        if target is None:
+            return None
+
+        nearest_position = cls._nearest_gps_position(log_data, attempt, attempt.end_s)
+        if nearest_position is None:
+            return None
+
+        position_time_s, aircraft_latitude_deg, aircraft_longitude_deg = nearest_position
+        return PlaneLandingTargetDistanceEvidence(
+            attempt=attempt,
+            time_s=attempt.end_s,
+            aircraft_position_time_s=position_time_s,
+            aircraft_latitude_deg=aircraft_latitude_deg,
+            aircraft_longitude_deg=aircraft_longitude_deg,
+            target=target,
+            distance_m=cls._horizontal_distance(
+                target.latitude_deg,
+                target.longitude_deg,
+                aircraft_latitude_deg,
+                aircraft_longitude_deg,
+            ),
+        )
+
+    @classmethod
+    def _complete_cmd_snapshots(cls, log_data: LogData) -> tuple[tuple[_MissionCommandRecord, ...], ...]:
+        """Return complete consecutive CMD snapshots in timestamp order."""
+        snapshots: list[tuple[_MissionCommandRecord, ...]] = []
+        current: list[_MissionCommandRecord] = []
+        expected_total: int | None = None
+        expected_number = 0
+        for row in sorted(cls._cmd_records(log_data), key=lambda record: record[0]):
+            total = cls._integer(row[1])
+            number = cls._integer(row[2])
+            if total is None or number is None:
+                current = []
+                expected_total = None
+                expected_number = 0
+                continue
+
+            if total <= 0 or number < 0 or number >= total:
+                current = []
+                expected_total = None
+                expected_number = 0
+                continue
+            if number == 0:
+                current = [row]
+                expected_total = total
+                expected_number = 1
+            elif not current or total != expected_total or number != expected_number:
+                current = []
+                expected_total = None
+                expected_number = 0
+                continue
+            else:
+                current.append(row)
+                expected_number += 1
+            if expected_number == expected_total:
+                snapshots.append(tuple(current))
+                current = []
+                expected_total = None
+                expected_number = 0
+        return tuple(snapshots)
+
+    @classmethod
+    def _cmd_records(cls, log_data: LogData) -> list[_MissionCommandRecord]:
+        """Return finite-timestamp CMD fields in their scaled representation."""
+        cmd = log_data.get_message_columns("CMD")
+        if cmd is None or not cls._CMD_FIELDS.issubset(cmd.dtype.names or ()):
+            return []
+
+        records: list[_MissionCommandRecord] = []
+        for timestamp, total, number, command_id, latitude, longitude in zip(
+            log_data.get_field("CMD", "TimeUS"),
+            log_data.get_field("CMD", "CTot"),
+            log_data.get_field("CMD", "CNum"),
+            log_data.get_field("CMD", "CId"),
+            log_data.get_field("CMD", "Lat"),
+            log_data.get_field("CMD", "Lng"),
+            strict=True,
+        ):
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is not None:
+                records.append((timestamp_s, total, number, command_id, latitude, longitude))
+        return records
+
+    @classmethod
+    def _nearest_gps_position(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        target_time_s: float,
+    ) -> tuple[float, float, float] | None:
+        """Return the nearest usable attempt-scoped GPS position."""
+        gps_fields = _active_gps_fields(log_data, "TimeUS", "Lat", "Lng")
+        if gps_fields is None:
+            return None
+
+        nearest_position: tuple[float, object, object] | None = None
+        nearest_offset: float | None = None
+        for timestamp, latitude, longitude in zip(*gps_fields, strict=True):
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is None or not _owns_attempt_observation(attempt, timestamp_s):
+                continue
+            offset = abs(timestamp_s - target_time_s)
+            if nearest_offset is None or offset < nearest_offset:
+                nearest_offset = offset
+                nearest_position = (timestamp_s, latitude, longitude)
+        if nearest_position is None:
+            return None
+        timestamp_s, latitude, longitude = nearest_position
+        latitude_deg = cls._finite_float(latitude)
+        longitude_deg = cls._finite_float(longitude)
+        if latitude_deg is None or longitude_deg is None:
+            return None
+        return timestamp_s, latitude_deg, longitude_deg
+
+    @classmethod
+    def _horizontal_distance(
+        cls,
+        latitude_one_deg: float,
+        longitude_one_deg: float,
+        latitude_two_deg: float,
+        longitude_two_deg: float,
+    ) -> float:
+        """Return the APT great-circle horizontal distance in metres."""
+        latitude_one_rad = math.radians(latitude_one_deg)
+        latitude_two_rad = math.radians(latitude_two_deg)
+        delta_latitude = math.radians(latitude_two_deg - latitude_one_deg)
+        delta_longitude = math.radians(longitude_two_deg - longitude_one_deg)
+        haversine = (
+            math.sin(delta_latitude / 2.0) ** 2
+            + math.cos(latitude_one_rad) * math.cos(latitude_two_rad) * math.sin(delta_longitude / 2.0) ** 2
+        )
+        central_angle = 2.0 * math.atan2(math.sqrt(haversine), math.sqrt(1.0 - haversine))
+        return cls.EARTH_RADIUS_M * central_angle
+
+    @staticmethod
+    def _finite_float(value: object) -> float | None:
+        try:
+            converted = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return converted if math.isfinite(converted) else None
+
+    @staticmethod
+    def _integer(value: object) -> int | None:
+        try:
+            converted: int = int(value)  # type: ignore[call-overload]
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return converted
+
+
+class PlaneLandingEvidenceExtractor:  # pylint: disable=too-many-locals
+    """Collect APT-compatible stage and nearest-telemetry evidence for one attempt."""
+
+    BARO_RATE_HALF_WINDOW_S: ClassVar[float] = 0.5
+
+    _PARAMETERS_BY_STAGE: ClassVar[dict[PlaneLandingStage, tuple[str, ...]]] = {
+        PlaneLandingStage.PREFLARE: ("LAND_PF_ALT", "LAND_PF_SEC"),
+        PlaneLandingStage.FLARE: ("LAND_FLARE_ALT", "LAND_FLARE_SEC", "LAND_PITCH_DEG"),
+    }
+
+    @classmethod
+    def extract(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+    ) -> tuple[PlaneLandingStageEvidence, ...]:
+        """Return the first preflare and flare transitions found inside ``attempt``."""
+        rangefinder_selection = _PlaneLandingRangefinderSelector.select(log_data, attempt, parameter_history)
+        return cls._extract_selected(log_data, attempt, parameter_history, rangefinder_selection)
+
+    @classmethod
+    def extract_attempts(
+        cls,
+        log_data: LogData,
+        attempts: tuple[PlaneLandingAttempt, ...],
+        parameter_history: ParameterHistory,
+    ) -> tuple[tuple[tuple[PlaneLandingStageEvidence, ...], PlaneLandingRangefinderEvidence | None], ...]:
+        """Prepare RFND once and reuse one selected sequence per attempt."""
+        prepared = _PlaneLandingRangefinderSelector.prepare(log_data)
+        evidence: list[tuple[tuple[PlaneLandingStageEvidence, ...], PlaneLandingRangefinderEvidence | None]] = []
+        for attempt in attempts:
+            selection = (
+                _PlaneLandingRangefinderSelector.select_prepared(prepared, attempt, parameter_history)
+                if prepared is not None
+                else None
+            )
+            evidence.append(
+                (
+                    cls._extract_selected(log_data, attempt, parameter_history, selection),
+                    PlaneLandingRangefinderEvidenceExtractor._extract_selected(  # noqa: SLF001  # pylint: disable=protected-access
+                        attempt,
+                        parameter_history,
+                        selection,
+                    ),
+                )
+            )
+        return tuple(evidence)
+
+    @classmethod
+    def _extract_selected(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+        rangefinder_selection: _PlaneLandingRangefinderSelection | None,
+    ) -> tuple[PlaneLandingStageEvidence, ...]:
+        """Build stage evidence from a preselected attempt-scoped RFND sequence."""
+        return tuple(
+            cls._build_stage_evidence(log_data, attempt, parameter_history, rangefinder_selection, transition)
+            for transition in cls._stage_transitions(log_data, attempt)
+        )
+
+    @classmethod
+    def _stage_transitions(
+        cls, log_data: LogData, attempt: PlaneLandingAttempt
+    ) -> list[tuple[PlaneLandingStage, float, float | None]]:
+        """Return the first scoped transition into each supported LAND stage."""
+        land = log_data.get_message_columns("LAND")
+        if land is None or not {"TimeUS", "stage"}.issubset(land.dtype.names or ()):
+            return []
+
+        flight_heights = log_data.get_field("LAND", "fh") if "fh" in (land.dtype.names or ()) else None
+        transitions: list[tuple[PlaneLandingStage, float, float | None]] = []
+        seen_stages: set[PlaneLandingStage] = set()
+        previous_stage: int | None = None
+
+        for index, (timestamp, stage_value) in enumerate(
+            zip(log_data.get_field("LAND", "TimeUS"), log_data.get_field("LAND", "stage"), strict=True)
+        ):
+            timestamp_s = float(timestamp)
+            if not _owns_attempt_observation(attempt, timestamp_s):
+                continue
+            stage_number = int(stage_value)
+            changed_stage = stage_number != previous_stage
+            previous_stage = stage_number
+            try:
+                stage = PlaneLandingStage(stage_number)
+            except ValueError:
+                continue
+            if not changed_stage or stage in seen_stages:
+                continue
+            seen_stages.add(stage)
+            transitions.append(
+                (
+                    stage,
+                    timestamp_s,
+                    cls._finite_float(flight_heights[index]) if flight_heights is not None else None,
+                )
+            )
+        return transitions
+
+    @classmethod
+    def _build_stage_evidence(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        parameter_history: ParameterHistory,
+        rangefinder_selection: _PlaneLandingRangefinderSelection | None,
+        transition: tuple[PlaneLandingStage, float, float | None],
+    ) -> PlaneLandingStageEvidence:
+        stage, time_s, flight_height_m = transition
+        rangefinder_distance_m, rangefinder_status = cls._nearest_rangefinder_observation(
+            rangefinder_selection.samples if rangefinder_selection is not None else None,
+            time_s,
+        )
+        return PlaneLandingStageEvidence(
+            attempt=attempt,
+            stage=stage,
+            time_s=time_s,
+            flight_height_m=flight_height_m,
+            airspeed_m_s=cls._nearest_value(log_data, attempt, ("ARSP", "Airspeed"), time_s),
+            gps_ground_speed_m_s=cls._nearest_value(log_data, attempt, ("GPS", "Spd"), time_s),
+            barometric_altitude_m=cls._nearest_value(log_data, attempt, ("BARO", "Alt"), time_s),
+            barometric_sink_rate_m_s=(
+                cls._barometric_sink_rate(log_data, attempt, time_s) if stage is PlaneLandingStage.PREFLARE else None
+            ),
+            rangefinder_distance_m=rangefinder_distance_m,
+            rangefinder_status=rangefinder_status,
+            flare_to_gps_stop_s=(
+                attempt.end_s - time_s
+                if stage is PlaneLandingStage.FLARE
+                and attempt.end_reason is PlaneLandingEndReason.GPS_STOP
+                and time_s <= attempt.end_s
+                else None
+            ),
+            parameter_values={
+                parameter_name: cls._finite_float(parameter_history.value_at(parameter_name, time_s))
+                for parameter_name in cls._PARAMETERS_BY_STAGE[stage]
+            },
+        )
+
+    @classmethod
+    def _nearest_value(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        telemetry_field: tuple[str, str],
+        target_time_s: float,
+    ) -> float | None:
+        message_name = telemetry_field[0]
+        records = log_data.get_message_columns(message_name)
+        if records is None or not {"TimeUS", telemetry_field[1]}.issubset(records.dtype.names or ()):
+            return None
+
+        if message_name == "ARSP":
+            return cls._nearest_primary_arsp_value(log_data, attempt, telemetry_field[1], target_time_s)
+        if message_name == "GPS":
+            telemetry_fields = _active_gps_fields(log_data, "TimeUS", telemetry_field[1])
+        elif message_name == "BARO":
+            telemetry_fields = _instance_zero_fields(log_data, "BARO", "I", "TimeUS", telemetry_field[1])
+        else:
+            telemetry_fields = (
+                log_data.get_field(message_name, "TimeUS"),
+                log_data.get_field(message_name, telemetry_field[1]),
+            )
+        if telemetry_fields is None:
+            return None
+
+        nearest_value: object | None = None
+        nearest_offset: float | None = None
+        for timestamp, value in zip(*telemetry_fields, strict=True):
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is None or not _owns_attempt_observation(attempt, timestamp_s):
+                continue
+            offset = abs(timestamp_s - target_time_s)
+            if nearest_offset is None or offset < nearest_offset:
+                nearest_offset = offset
+                nearest_value = value
+        return cls._finite_float(nearest_value)
+
+    @classmethod
+    def _nearest_rangefinder_observation(
+        cls,
+        selected_samples: tuple[_PlaneLandingRangefinderSample, ...] | None,
+        target_time_s: float,
+    ) -> tuple[float | None, int | None]:
+        """Return the nearest firmware-selected RFND observation and status."""
+        if not selected_samples:
+            return None, None
+        nearest_sample = min(selected_samples, key=lambda sample: abs(sample.time_s - target_time_s))
+        if (
+            nearest_sample.status is not None
+            and nearest_sample.status not in _PlaneLandingRangefinderSelector.CURRENT_DATA_STATUSES
+        ):
+            return None, nearest_sample.status
+        return nearest_sample.distance_m, nearest_sample.status
+
+    @classmethod
+    def _nearest_primary_arsp_value(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        field_name: str,
+        target_time_s: float,
+    ) -> float | None:
+        """Return nearest usable primary ARSP value without falling back to another sensor."""
+        records = log_data.get_message_columns("ARSP")
+        if records is None:
+            return None
+        names = records.dtype.names or ()
+        selector_fields = {"I", "H", "Pri"}
+        present_selectors = selector_fields.intersection(names)
+        if not present_selectors:
+            return cls._nearest_unselected_arsp_value(log_data, attempt, field_name, target_time_s)
+        if not selector_fields.issubset(names):
+            return None
+
+        grouped_rows: dict[float, list[tuple[object, object, object, object]]] = {}
+        for timestamp, value, instance, healthy, primary in zip(
+            log_data.get_field("ARSP", "TimeUS"),
+            log_data.get_field("ARSP", field_name),
+            log_data.get_field("ARSP", "I"),
+            log_data.get_field("ARSP", "H"),
+            log_data.get_field("ARSP", "Pri"),
+            strict=True,
+        ):
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is not None and _owns_attempt_observation(attempt, timestamp_s):
+                grouped_rows.setdefault(timestamp_s, []).append((value, instance, healthy, primary))
+
+        if not grouped_rows:
+            return None
+        _timestamp_s, rows = min(grouped_rows.items(), key=lambda frame: abs(frame[0] - target_time_s))
+        return cls._primary_arsp_frame_value(rows)
+
+    @classmethod
+    def _primary_arsp_frame_value(cls, rows: list[tuple[object, object, object, object]]) -> float | None:
+        """Return the usable primary value from one already-selected ARSP frame."""
+        instances = tuple(cls._selector_integer(row[1]) for row in rows)
+        if any(instance is None for instance in instances):
+            return None
+        primary_instances = {cls._selector_integer(row[3]) for row in rows}
+        if None in primary_instances or len(primary_instances) != 1:
+            return None
+        primary_instance = next(iter(primary_instances))
+        primary_rows = [row for row, instance in zip(rows, instances, strict=True) if instance == primary_instance]
+        if len(primary_rows) != 1:
+            return None
+        value, _instance, healthy, _primary = primary_rows[0]
+        healthy_value = cls._finite_float(healthy)
+        if healthy_value is None or healthy_value == 0.0:
+            return None
+        return cls._finite_float(value)
+
+    @classmethod
+    def _nearest_unselected_arsp_value(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        field_name: str,
+        target_time_s: float,
+    ) -> float | None:
+        candidates: list[tuple[float, object]] = []
+        for timestamp, value in zip(
+            log_data.get_field("ARSP", "TimeUS"),
+            log_data.get_field("ARSP", field_name),
+            strict=True,
+        ):
+            timestamp_s = cls._finite_float(timestamp)
+            if timestamp_s is not None and _owns_attempt_observation(attempt, timestamp_s):
+                candidates.append((timestamp_s, value))
+        return cls._nearest_candidate_value(candidates, target_time_s)
+
+    @classmethod
+    def _nearest_candidate_value(cls, candidates: list[tuple[float, object]], target_time_s: float) -> float | None:
+        if not candidates:
+            return None
+        return cls._finite_float(min(candidates, key=lambda sample: abs(sample[0] - target_time_s))[1])
+
+    @classmethod
+    def _selector_integer(cls, value: object) -> int | None:
+        converted = cls._finite_float(value)
+        return int(converted) if converted is not None and converted.is_integer() else None
+
+    @classmethod
+    def _barometric_sink_rate(
+        cls,
+        log_data: LogData,
+        attempt: PlaneLandingAttempt,
+        target_time_s: float,
+    ) -> float | None:
+        """Return the APT-compatible local preflare sink rate, positive while descending."""
+        baro_fields = _instance_zero_fields(log_data, "BARO", "I", "TimeUS", "Alt")
+        if baro_fields is None:
+            return None
+        timestamps, altitudes = baro_fields
+
+        start_s = max(attempt.start_s, target_time_s - cls.BARO_RATE_HALF_WINDOW_S)
+        end_s = min(attempt.end_s, target_time_s + cls.BARO_RATE_HALF_WINDOW_S)
+        scoped_samples: list[tuple[float, float]] = []
+        for timestamp, altitude in zip(timestamps, altitudes, strict=True):
+            timestamp_s = cls._finite_float(timestamp)
+            altitude_m = cls._finite_float(altitude)
+            if (
+                timestamp_s is None
+                or altitude_m is None
+                or not start_s <= timestamp_s <= end_s
+                or not _owns_attempt_observation(attempt, timestamp_s)
+            ):
+                continue
+            scoped_samples.append((timestamp_s, altitude_m))
+
+        if len(scoped_samples) < 2:
+            return None
+        first_sample = scoped_samples[0]
+        last_sample = scoped_samples[-1]
+        elapsed_s = last_sample[0] - first_sample[0]
+        if elapsed_s <= 0:
+            return None
+        return -(last_sample[1] - first_sample[1]) / elapsed_s
+
+    @staticmethod
+    def _finite_float(value: object) -> float | None:
+        try:
+            converted = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return converted if math.isfinite(converted) else None

--- a/tests/test_data_model_plane_landing.py
+++ b/tests/test_data_model_plane_landing.py
@@ -1,0 +1,3002 @@
+#!/usr/bin/env python3
+
+"""
+Focused tests for AMC-native ArduPlane landing-attempt analysis.
+
+SPDX-FileCopyrightText: 2026 Donald Smith
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# pylint: disable=too-many-lines
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+
+from ardupilot_methodic_configurator.log_analysis import data_model_log_analysis, data_model_plane_landing
+from ardupilot_methodic_configurator.log_analysis.data_model_availability_plane_landing import (
+    PlaneLandingAnalysis,
+    PlaneLandingAvailabilityModel,
+)
+from ardupilot_methodic_configurator.log_analysis.data_model_flight_segment import FlightSegment
+from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_context import LogAnalysisContext
+from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_result import LogAnalysis
+from ardupilot_methodic_configurator.log_analysis.data_model_log_availability import LogAvailabilityResult
+from ardupilot_methodic_configurator.log_analysis.data_model_log_data import LogData, MessageSchema
+from ardupilot_methodic_configurator.log_analysis.data_model_parameter_history import ParameterChange, ParameterHistory
+from ardupilot_methodic_configurator.log_analysis.data_model_plane_flight_segment import PlaneFlightSegmentDetector
+from ardupilot_methodic_configurator.log_analysis.data_model_plane_landing import (
+    PlaneLandingAttempt,
+    PlaneLandingAttemptDetector,
+    PlaneLandingEndReason,
+    PlaneLandingEvidenceExtractor,
+    PlaneLandingFirmwareFlareEvidence,
+    PlaneLandingFirmwareGlideSlopeEvidence,
+    PlaneLandingFirmwareMessageExtractor,
+    PlaneLandingMissionTarget,
+    PlaneLandingMissionTargetExtractor,
+    PlaneLandingRangefinderEvidence,
+    PlaneLandingRangefinderEvidenceExtractor,
+    PlaneLandingStage,
+    PlaneLandingStageEvidence,
+)
+
+
+def _add_columns(
+    log_data: LogData,
+    message_name: str,
+    records: Sequence[tuple[object, ...]],
+    dtype: list[tuple[str, str]],
+    *,
+    microsecond_time: bool = False,
+) -> None:
+    columns = np.array(list(records), dtype=dtype)
+    schema = None
+    if microsecond_time:
+        fields = [name for name, _field_type in dtype]
+        schema = MessageSchema(
+            name=message_name,
+            msg_type=1,
+            length=0,
+            format="",
+            fields=fields,
+            stored_units=["µs" if name == "TimeUS" else "" for name in fields],
+            scaled_units=["s" if name == "TimeUS" else "" for name in fields],
+            multipliers=[1e-6 if name == "TimeUS" else 1.0 for name in fields],
+            multipliers_applied_at_ingest=[False] * len(fields),
+            records=len(records),
+        )
+    log_data.add_message_columns(message_name, columns, schema)
+
+
+def _plane_log(  # pylint: disable=too-many-arguments
+    *,
+    vehicle_type: str = "ArduPlane",
+    firmware_version: tuple[int, int, int] = (4, 7, 1),
+    gps: Sequence[tuple[float, float]] | None = None,
+    land: Sequence[tuple[object, ...]] | None = None,
+    mode: Sequence[tuple[float, int]] | None = None,
+    messages: Sequence[tuple[float, str]] | None = None,
+    include_land: bool = True,
+    include_baro: bool = True,
+) -> LogData:
+    log_data = LogData(vehicle_type=vehicle_type, firmware_version=firmware_version)
+    gps_records = (
+        gps if gps is not None else ((0.0, 6.0), (2.0, 6.0), (15.0, 6.0), (30.0, 6.0), (60.0, 6.0), (61.0, 0.0), (91.0, 0.0))
+    )
+    _add_columns(
+        log_data,
+        "GPS",
+        gps_records,
+        [("TimeUS", "f8"), ("Spd", "f8")],
+    )
+    if include_land:
+        land_records = land if land is not None else ((5.0, 0), (10.0, 1), (11.0, 2))
+        land_dtype = [("TimeUS", "f8"), ("stage", "i4")]
+        if land_records and len(land_records[0]) == 3:
+            land_dtype.append(("fh", "f8"))
+        _add_columns(
+            log_data,
+            "LAND",
+            land_records,
+            land_dtype,
+        )
+    _add_columns(
+        log_data,
+        "MODE",
+        mode if mode is not None else ((0.0, 10),),
+        [("TimeUS", "f8"), ("ModeNum", "i4")],
+    )
+    if include_baro:
+        _add_columns(
+            log_data,
+            "BARO",
+            ((15.0, 100.0), (20.0, 99.0), (35.0, 98.0), (38.0, 97.0)),
+            [("TimeUS", "f8"), ("Alt", "f8")],
+        )
+    if messages is not None:
+        _add_columns(log_data, "MSG", messages, [("TimeUS", "f8"), ("Message", "U64")])
+    return log_data
+
+
+def _gps_stop_log(
+    cmd: Sequence[tuple[object, ...]] | None,
+    *,
+    messages: Sequence[tuple[float, str]] | None = None,
+) -> LogData:
+    """Return a synthetic GPS-ended landing with optional CMD snapshot records."""
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (15.0, 5.0), (20.0, 2.0), (22.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (12.0, 2), (14.0, 3)),
+        messages=messages,
+    )
+    _add_columns(
+        log_data,
+        "GPS",
+        (
+            (0.0, 6.0, 0.0, 1.0),
+            (2.0, 6.0, 0.0, 1.0),
+            (15.0, 5.0, 0.0, 1.0),
+            (20.0, 2.0, 0.0, 1.001),
+            (22.0, 2.0, 0.0, 1.001),
+            (30.0, 6.0, 0.0, 1.001),
+        ),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    if cmd is not None:
+        _add_columns(
+            log_data,
+            "CMD",
+            cmd,
+            [("TimeUS", "f8"), ("CTot", "f8"), ("CNum", "f8"), ("CId", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+        )
+    return log_data
+
+
+def _context(parameter_history: ParameterHistory | None = None) -> LogAnalysisContext:
+    history = parameter_history or ParameterHistory()
+    return LogAnalysisContext(
+        parameters=history.latest_values,
+        configuration_steps={},
+        parameter_history=history,
+    )
+
+
+def _availability(log_data: LogData) -> LogAvailabilityResult:
+    return PlaneLandingAvailabilityModel(log_data, _context()).check()
+
+
+def _rangefinder_evidence(
+    records: Sequence[tuple[object, object]],
+    parameter_history: ParameterHistory | None = None,
+    *,
+    dtype: list[tuple[str, str]] | None = None,
+) -> tuple[LogData, PlaneLandingAttempt, PlaneLandingRangefinderEvidence | None]:
+    """Return one synthetic attempt and its optional RFND lifecycle evidence."""
+    log_data = _plane_log(messages=((40.0, "Throttle disarmed"),))
+    _add_columns(log_data, "RFND", records, dtype or [("TimeUS", "f8"), ("Dist", "f8")])
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+    evidence = PlaneLandingRangefinderEvidenceExtractor.extract(
+        log_data,
+        attempt,
+        parameter_history or ParameterHistory(),
+    )
+    return log_data, attempt, evidence
+
+
+def _oriented_rangefinder_evidence(
+    records: Sequence[tuple[object, ...]],
+    parameter_history: ParameterHistory,
+    *,
+    dtype: list[tuple[str, str]] | None = None,
+    attempt_bounds: tuple[float, float, PlaneLandingEndReason] | None = None,
+) -> tuple[tuple[PlaneLandingStageEvidence, ...], PlaneLandingRangefinderEvidence | None]:
+    """Return stage and lifecycle evidence for full-schema RFND records."""
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        records,
+        dtype or [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+    if attempt_bounds is not None:
+        start_s, end_s, end_reason = attempt_bounds
+        land_stages = {
+            float(timestamp): int(stage)
+            for timestamp, stage in zip(log_data.get_field("LAND", "TimeUS"), log_data.get_field("LAND", "stage"), strict=True)
+        }
+        attempt = PlaneLandingAttempt(
+            flight_segment=segment,
+            start_s=start_s,
+            end_s=end_s,
+            end_reason=end_reason,
+            mode_number=attempt.mode_number,
+            start_stage=land_stages[start_s],
+        )
+    return (
+        PlaneLandingEvidenceExtractor.extract(log_data, attempt, parameter_history),
+        PlaneLandingRangefinderEvidenceExtractor.extract(log_data, attempt, parameter_history),
+    )
+
+
+def test_non_arduplane_log_is_unavailable() -> None:
+    result = _availability(_plane_log(vehicle_type="ArduCopter"))
+
+    assert result.available is False
+    assert result.reason == "Plane landing analysis is available only for ArduPlane logs"
+
+
+@pytest.mark.parametrize("firmware_version", [(4, 6, 3), (4, 8, 0)])
+def test_only_arduplane_47_x_is_available(firmware_version: tuple[int, int, int]) -> None:
+    result = _availability(_plane_log(firmware_version=firmware_version))
+
+    assert result.available is False
+    assert result.reason == "Plane landing analysis currently supports ArduPlane 4.7.x only"
+
+
+def test_arduplane_47_x_with_required_evidence_is_available() -> None:
+    result = _availability(_plane_log())
+
+    assert result.available is True
+    assert not result.issues
+
+
+def test_missing_required_landing_evidence_is_unavailable() -> None:
+    log_data = _plane_log(include_land=False)
+
+    result = _availability(log_data)
+
+    assert result.available is False
+    assert [issue.message for issue in result.issues] == ["No LAND messages found"]
+
+
+def test_missing_baro_is_unavailable() -> None:
+    result = _availability(_plane_log(include_baro=False))
+
+    assert result.available is False
+    assert [issue.message for issue in result.issues] == ["No BARO messages found"]
+
+
+@pytest.mark.parametrize(
+    ("records", "dtype", "expected_issue"),
+    [
+        (((100.0,),), [("Alt", "f8")], "TimeUS field not present in this firmware's BARO schema"),
+        (((0.0,),), [("TimeUS", "f8")], "Alt field not present in this firmware's BARO schema"),
+    ],
+)
+def test_missing_required_baro_field_is_unavailable(
+    records: Sequence[tuple[object, ...]],
+    dtype: list[tuple[str, str]],
+    expected_issue: str,
+) -> None:
+    log_data = _plane_log(include_baro=False)
+    _add_columns(log_data, "BARO", records, dtype)
+
+    result = _availability(log_data)
+
+    assert result.available is False
+    assert [issue.message for issue in result.issues] == [expected_issue]
+
+
+def test_valid_baro_allows_plane_landing_availability() -> None:
+    result = _availability(_plane_log())
+
+    assert result.available is True
+    assert not result.issues
+
+
+def test_optional_sensor_and_message_evidence_is_not_required() -> None:
+    log_data = _plane_log(messages=None)
+
+    result = _availability(log_data)
+    analysis = PlaneLandingAnalysis(log_data, _context()).analyse()
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert result.available is True
+    assert analysis.available is True
+    assert not PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+    assert not any("firmware" in outcome.message.lower() for outcome in analysis.outcomes)
+    for optional_message in ("ARSP", "RFND", "CMD", "MSG"):
+        assert log_data.get_message_columns(optional_message) is None
+
+
+def test_one_normal_attempt_uses_independent_disarm_termination() -> None:
+    log_data = _plane_log(messages=((40.0, "Throttle disarmed"),))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert attempts == (
+        PlaneLandingAttempt(
+            flight_segment=segment,
+            start_s=10.0,
+            end_s=40.0,
+            end_reason=PlaneLandingEndReason.DISARM,
+            mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+        ),
+    )
+
+
+@pytest.mark.parametrize("first_active_stage", [1, 2, 3])
+def test_first_observed_active_land_stage_opens_one_attempt(first_active_stage: int) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, first_active_stage), (15.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 40.0, PlaneLandingEndReason.DISARM)
+    ]
+
+
+def test_repeated_final_stage_does_not_open_duplicate_attempts() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 3), (11.0, 3), (12.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s) for attempt in attempts] == [(10.0, 40.0)]
+
+
+@pytest.mark.parametrize("first_active_stage", [2, 3])
+def test_flight_observation_beginning_in_active_stage_opens_left_truncated_attempt(
+    first_active_stage: int,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 1), (10.0, first_active_stage), (15.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    segment = FlightSegment(start_s=10.0, end_s=60.0, is_complete=False)
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s) for attempt in attempts] == [(10.0, 40.0)]
+
+
+def test_autoland_only_attempt_preserves_mode_and_flat_result_label() -> None:
+    log_data = _plane_log(mode=((0.0, 26),), messages=((40.0, "Throttle disarmed"),))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert len(attempts) == 1
+    assert attempts[0].mode_number == PlaneLandingAttemptDetector.AUTOLAND_MODE_NUMBER
+    assert any(outcome.message.startswith("AUTOLAND landing attempt 1") for outcome in result.outcomes)
+
+
+def test_stage_one_transition_is_ignored_when_current_mode_is_not_auto() -> None:
+    log_data = _plane_log(mode=((0.0, 5),))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert not attempts
+
+
+def test_first_transition_away_from_auto_terminates_attempt() -> None:
+    log_data = _plane_log(mode=((0.0, 10), (25.0, 5)))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 25.0, PlaneLandingEndReason.MODE_EXIT)
+    ]
+
+
+def test_auto_to_autoland_terminates_old_attempt_and_allows_new_stage_one_attempt() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (11.0, 2), (29.0, 0), (30.0, 1), (31.0, 2)),
+        mode=((0.0, 10), (25.0, 26)),
+        messages=((50.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason, attempt.mode_number) for attempt in attempts] == [
+        (10.0, 25.0, PlaneLandingEndReason.MODE_EXIT, 10),
+        (30.0, 50.0, PlaneLandingEndReason.DISARM, 26),
+    ]
+
+
+def test_autoland_to_auto_terminates_attempt() -> None:
+    log_data = _plane_log(mode=((0.0, 26), (25.0, 10)))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason, attempt.mode_number) for attempt in attempts] == [
+        (10.0, 25.0, PlaneLandingEndReason.MODE_EXIT, 26)
+    ]
+
+
+def test_mode_exit_and_reentry_does_not_reopen_stale_active_stage() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (30.0, 2), (40.0, 2)),
+        mode=((0.0, 10), (20.0, 5), (35.0, 10)),
+        messages=((50.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 20.0, PlaneLandingEndReason.MODE_EXIT)
+    ]
+
+
+def test_multiple_abort_and_restart_attempts_remain_distinguishable() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (11.0, 2), (30.0, 1)),
+        messages=((20.0, "Landing aborted by pilot"), (50.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 20.0, PlaneLandingEndReason.ABORT),
+        (30.0, 50.0, PlaneLandingEndReason.DISARM),
+    ]
+    assert all(attempt.flight_segment is segment for attempt in attempts)
+    assert all(segment.contains(attempt.start_s, attempt.end_s) for attempt in attempts)
+
+
+def test_abort_reset_and_new_active_stage_create_separate_attempts() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 3), (22.0, 0), (30.0, 2), (35.0, 3)),
+        messages=((20.0, "Landing aborted by pilot"), (50.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 20.0, PlaneLandingEndReason.ABORT),
+        (30.0, 50.0, PlaneLandingEndReason.DISARM),
+    ]
+
+
+def test_stage_one_restart_closes_previous_attempt_without_explicit_termination() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (15.0, 6.0), (30.0, 6.0), (60.0, 6.0), (61.0, 6.0), (91.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (11.0, 3), (30.0, 1), (31.0, 2)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 30.0, PlaneLandingEndReason.STAGE_RESTART),
+        (30.0, 91.0, PlaneLandingEndReason.FLIGHT_SEGMENT_END),
+    ]
+
+
+def test_restart_boundary_observations_belong_only_to_new_attempt() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (20.0, 8.0), (30.0, 3.0), (50.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (29.0, 2), (29.5, 0), (30.0, 2), (35.0, 3)),
+        messages=((30.0, "Landing glide slope 4.7 degrees"), (50.0, "Throttle disarmed")),
+        include_baro=False,
+    )
+    _add_columns(log_data, "BARO", ((20.0, 100.0), (30.0, 90.0)), [("TimeUS", "f8"), ("Alt", "f8")])
+    _add_columns(log_data, "ARSP", ((20.0, 12.0), (30.0, 7.0)), [("TimeUS", "f8"), ("Airspeed", "f8")])
+    _add_columns(
+        log_data,
+        "RFND",
+        ((20.0, 8.0, 0, 25, 4), (30.0, 3.0, 0, 25, 4)),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    _add_columns(
+        log_data,
+        "CMD",
+        ((30.0, 1, 0, 21, -35.0, 174.0),),
+        [("TimeUS", "f8"), ("CTot", "i4"), ("CNum", "i4"), ("CId", "i4"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    history = ParameterHistory(
+        {"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "LAND_PF_ALT": 5.0},
+        {"LAND_PF_ALT": (ParameterChange(time_s=30.0, value=7.0),)},
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    first_stages = PlaneLandingEvidenceExtractor.extract(log_data, attempts[0], history)
+    second_stages = PlaneLandingEvidenceExtractor.extract(log_data, attempts[1], history)
+    first_messages = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempts[0])
+    second_messages = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempts[1])
+    second_target = PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempts[1])
+
+    assert attempts[0].end_reason is PlaneLandingEndReason.STAGE_RESTART
+    assert [item.time_s for item in first_stages] == [29.0]
+    assert [item.time_s for item in second_stages] == [30.0, 35.0]
+    assert (
+        first_stages[0].gps_ground_speed_m_s,
+        first_stages[0].barometric_altitude_m,
+        first_stages[0].airspeed_m_s,
+        first_stages[0].rangefinder_distance_m,
+    ) == (8.0, 100.0, 12.0, 8.0)
+    assert (
+        second_stages[0].gps_ground_speed_m_s,
+        second_stages[0].barometric_altitude_m,
+        second_stages[0].airspeed_m_s,
+        second_stages[0].rangefinder_distance_m,
+    ) == (3.0, 90.0, 7.0, 3.0)
+    assert not first_messages
+    assert [item.time_s for item in second_messages] == [30.0]
+    assert first_stages[0].parameter_values["LAND_PF_ALT"] == 5.0
+    assert second_stages[0].parameter_values["LAND_PF_ALT"] == 7.0
+    assert second_target is not None
+    assert second_target.snapshot_completed_s == 30.0
+
+
+def test_restart_wins_equal_time_termination_tie() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (20.0, 6.0), (40.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (29.0, 0), (30.0, 2)),
+        messages=((30.0, "Landing aborted"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert (attempts[0].end_s, attempts[0].end_reason) == (30.0, PlaneLandingEndReason.STAGE_RESTART)
+    assert attempts[1].start_s == 30.0
+
+
+@pytest.mark.parametrize(
+    ("land_records", "land_dtype", "mode_records", "mode_dtype"),
+    [
+        (((1,),), [("stage", "i4")], ((0.0, 10),), [("TimeUS", "f8"), ("ModeNum", "i4")]),
+        (((10.0,),), [("TimeUS", "f8")], ((0.0, 10),), [("TimeUS", "f8"), ("ModeNum", "i4")]),
+        (((10.0, 1),), [("TimeUS", "f8"), ("stage", "i4")], ((10,),), [("ModeNum", "i4")]),
+        (((10.0, 1),), [("TimeUS", "f8"), ("stage", "i4")], ((0.0,),), [("TimeUS", "f8")]),
+    ],
+)
+def test_partial_land_or_mode_schema_returns_no_attempts(
+    land_records: Sequence[tuple[object, ...]],
+    land_dtype: list[tuple[str, str]],
+    mode_records: Sequence[tuple[object, ...]],
+    mode_dtype: list[tuple[str, str]],
+) -> None:
+    log_data = LogData(vehicle_type="ArduPlane", firmware_version=(4, 7, 0))
+    _add_columns(log_data, "LAND", land_records, land_dtype)
+    _add_columns(log_data, "MODE", mode_records, mode_dtype)
+
+    assert not PlaneLandingAttemptDetector.detect(
+        log_data,
+        FlightSegment(start_s=0.0, end_s=20.0, is_complete=False),
+    )
+
+
+def test_go_around_does_not_split_parent_flight_segment() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (15.0, 2.0), (17.0, 2.0), (20.0, 6.0), (60.0, 6.0), (61.0, 0.0), (91.0, 0.0)),
+        land=((5.0, 0), (10.0, 1), (11.0, 2), (12.0, 3), (30.0, 1)),
+        messages=((50.0, "Throttle disarmed"),),
+    )
+
+    segmentation = PlaneFlightSegmentDetector.detect(log_data, {})
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segmentation.segments[0])
+
+    assert len(segmentation.segments) == 1
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in attempts] == [
+        (10.0, 15.0, PlaneLandingEndReason.GPS_STOP),
+        (30.0, 50.0, PlaneLandingEndReason.DISARM),
+    ]
+    assert attempts[0].end_reason is PlaneLandingEndReason.GPS_STOP
+
+
+def test_attempt_times_use_scaled_seconds() -> None:
+    log_data = LogData(vehicle_type="ArduPlane", firmware_version=(4, 7, 0))
+    _add_columns(
+        log_data,
+        "GPS",
+        ((0, 6.0), (2_000_000, 6.0), (20_000_000, 6.0)),
+        [("TimeUS", "u8"), ("Spd", "f8")],
+        microsecond_time=True,
+    )
+    _add_columns(
+        log_data,
+        "LAND",
+        ((5_000_000, 0), (10_000_000, 1), (15_000_000, 2)),
+        [("TimeUS", "u8"), ("stage", "i4")],
+        microsecond_time=True,
+    )
+    _add_columns(
+        log_data,
+        "MODE",
+        ((0, 10),),
+        [("TimeUS", "u8"), ("ModeNum", "i4")],
+        microsecond_time=True,
+    )
+    segment = FlightSegment(start_s=0.0, end_s=20.0, is_complete=False)
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempts[0], ParameterHistory())
+
+    assert attempts[0].start_s == 10.0
+    assert attempts[0].end_s == 20.0
+    assert attempts[0].duration_s == 10.0
+    assert evidence[0].time_s == 15.0
+
+
+def test_inactive_gps_receiver_cannot_create_false_stop() -> None:
+    log_data = _plane_log(messages=((40.0, "Throttle disarmed"),))
+    _add_columns(
+        log_data,
+        "GPS",
+        (
+            (0.0, 6.0, 0, 1),
+            (2.0, 6.0, 0, 1),
+            (11.0, 1.0, 1, 0),
+            (13.0, 1.0, 1, 0),
+            (20.0, 6.0, 0, 1),
+            (40.0, 6.0, 0, 1),
+        ),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("I", "u1"), ("U", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (10.0, 40.0, PlaneLandingEndReason.DISARM)
+
+
+def test_inactive_gps_receiver_cannot_supply_stage_speed() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "GPS",
+        (
+            (0.0, 6.0, 0, 1),
+            (2.0, 6.0, 0, 1),
+            (14.0, 7.0, 0, 1),
+            (15.0, 1.0, 1, 0),
+            (16.0, 8.0, 0, 1),
+            (40.0, 6.0, 0, 1),
+        ),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("I", "u1"), ("U", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].gps_ground_speed_m_s == 7.0
+
+
+def test_inactive_gps_receiver_cannot_supply_target_distance_position() -> None:
+    log_data = _gps_stop_log(((1.0, 1, 0, 21, 0.0, 1.0),))
+    _add_columns(
+        log_data,
+        "GPS",
+        (
+            (20.0, 2.0, 10.0, 10.0, 1, 0),
+            (20.0, 2.0, 0.0, 1.001, 0, 1),
+        ),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("Lat", "f8"), ("Lng", "f8"), ("I", "u1"), ("U", "u1")],
+    )
+    segment = FlightSegment(start_s=0.0, end_s=30.0, is_complete=True)
+    attempt = PlaneLandingAttempt(
+        flight_segment=segment,
+        start_s=10.0,
+        end_s=20.0,
+        end_reason=PlaneLandingEndReason.GPS_STOP,
+        mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+    )
+
+    distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt)
+
+    assert distance is not None
+    assert (distance.aircraft_latitude_deg, distance.aircraft_longitude_deg) == (0.0, 1.001)
+    assert distance.distance_m == pytest.approx(111.1949266)
+
+
+def test_gps_without_use_flag_retains_existing_stop_behavior() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (20.0, 2.0), (22.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (11.0, 2), (14.0, 3)),
+    )
+    gps = log_data.get_message_columns("GPS")
+    assert gps is not None
+    assert "U" not in (gps.dtype.names or ())
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (20.0, PlaneLandingEndReason.GPS_STOP)
+
+
+def test_preflare_headwind_low_groundspeed_does_not_truncate_before_final() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (11.0, 2.0), (13.0, 2.0), (20.0, 5.0), (25.0, 2.0), (27.0, 2.0)),
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (10.0, 25.0, PlaneLandingEndReason.GPS_STOP)
+
+
+def test_pre_final_low_speed_run_is_reset_at_corroboration() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (18.0, 2.0), (20.0, 2.0), (22.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (20.0, PlaneLandingEndReason.GPS_STOP)
+
+
+@pytest.mark.parametrize(
+    ("mode", "land", "messages", "expected_reason"),
+    [
+        (((0.0, 10),), ((5.0, 0), (10.0, 1), (12.0, 3)), ((45.0, "Throttle disarmed"),), PlaneLandingEndReason.DISARM),
+        (((0.0, 10),), ((5.0, 0), (10.0, 1), (12.0, 3)), ((45.0, "Landing aborted"),), PlaneLandingEndReason.ABORT),
+        (((0.0, 10), (45.0, 5)), ((5.0, 0), (10.0, 1), (12.0, 3)), None, PlaneLandingEndReason.MODE_EXIT),
+        (((0.0, 10),), ((5.0, 0), (10.0, 1), (12.0, 3), (45.0, 1)), None, PlaneLandingEndReason.STAGE_RESTART),
+    ],
+)
+def test_gps_persistence_cannot_be_confirmed_after_competing_termination(
+    mode: Sequence[tuple[float, int]],
+    land: Sequence[tuple[object, ...]],
+    messages: Sequence[tuple[float, str]] | None,
+    expected_reason: PlaneLandingEndReason,
+) -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (44.0, 2.0), (46.0, 2.0), (60.0, 6.0)),
+        land=land,
+        mode=mode,
+        messages=messages,
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (45.0, expected_reason)
+
+
+def test_gps_persistence_confirmed_before_disarm_backdates_to_first_low_sample() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (42.0, 2.0), (44.0, 2.0), (60.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (12.0, 3)),
+        messages=((45.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (42.0, PlaneLandingEndReason.GPS_STOP)
+
+
+def test_zero_length_gps_stop_attempt_is_omitted_without_crashing_analysis() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (10.0, 2.0), (12.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert not attempts
+    assert result.available is True
+    assert not result.outcomes
+    assert result.reason == "No Plane landing attempts detected"
+
+
+def test_short_positive_duration_gps_stop_attempt_remains_valid() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (10.001, 2.0), (12.001, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (
+        10.0,
+        10.001,
+        PlaneLandingEndReason.GPS_STOP,
+    )
+
+
+def test_later_disarm_does_not_replace_zero_length_gps_stop() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (10.0, 2.0), (12.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 3)),
+        messages=((20.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert not attempts
+
+
+def test_stage_three_alone_corroborates_gps_stop() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (14.0, 4.0), (16.0, 2.0), (18.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (12.0, 2), (14.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (16.0, PlaneLandingEndReason.GPS_STOP)
+
+
+def test_complete_firmware_flare_corroborates_gps_stop_without_stage_three() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (12.0, 2.0), (14.0, 2.0), (16.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (11.0, 2)),
+        messages=((13.0, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (14.0, PlaneLandingEndReason.GPS_STOP)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Flare malformed",
+        "Flare 2.0m sink=1.0 speed=10.0",
+        "Flare nanm sink=1.0 speed=10.0 dist=20.0",
+        "Flare 2.0m sink=inf speed=10.0 dist=20.0",
+    ],
+)
+def test_unusable_firmware_flare_does_not_corroborate_gps_stop(message: str) -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (12.0, 2.0), (14.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (11.0, 2)),
+        messages=((11.5, message), (25.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert (attempt.end_s, attempt.end_reason) == (25.0, PlaneLandingEndReason.DISARM)
+
+
+def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
+    log_data = _plane_log(
+        gps=(
+            (0.0, 6.0),
+            (2.0, 6.0),
+            (14.9, 8.0),
+            (15.0, 7.0),
+            (15.1, 9.0),
+            (19.9, 6.0),
+            (20.0, 5.0),
+            (20.1, 7.0),
+            (60.0, 6.0),
+            (61.0, 0.0),
+            (91.0, 0.0),
+        ),
+        land=((5.0, 0, 0.0), (10.0, 1, 20.0), (15.0, 2, 5.5), (20.0, 3, 1.2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(log_data, "ARSP", ((14.8, 12.0), (15.1, 13.0), (19.8, 9.0)), [("TimeUS", "f8"), ("Airspeed", "f8")])
+    _add_columns(
+        log_data,
+        "BARO",
+        ((14.5, 101.0), (14.9, 100.0), (15.5, 99.0), (19.5, 92.0), (20.1, 90.0), (20.5, 89.0)),
+        [("TimeUS", "f8"), ("Alt", "f8")],
+    )
+    _add_columns(log_data, "RFND", ((14.7, 6.0), (20.2, 1.5)), [("TimeUS", "f8"), ("Dist", "f8")])
+    history = ParameterHistory(
+        {
+            "LAND_PF_ALT": 6.0,
+            "LAND_PF_SEC": 2.0,
+            "LAND_FLARE_ALT": 3.0,
+            "LAND_FLARE_SEC": 1.5,
+            "LAND_PITCH_DEG": 4.0,
+        }
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, history)
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    assert [item.stage for item in evidence] == [PlaneLandingStage.PREFLARE, PlaneLandingStage.FLARE]
+    preflare, flare = evidence
+    assert (preflare.time_s, preflare.flight_height_m) == (15.0, 5.5)
+    assert (preflare.airspeed_m_s, preflare.barometric_altitude_m, preflare.rangefinder_distance_m) == (
+        13.0,
+        100.0,
+        6.0,
+    )
+    assert preflare.rangefinder_status is None
+    assert preflare.gps_ground_speed_m_s == 7.0
+    assert preflare.barometric_sink_rate_m_s == 2.0
+    assert preflare.flare_to_gps_stop_s is None
+    assert preflare.parameter_values == {"LAND_PF_ALT": 6.0, "LAND_PF_SEC": 2.0}
+    assert (flare.time_s, flare.flight_height_m) == (20.0, 1.2)
+    assert (flare.airspeed_m_s, flare.barometric_altitude_m, flare.rangefinder_distance_m) == (9.0, 90.0, 1.5)
+    assert flare.rangefinder_status is None
+    assert flare.gps_ground_speed_m_s == 5.0
+    assert flare.barometric_sink_rate_m_s is None
+    assert flare.flare_to_gps_stop_s is None
+    assert flare.parameter_values == {
+        "LAND_FLARE_ALT": 3.0,
+        "LAND_FLARE_SEC": 1.5,
+        "LAND_PITCH_DEG": 4.0,
+    }
+    outcome_messages = [outcome.message for outcome in result.outcomes]
+    for expected_measurement in (
+        "LAND stage 2 (preflare) entered",
+        "LAND stage 3 (flare) entered",
+        "LAND flight height",
+        "ARSP airspeed",
+        "GPS groundspeed",
+        "BARO altitude",
+        "BARO sink rate",
+        "RFND distance",
+        "LAND_PF_ALT effective value",
+        "LAND_FLARE_ALT effective value",
+        "LAND_PITCH_DEG effective value",
+    ):
+        assert any(expected_measurement in message for message in outcome_messages)
+    assert all(outcome.param_name is None for outcome in result.outcomes)
+    assert all(outcome.suggested_value is None for outcome in result.outcomes)
+    assert all(isinstance(outcome, LogAnalysis) for outcome in result.outcomes)
+    assert not any(
+        label in outcome.message.lower() for outcome in result.outcomes for label in ("good", "poor", "safe", "unsafe")
+    )
+
+
+@pytest.mark.parametrize(("nonprimary_used", "nonprimary_healthy"), [(1, 1), (0, 1), (1, 0)])
+def test_arsp_nearest_value_uses_healthy_primary_sensor_regardless_of_row_order(
+    nonprimary_used: int,
+    nonprimary_healthy: int,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        (
+            (15.0, 5.0, 0, nonprimary_used, nonprimary_healthy, 1),
+            (15.0, 22.0, 1, 1, 1, 1),
+        ),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1"), ("U", "u1"), ("H", "u1"), ("Pri", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].airspeed_m_s == 22.0
+
+
+@pytest.mark.parametrize("primary_used", [0, 1])
+def test_arsp_observational_evidence_does_not_require_primary_use(primary_used: int) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        (
+            (15.0, 5.0, 0, 1, 1, 1),
+            (15.0, 22.0, 1, primary_used, 1, 1),
+        ),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1"), ("U", "u1"), ("H", "u1"), ("Pri", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].airspeed_m_s == 22.0
+
+
+def test_arsp_selector_schema_without_use_field_remains_sufficient() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        ((15.0, 22.0, 1, 1, 1),),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1"), ("H", "u1"), ("Pri", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].airspeed_m_s == 22.0
+
+
+@pytest.mark.parametrize(
+    "arsp_records",
+    [
+        ((15.0, 5.0, 0, 1, 1, 1), (15.0, 22.0, 1, 1, 0, 1)),
+        ((15.0, 5.0, 0, 1, 1, 1), (15.0, float("nan"), 1, 1, 1, 1)),
+        ((15.0, 5.0, 0, 1, 1, 0), (15.0, 22.0, 1, 1, 1, 1)),
+        ((15.0, 5.0, float("nan"), 1, 1, 1), (15.0, 22.0, 1, 1, 1, 1)),
+        ((15.0, 5.0, 0, 1, 1, float("inf")), (15.0, 22.0, 1, 1, 1, 1)),
+        ((15.0, 5.0, 0, 1, 1, 1), (15.0, 22.0, 1, 1, float("inf"), 1)),
+        ((15.0, 21.0, 1, 1, 1, 1), (15.0, 22.0, 1, 1, 1, 1)),
+    ],
+)
+def test_arsp_unusable_or_ambiguous_primary_is_unavailable(
+    arsp_records: Sequence[tuple[object, ...]],
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        arsp_records,
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "f8"), ("U", "f8"), ("H", "f8"), ("Pri", "f8")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].airspeed_m_s is None
+
+
+def test_arsp_partial_selector_schema_is_unavailable() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        ((15.0, 22.0, 1),),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    assert evidence[0].airspeed_m_s is None
+
+
+@pytest.mark.parametrize(
+    ("event_airspeed", "event_healthy"),
+    [(22.0, 0.0), (float("nan"), 1.0)],
+    ids=("unhealthy", "non-finite"),
+)
+def test_arsp_nearest_primary_frame_does_not_fall_back_to_farther_healthy_value(
+    event_airspeed: float,
+    event_healthy: float,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        (
+            (10.0, 21.0, 1, 0, 1, 1),
+            (20.0, 30.0, 0, 1, 1, 1),
+            (20.0, event_airspeed, 1, 1, event_healthy, 1),
+            (30.0, 23.0, 1, 1, 1, 1),
+        ),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1"), ("U", "u1"), ("H", "f8"), ("Pri", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    assert flare.airspeed_m_s is None
+    assert not any("ARSP airspeed" in outcome.message for outcome in result.outcomes)
+
+
+def test_arsp_ambiguous_nearest_primary_frame_does_not_fall_back_to_farther_healthy_value() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "ARSP",
+        (
+            (10.0, 21.0, 1, 1, 1),
+            (20.0, 30.0, 0, 1, 0),
+            (20.0, 22.0, 1, 1, 1),
+            (30.0, 23.0, 1, 1, 1),
+        ),
+        [("TimeUS", "f8"), ("Airspeed", "f8"), ("I", "u1"), ("H", "u1"), ("Pri", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    assert flare.airspeed_m_s is None
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        ((20.0, float("nan")), (30.0, 23.0)),
+        ((10.0, 21.0), (20.0, float("nan")), (30.0, 23.0)),
+    ],
+    ids=("finite-later", "finite-older-and-newer"),
+)
+def test_legacy_arsp_nearest_non_finite_observation_does_not_fall_back(
+    records: Sequence[tuple[float, float]],
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(log_data, "ARSP", records, [("TimeUS", "f8"), ("Airspeed", "f8")])
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    assert flare.airspeed_m_s is None
+
+
+@pytest.mark.parametrize(
+    ("records", "expected_airspeed_m_s"),
+    [
+        (((20.0, 22.0), (30.0, 23.0)), 22.0),
+        (((19.0, 21.0), (21.0, 23.0)), 21.0),
+    ],
+    ids=("nearest-finite", "equidistant-first-wins"),
+)
+def test_legacy_arsp_nearest_finite_observation_preserves_existing_tie_behavior(
+    records: Sequence[tuple[float, float]],
+    expected_airspeed_m_s: float,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(log_data, "ARSP", records, [("TimeUS", "f8"), ("Airspeed", "f8")])
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    assert flare.airspeed_m_s == expected_airspeed_m_s
+
+
+def test_flare_to_gps_stop_uses_the_authoritative_attempt_end() -> None:
+    log_data = _plane_log(
+        gps=((0.0, 6.0), (2.0, 6.0), (12.0, 5.0), (14.0, 4.0), (20.0, 2.0), (22.0, 2.0), (30.0, 6.0)),
+        land=((5.0, 0), (10.0, 1), (12.0, 2), (14.0, 3)),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (10.0, 20.0, PlaneLandingEndReason.GPS_STOP)
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    assert flare.flare_to_gps_stop_s == 6.0
+    outcomes = [outcome for outcome in result.outcomes if "Flare to GPS stop" in outcome.message]
+    assert [(outcome.timestamp_us, outcome.value) for outcome in outcomes] == [(14_000_000, 6.0)]
+
+
+def test_sparse_and_non_finite_baro_omits_preflare_sink_rate() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    _add_columns(
+        log_data,
+        "BARO",
+        ((float("nan"), 95.0), (14.5, float("nan")), (15.0, 100.0), (15.5, float("inf"))),
+        [("TimeUS", "f8"), ("Alt", "f8")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    preflare = next(item for item in evidence if item.stage is PlaneLandingStage.PREFLARE)
+    assert preflare.barometric_altitude_m == 100.0
+    assert preflare.barometric_sink_rate_m_s is None
+
+
+def test_duplicate_timestamp_baro_omits_preflare_sink_rate() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    _add_columns(
+        log_data,
+        "BARO",
+        ((15.0, 100.0), (15.0, 99.0)),
+        [("TimeUS", "f8"), ("Alt", "f8")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    preflare = next(item for item in evidence if item.stage is PlaneLandingStage.PREFLARE)
+    assert preflare.barometric_altitude_m == 100.0
+    assert preflare.barometric_sink_rate_m_s is None
+
+
+@pytest.mark.parametrize(("message_name", "field_name"), [("BARO", "Alt"), ("GPS", "Spd")])
+@pytest.mark.parametrize(
+    ("records", "expected_value"),
+    [
+        (((20.0, float("nan")), (30.0, 23.0)), None),
+        (((10.0, 21.0), (20.0, float("nan")), (30.0, 23.0)), None),
+        (((20.0, 22.0), (30.0, 23.0)), 22.0),
+        (((20.0, 0.0), (30.0, 23.0)), 0.0),
+        (((19.0, 21.0), (21.0, 23.0)), 21.0),
+    ],
+    ids=("non-finite-with-later", "non-finite-with-older-and-newer", "finite", "zero", "tie-first-wins"),
+)
+def test_stage_nearest_value_applies_finiteness_after_selection(
+    message_name: str,
+    field_name: str,
+    records: Sequence[tuple[float, float]],
+    expected_value: float | None,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    _add_columns(log_data, message_name, records, [("TimeUS", "f8"), (field_name, "f8")])
+    attempt = PlaneLandingAttempt(
+        flight_segment=FlightSegment(start_s=0.0, end_s=40.0, is_complete=False),
+        start_s=10.0,
+        end_s=40.0,
+        end_reason=PlaneLandingEndReason.DISARM,
+        mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+    )
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    flare = next(item for item in evidence if item.stage is PlaneLandingStage.FLARE)
+    actual_value = flare.barometric_altitude_m if message_name == "BARO" else flare.gps_ground_speed_m_s
+    assert actual_value == expected_value
+
+
+def test_baro_stage_altitude_and_sink_rate_use_only_instance_zero() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    _add_columns(
+        log_data,
+        "BARO",
+        (
+            (14.5, 200.0, 1),
+            (14.5, 100.0, 0),
+            (15.0, 199.5, 1),
+            (15.0, 99.5, 0),
+            (15.5, 199.0, 1),
+            (15.5, 99.0, 0),
+        ),
+        [("TimeUS", "f8"), ("Alt", "f8"), ("I", "u1")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+
+    preflare = next(item for item in evidence if item.stage is PlaneLandingStage.PREFLARE)
+    assert preflare.barometric_altitude_m == 99.5
+    assert preflare.barometric_sink_rate_m_s == pytest.approx(1.0)
+
+
+def test_firmware_flare_and_glide_slope_messages_are_separate_from_land_stage() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=(
+            (10.1, "Landing glide slope 4.7 degrees"),
+            (19.9999, "Flare -160.1m sink=1.13 speed=13.5 dist=32.6"),
+            (40.0, "Throttle disarmed"),
+        ),
+    )
+    _add_columns(log_data, "ARSP", ((20.0, 17.0),), [("TimeUS", "f8"), ("Airspeed", "f8")])
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    stage_evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+    firmware_evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    stage_flare = next(item for item in stage_evidence if item.stage is PlaneLandingStage.FLARE)
+    glide_slope = next(item for item in firmware_evidence if isinstance(item, PlaneLandingFirmwareGlideSlopeEvidence))
+    firmware_flare = next(item for item in firmware_evidence if isinstance(item, PlaneLandingFirmwareFlareEvidence))
+    assert (glide_slope.time_s, glide_slope.glide_slope_degrees) == (10.1, 4.7)
+    assert firmware_flare == PlaneLandingFirmwareFlareEvidence(
+        attempt=attempt,
+        time_s=19.9999,
+        altitude_m=-160.1,
+        sink_rate_m_s=1.13,
+        groundspeed_m_s=13.5,
+        distance_to_target_m=32.6,
+    )
+    assert stage_flare.time_s == 20.0
+    assert stage_flare.airspeed_m_s == 17.0
+    assert firmware_flare.groundspeed_m_s == 13.5
+    assert firmware_flare.time_s != stage_flare.time_s
+    firmware_outcomes = [outcome for outcome in result.outcomes if "firmware" in outcome.message.lower()]
+    assert [outcome.timestamp_us for outcome in firmware_outcomes] == [10_100_000] + [19_999_900] * 4
+    assert [outcome.value for outcome in firmware_outcomes] == [4.7, -160.1, 1.13, 13.5, 32.6]
+    assert any("firmware flare: groundspeed 13.500 m/s" in outcome.message for outcome in firmware_outcomes)
+    assert not any("firmware flare: airspeed" in outcome.message for outcome in firmware_outcomes)
+    assert all(isinstance(outcome, LogAnalysis) for outcome in firmware_outcomes)
+    assert all(outcome.param_name is None and outcome.suggested_value is None for outcome in firmware_outcomes)
+    assert not any(
+        label in outcome.message.lower() for outcome in firmware_outcomes for label in ("good", "poor", "safe", "unsafe")
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Flare malformed",
+        "Flare 1.2m sink=bad speed=10.0 dist=20.0",
+        "Flare 1.2m sink=0.5 speed=10.0",
+        "Flare 1.2m sink=nan speed=10.0 dist=20.0",
+    ],
+)
+def test_malformed_or_partial_firmware_flare_message_is_omitted(message: str) -> None:
+    log_data = _plane_log(messages=((15.0, message), (40.0, "Throttle disarmed")))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Landing glide slope malformed",
+        "Landing glide slope nan degrees",
+        "Landing glide slope 4.7",
+    ],
+)
+def test_malformed_firmware_glide_slope_message_is_omitted(message: str) -> None:
+    log_data = _plane_log(messages=((15.0, message), (40.0, "Throttle disarmed")))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareGlideSlopeEvidence) for item in evidence)
+
+
+def test_firmware_messages_outside_attempt_are_ignored() -> None:
+    log_data = _plane_log(
+        messages=(
+            (9.9, "Landing approach start at 20.0m"),
+            (9.95, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),
+            (20.0, "Landing aborted"),
+            (20.1, "Landing glide slope 4.7 degrees"),
+        )
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert (attempt.start_s, attempt.end_s) == (10.0, 20.0)
+    assert not evidence
+
+
+def test_stage_three_opened_attempt_associates_immediately_preceding_flare() -> None:
+    log_data = _plane_log(
+        land=((9.998, 0), (10.0, 3)),
+        messages=((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    flare = next(item for item in evidence if isinstance(item, PlaneLandingFirmwareFlareEvidence))
+    assert (attempt.start_s, attempt.start_stage) == (10.0, 3)
+    assert flare.time_s == 9.999
+    assert flare.associated_before_attempt_start is True
+
+
+@pytest.mark.parametrize(("flare_mode", "attempt_mode"), [(26, 10), (10, 26)])
+def test_prestart_flare_known_mode_mismatch_is_rejected(flare_mode: int, attempt_mode: int) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (9.998, 0), (10.0, 3)),
+        mode=((0.0, flare_mode), (10.0, attempt_mode)),
+        messages=((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+def test_prestart_flare_known_same_mode_remains_associated() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (9.998, 0), (10.0, 3)),
+        mode=((0.0, 10),),
+        messages=((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    flare = next(
+        item
+        for item in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+        if isinstance(item, PlaneLandingFirmwareFlareEvidence)
+    )
+
+    assert (flare.time_s, flare.associated_before_attempt_start) == (9.999, True)
+
+
+def test_prestart_flare_unknown_mode_is_not_treated_as_contradictory() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (9.998, 0), (10.0, 3)),
+        mode=((10.0, 10),),
+        messages=((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    flare = next(
+        item
+        for item in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+        if isinstance(item, PlaneLandingFirmwareFlareEvidence)
+    )
+
+    assert (flare.time_s, flare.associated_before_attempt_start) == (9.999, True)
+
+
+@pytest.mark.parametrize(("earlier_mode", "later_mode"), [(26, 10), (10, 26)])
+def test_mode_transition_flare_is_owned_only_by_earlier_attempt(earlier_mode: int, later_mode: int) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3), (29.998, 0), (30.0, 3)),
+        mode=((0.0, earlier_mode), (29.9995, later_mode)),
+        messages=((29.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    flare_evidence = [
+        (attempt_number, evidence)
+        for attempt_number, attempt in enumerate(attempts, start=1)
+        for evidence in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+        if isinstance(evidence, PlaneLandingFirmwareFlareEvidence)
+    ]
+
+    assert len(attempts) == 2
+    assert [(number, evidence.time_s, evidence.associated_before_attempt_start) for number, evidence in flare_evidence] == [
+        (1, 29.999, False)
+    ]
+
+
+def test_same_mode_restart_flare_is_owned_only_by_earlier_attempt() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (20.0, 3), (29.998, 0), (30.0, 3)),
+        messages=((29.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    flare_evidence = [
+        (attempt_number, evidence)
+        for attempt_number, attempt in enumerate(attempts, start=1)
+        for evidence in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+        if isinstance(evidence, PlaneLandingFirmwareFlareEvidence)
+    ]
+
+    assert len(attempts) == 2
+    assert [(number, evidence.time_s, evidence.associated_before_attempt_start) for number, evidence in flare_evidence] == [
+        (1, 29.999, False)
+    ]
+
+
+def test_stage_two_opened_attempt_cannot_associate_preceding_flare() -> None:
+    log_data = _plane_log(
+        land=((9.998, 0), (10.0, 2)),
+        messages=((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert attempt.start_stage == 2
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+@pytest.mark.parametrize(
+    ("land", "messages", "mode"),
+    [
+        (
+            ((9.998, 0), (9.9995, 0), (10.0, 3)),
+            ((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+            ((0.0, 10),),
+        ),
+        (
+            ((9.998, 0), (10.0, 3)),
+            (
+                (9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),
+                (9.9995, "Landing aborted"),
+                (40.0, "Throttle disarmed"),
+            ),
+            ((0.0, 10),),
+        ),
+        (
+            ((9.998, 0), (10.0, 3)),
+            (
+                (9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),
+                (9.9995, "Throttle disarmed"),
+                (40.0, "Throttle disarmed"),
+            ),
+            ((0.0, 10),),
+        ),
+        (
+            ((9.998, 0), (10.0, 3)),
+            ((9.999, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+            ((0.0, 10), (9.9995, 5), (10.0, 10)),
+        ),
+    ],
+)
+def test_intervening_reset_termination_or_mode_exit_blocks_left_truncated_flare(
+    land: Sequence[tuple[float, int]],
+    messages: Sequence[tuple[float, str]],
+    mode: Sequence[tuple[float, int]],
+) -> None:
+    log_data = _plane_log(land=land, messages=messages, mode=mode)
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["Flare malformed", "Flare 2.0m sink=nan speed=10.0 dist=20.0"],
+)
+def test_unusable_preceding_flare_is_not_associated(message: str) -> None:
+    log_data = _plane_log(
+        land=((9.998, 0), (10.0, 3)),
+        messages=((9.999, message), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert not any(
+        isinstance(item, PlaneLandingFirmwareFlareEvidence)
+        for item in PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+    )
+
+
+def test_old_or_outside_parent_flare_is_not_associated() -> None:
+    log_data = _plane_log(
+        land=((9.5, 0), (10.0, 3)),
+        messages=((9.0, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),),
+    )
+    attempt = PlaneLandingAttempt(
+        flight_segment=FlightSegment(start_s=9.25, end_s=20.0, is_complete=False),
+        start_s=10.0,
+        end_s=20.0,
+        end_reason=PlaneLandingEndReason.FLIGHT_SEGMENT_END,
+        mode_number=10,
+        start_stage=3,
+    )
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+def test_old_flare_before_preceding_land_record_is_not_associated() -> None:
+    log_data = _plane_log(
+        land=((9.5, 0), (10.0, 3)),
+        messages=((9.0, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"), (40.0, "Throttle disarmed")),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
+
+    assert not any(isinstance(item, PlaneLandingFirmwareFlareEvidence) for item in evidence)
+
+
+def test_multiple_attempts_do_not_cross_associate_firmware_messages() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (11.0, 3), (25.0, 0), (30.0, 1), (31.0, 3)),
+        messages=(
+            (10.1, "Landing glide slope 4.0 degrees"),
+            (15.0, "Flare 2.0m sink=1.0 speed=10.0 dist=20.0"),
+            (20.0, "Landing aborted"),
+            (30.1, "Landing glide slope 5.0 degrees"),
+            (35.0, "Flare 3.0m sink=2.0 speed=11.0 dist=30.0"),
+            (50.0, "Throttle disarmed"),
+        ),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    first = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempts[0])
+    second = PlaneLandingFirmwareMessageExtractor.extract(log_data, attempts[1])
+
+    first_flare = next(item for item in first if isinstance(item, PlaneLandingFirmwareFlareEvidence))
+    second_flare = next(item for item in second if isinstance(item, PlaneLandingFirmwareFlareEvidence))
+    first_glide = next(item for item in first if isinstance(item, PlaneLandingFirmwareGlideSlopeEvidence))
+    second_glide = next(item for item in second if isinstance(item, PlaneLandingFirmwareGlideSlopeEvidence))
+    assert (first_flare.time_s, first_flare.altitude_m, first_glide.glide_slope_degrees) == (15.0, 2.0, 4.0)
+    assert (second_flare.time_s, second_flare.altitude_m, second_glide.glide_slope_degrees) == (35.0, 3.0, 5.0)
+    assert first_flare.attempt is attempts[0]
+    assert second_flare.attempt is attempts[1]
+
+
+def test_complete_cmd_snapshot_produces_independent_mission_target_distance() -> None:
+    log_data = _gps_stop_log(
+        (
+            (1.0, 3, 0, 16, 0.0, 0.0),
+            (2.0, 3, 1, 21, 0.0, 1.0),
+            (3.0, 3, 2, 20, 0.0, 0.0),
+        ),
+        messages=((13.9999, "Flare 2.0m sink=1.0 speed=10.0 dist=32.6"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    target = PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempt)
+    distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt)
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert target == PlaneLandingMissionTarget(
+        attempt=attempt,
+        snapshot_completed_s=3.0,
+        latitude_deg=0.0,
+        longitude_deg=1.0,
+    )
+    assert distance is not None
+    assert (distance.time_s, distance.aircraft_position_time_s) == (20.0, 20.0)
+    assert (distance.aircraft_latitude_deg, distance.aircraft_longitude_deg) == (0.0, 1.001)
+    assert distance.distance_m == pytest.approx(111.1949266)
+    firmware_distance = [outcome for outcome in result.outcomes if "firmware flare: distance to target" in outcome.message]
+    computed_distance = [
+        outcome for outcome in result.outcomes if "computed distance to mission LAND target" in outcome.message
+    ]
+    assert [(outcome.timestamp_us, outcome.value) for outcome in firmware_distance] == [(13_999_900, 32.6)]
+    assert len(computed_distance) == 1
+    assert (computed_distance[0].timestamp_us, computed_distance[0].value) == pytest.approx((20_000_000, 111.1949266))
+    assert all(isinstance(outcome, LogAnalysis) for outcome in result.outcomes)
+    assert all(outcome.param_name is None and outcome.suggested_value is None for outcome in result.outcomes)
+    assert not any(
+        label in outcome.message.lower() for outcome in result.outcomes for label in ("good", "poor", "safe", "unsafe")
+    )
+    assert not any("touchdown" in outcome.message.lower() for outcome in result.outcomes)
+
+
+def test_missing_cmd_keeps_analysis_available_and_omits_target_evidence() -> None:
+    log_data = _gps_stop_log(None)
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    availability = _availability(log_data)
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert availability.available is True
+    assert PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempt) is None
+    assert PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt) is None
+    assert not any("computed distance to mission LAND target" in outcome.message for outcome in result.outcomes)
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        ((1.0, 3, 0, 16, 0.0, 0.0), (2.0, 3, 2, 21, 0.0, 1.0)),
+        ((1.0, 2, 0, 21, 0.0, 1.0), (2.0, 2, 1, 21, 0.0, 2.0)),
+        ((1.0, 2, 0, 16, 0.0, 0.0), (2.0, 2, 1, 20, 0.0, 1.0)),
+    ],
+    ids=("incomplete", "ambiguous-land", "no-land"),
+)
+def test_unusable_cmd_snapshot_omits_target_evidence(cmd: Sequence[tuple[object, ...]]) -> None:
+    log_data = _gps_stop_log(cmd)
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempt) is None
+    assert PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt) is None
+
+
+@pytest.mark.parametrize(("latitude", "longitude"), [(0.0, 0.0), (float("nan"), 1.0), (0.0, float("inf"))])
+def test_malformed_mission_target_coordinates_are_rejected(latitude: float, longitude: float) -> None:
+    log_data = _gps_stop_log(((1.0, 1, 0, 21, latitude, longitude),))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    assert PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempt) is None
+    assert PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt) is None
+
+
+def test_latest_complete_snapshot_before_each_attempt_selects_the_correct_target() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (11.0, 3), (25.0, 0), (30.0, 1), (31.0, 3)),
+        messages=((20.0, "Landing aborted"), (50.0, "Throttle disarmed")),
+    )
+    _add_columns(
+        log_data,
+        "CMD",
+        (
+            (1.0, 2, 0, 16, 0.0, 0.0),
+            (2.0, 2, 1, 21, -35.0, 174.0),
+            (22.0, 2, 0, 16, 0.0, 0.0),
+            (23.0, 2, 1, 21, -36.0, 175.0),
+        ),
+        [("TimeUS", "f8"), ("CTot", "f8"), ("CNum", "f8"), ("CId", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempts = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    first = PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempts[0])
+    second = PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempts[1])
+
+    assert first is not None
+    assert second is not None
+    assert (first.snapshot_completed_s, first.latitude_deg, first.longitude_deg) == (2.0, -35.0, 174.0)
+    assert (second.snapshot_completed_s, second.latitude_deg, second.longitude_deg) == (23.0, -36.0, 175.0)
+    assert first.attempt is attempts[0]
+    assert second.attempt is attempts[1]
+
+
+def test_target_distance_does_not_use_gps_position_outside_attempt() -> None:
+    log_data = _gps_stop_log(((1.0, 1, 0, 21, 0.0, 1.0),))
+    gps = log_data.get_message_columns("GPS")
+    assert gps is not None
+    gps["Lat"][3] = float("nan")
+    gps["Lng"][3] = float("nan")
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt)
+
+    assert (attempt.end_s, attempt.end_reason) == (20.0, PlaneLandingEndReason.GPS_STOP)
+    assert distance is None
+
+
+def test_target_distance_scopes_gps_positions_before_nearest_selection() -> None:
+    log_data = _gps_stop_log(((1.0, 1, 0, 21, 0.0, 1.0),))
+    _add_columns(
+        log_data,
+        "GPS",
+        ((19.0, 2.0, 0.0, 1.001), (20.5, 2.0, 0.0, 1.002)),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    attempt = PlaneLandingAttempt(
+        flight_segment=FlightSegment(start_s=0.0, end_s=30.0, is_complete=False),
+        start_s=10.0,
+        end_s=20.0,
+        end_reason=PlaneLandingEndReason.GPS_STOP,
+        mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+    )
+
+    distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt)
+
+    assert distance is not None
+    assert (distance.aircraft_position_time_s, distance.aircraft_longitude_deg) == (19.0, 1.001)
+
+
+def test_target_distance_without_in_scope_gps_position_remains_unavailable() -> None:
+    log_data = _gps_stop_log(((1.0, 1, 0, 21, 0.0, 1.0),))
+    _add_columns(
+        log_data,
+        "GPS",
+        ((20.5, 2.0, 0.0, 1.002),),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    attempt = PlaneLandingAttempt(
+        flight_segment=FlightSegment(start_s=0.0, end_s=30.0, is_complete=False),
+        start_s=10.0,
+        end_s=20.0,
+        end_reason=PlaneLandingEndReason.GPS_STOP,
+        mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+    )
+
+    assert PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt) is None
+
+
+@pytest.mark.parametrize(
+    ("end_reason", "target_time_s", "expected_time_s"),
+    [
+        (PlaneLandingEndReason.GPS_STOP, 20.0, 20.0),
+        (PlaneLandingEndReason.STAGE_RESTART, 20.0, 19.0),
+        (PlaneLandingEndReason.GPS_STOP, 18.0, 17.0),
+    ],
+    ids=("inclusive-endpoint", "stage-restart-exclusive-endpoint", "tie-first-wins"),
+)
+def test_nearest_gps_position_preserves_attempt_endpoint_and_tie_semantics(
+    end_reason: PlaneLandingEndReason,
+    target_time_s: float,
+    expected_time_s: float,
+) -> None:
+    log_data = _plane_log()
+    _add_columns(
+        log_data,
+        "GPS",
+        ((17.0, 2.0, 0.0, 1.001), (19.0, 2.0, 0.0, 1.002), (20.0, 2.0, 0.0, 1.003)),
+        [("TimeUS", "f8"), ("Spd", "f8"), ("Lat", "f8"), ("Lng", "f8")],
+    )
+    attempt = PlaneLandingAttempt(
+        flight_segment=FlightSegment(start_s=0.0, end_s=30.0, is_complete=False),
+        start_s=10.0,
+        end_s=20.0,
+        end_reason=end_reason,
+        mode_number=PlaneLandingAttemptDetector.AUTO_MODE_NUMBER,
+    )
+
+    position = PlaneLandingMissionTargetExtractor._nearest_gps_position(  # pylint: disable=protected-access
+        log_data,
+        attempt,
+        target_time_s,
+    )
+
+    assert position is not None
+    assert position[0] == expected_time_s
+
+
+def test_missing_optional_arsp_and_rfnd_omits_only_their_measurements() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0, 0.0), (10.0, 1, 20.0), (15.0, 2, 5.5), (20.0, 3, 1.2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert _availability(log_data).available is True
+    assert len(evidence) == 2
+    assert all(item.airspeed_m_s is None for item in evidence)
+    assert all(item.barometric_altitude_m is not None for item in evidence)
+    assert all(item.rangefinder_distance_m is None for item in evidence)
+    assert not any("ARSP airspeed" in outcome.message for outcome in result.outcomes)
+    assert any("BARO altitude" in outcome.message for outcome in result.outcomes)
+    assert not any("RFND distance" in outcome.message for outcome in result.outcomes)
+
+
+def test_missing_rfnd_omits_lifecycle_evidence_without_affecting_availability() -> None:
+    log_data = _plane_log(messages=((40.0, "Throttle disarmed"),))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingRangefinderEvidenceExtractor.extract(log_data, attempt, ParameterHistory())
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    assert _availability(log_data).available is True
+    assert evidence is None
+    assert not any("RFND lifecycle" in outcome.message for outcome in result.outcomes)
+
+
+def test_rfnd_uses_configured_landing_orientation_instead_of_instance_zero() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 40.0, 0, 0, 4),
+            (14.0, 12.0, 1, 25, 4),
+            (15.0, 40.0, 0, 0, 4),
+            (15.0, 7.0, 1, 25, 4),
+            (20.0, 40.0, 0, 0, 4),
+            (20.0, 2.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND2_MAX": 15.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [7.0, 2.0]
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s, lifecycle.first_nonzero_distance_m) == (14.0, 12.0)
+    assert (lifecycle.first_in_range_time_s, lifecycle.first_in_range_distance_m) == (14.0, 12.0)
+
+
+def test_rfnd_only_nonzero_configured_instance_remains_available() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 12.0, 1, 25, 4), (15.0, 7.0, 1, 25, 4), (20.0, 2.0, 1, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND2_MAX": 15.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [7.0, 2.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 12.0
+
+
+def test_rfnd_selection_follows_nondefault_configured_orientation() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 4),
+            (14.0, 8.0, 1, 0, 4),
+            (15.0, 7.0, 0, 25, 4),
+            (15.0, 4.0, 1, 0, 4),
+            (20.0, 2.0, 0, 25, 4),
+            (20.0, 1.0, 1, 0, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 0.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [4.0, 1.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 8.0
+
+
+def test_rfnd_selection_uses_landing_orientation_at_each_sample_time() -> None:
+    history = ParameterHistory(
+        {"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0},
+        {"RNGFND_LND_ORNT": (ParameterChange(time_s=20.0, value=0.0),)},
+    )
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 0, 4),
+            (14.0, 8.0, 1, 25, 4),
+            (15.0, 6.0, 0, 0, 4),
+            (15.0, 4.0, 1, 25, 4),
+            (20.0, 2.0, 0, 0, 4),
+            (20.0, 1.0, 1, 25, 4),
+        ),
+        history,
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [4.0, 2.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 8.0
+
+
+def test_rfnd_orient_schema_without_historical_landing_orientation_is_unavailable() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 8.0, 0, 25, 4), (15.0, 4.0, 0, 25, 4), (20.0, 1.0, 0, 25, 4)),
+        ParameterHistory({"RNGFND1_MAX": 10.0}),
+    )
+
+    assert all(item.rangefinder_distance_m is None for item in stage_evidence)
+    assert lifecycle is None
+
+
+def test_rfnd_multiple_matching_instances_emulate_firmware_good_preference() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 3),
+            (14.0, 8.0, 1, 25, 4),
+            (15.0, 7.0, 0, 25, 3),
+            (15.0, 4.0, 1, 25, 4),
+            (20.0, 2.0, 0, 25, 4),
+            (20.0, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [4.0, 2.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 8.0
+
+
+def test_rfnd_logical_frame_allows_distinct_instance_timestamps() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 3),
+            (14.000001, 8.0, 1, 25, 4),
+            (15.0, 7.0, 0, 25, 3),
+            (15.000001, 4.0, 1, 25, 4),
+            (20.0, 2.0, 0, 25, 3),
+            (20.000001, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [4.0, 1.0]
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s, lifecycle.first_nonzero_distance_m) == (14.000001, 8.0)
+
+
+def test_rfnd_prestart_orientation_state_prevents_leading_partial_frame_selection() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.999999, 12.0, 0, 25, 4),
+            (15.000001, 3.0, 1, 25, 4),
+            (16.0, 8.0, 0, 25, 4),
+            (16.000001, 4.0, 1, 25, 3),
+            (17.0, 8.0, 0, 25, 4),
+            (17.000001, 4.0, 1, 25, 3),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+        attempt_bounds=(15.0, 40.0, PlaneLandingEndReason.DISARM),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [8.0, 8.0]
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s, lifecycle.first_nonzero_distance_m) == (16.0, 8.0)
+
+
+def test_rfnd_prestart_state_never_becomes_attempt_observation() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 4),
+            (14.999999, 11.0, 0, 25, 4),
+            (15.000001, 3.0, 1, 25, 4),
+            (16.0, 8.0, 0, 25, 4),
+            (16.000001, 4.0, 1, 25, 3),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+        attempt_bounds=(15.0, 40.0, PlaneLandingEndReason.DISARM),
+    )
+
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s, lifecycle.first_nonzero_distance_m) == (16.0, 8.0)
+
+
+def test_rfnd_removing_latest_prestart_row_still_degrades_leading_partial_frame() -> None:
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0})
+    records = (
+        (14.0, 12.0, 0, 25, 4),
+        (14.999999, 11.0, 0, 25, 4),
+        (15.000001, 3.0, 1, 25, 4),
+        (16.0, 8.0, 0, 25, 4),
+        (16.000001, 4.0, 1, 25, 3),
+    )
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        records[:1] + records[2:],
+        history,
+        attempt_bounds=(15.0, 40.0, PlaneLandingEndReason.DISARM),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [8.0, 8.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_time_s == 16.0
+
+
+def test_rfnd_multiple_matching_instances_use_lowest_instance_when_none_is_good() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 3),
+            (14.0, 8.0, 1, 25, 2),
+            (15.0, 7.0, 0, 25, 3),
+            (15.0, 4.0, 1, 25, 2),
+            (20.0, 2.0, 0, 25, 3),
+            (20.0, 1.0, 1, 25, 2),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 15.0, "RNGFND2_MAX": 15.0}),
+    )
+
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 12.0
+    assert lifecycle.first_in_range_time_s is None
+
+
+def test_rfnd_incomplete_middle_frame_does_not_erase_valid_frames() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 4),
+            (14.0, 8.0, 1, 25, 4),
+            (15.0, 7.0, 0, 25, 4),
+            (20.0, 2.0, 0, 25, 4),
+            (20.0, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [12.0, 2.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 12.0
+
+
+def test_rfnd_nonmatching_middle_frame_degrades_locally() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 8.0, 0, 25, 4),
+            (15.0, 40.0, 0, 0, 4),
+            (20.0, 2.0, 0, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [8.0, 2.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_time_s == 14.0
+
+
+def test_rfnd_unusable_middle_frame_breaks_continuity_without_disengagement() -> None:
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+    records = (
+        (10.0, 5.0, 0, 25, 4),
+        (10.25, 5.0, 0, 25, 4),
+        (10.5, 40.0, 0, 0, 4),
+        (10.75, 5.0, 0, 25, 4),
+        (11.0, 5.0, 0, 25, 4),
+    )
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(records, history)
+    stage_without_break, lifecycle_without_break = _oriented_rangefinder_evidence(
+        records[:2] + records[3:],
+        history,
+    )
+
+    assert stage_evidence == stage_without_break
+    assert lifecycle is not None
+    assert lifecycle.continuous_time_s is None
+    assert lifecycle.continuous_samples is None
+    assert lifecycle.disengagement_count == 0
+    assert lifecycle.last_disengagement_time_s is None
+    assert lifecycle_without_break is not None
+    assert (lifecycle_without_break.continuous_time_s, lifecycle_without_break.continuous_samples) == (10.0, 4)
+
+
+def test_rfnd_break_markers_do_not_reduce_observation_sample_rate_requirement() -> None:
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+    selected_records = (
+        (10.0, 5.0, 0, 25, 4),
+        (10.125, 5.0, 0, 25, 4),
+        (10.25, 5.0, 0, 25, 4),
+    )
+    records_with_breaks = (
+        *selected_records,
+        (11.25, 40.0, 0, 0, 4),
+        (12.25, 40.0, 0, 0, 4),
+        (13.25, 40.0, 0, 0, 4),
+    )
+
+    _stages, lifecycle = _oriented_rangefinder_evidence(records_with_breaks, history)
+    _stages_without_breaks, lifecycle_without_breaks = _oriented_rangefinder_evidence(selected_records, history)
+
+    assert lifecycle is not None
+    assert lifecycle_without_breaks is not None
+    assert (lifecycle.continuous_time_s, lifecycle.continuous_samples) == (None, None)
+    assert (lifecycle_without_breaks.continuous_time_s, lifecycle_without_breaks.continuous_samples) == (None, None)
+    assert (
+        PlaneLandingRangefinderEvidenceExtractor._required_continuous_samples(  # pylint: disable=protected-access
+            tuple(record[0] for record in selected_records)
+        )
+        == 8
+    )
+
+
+def test_rfnd_incomplete_middle_frame_breaks_acquisition_continuity() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (10.0, 5.0, 0, 25, 4),
+            (10.000001, 4.0, 1, 25, 3),
+            (10.25, 5.0, 0, 25, 4),
+            (10.250001, 4.0, 1, 25, 3),
+            (10.5, 5.0, 0, 25, 4),
+            (10.75, 5.0, 0, 25, 4),
+            (10.750001, 4.0, 1, 25, 3),
+            (11.0, 5.0, 0, 25, 4),
+            (11.000001, 4.0, 1, 25, 3),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert lifecycle is not None
+    assert lifecycle.continuous_time_s is None
+    assert lifecycle.continuous_samples is None
+    assert lifecycle.disengagement_count == 0
+
+
+def test_rfnd_future_matching_instance_does_not_invalidate_earlier_attempt() -> None:
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0})
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((20.0, 2.0, 0, 25, 4), (41.0, 1.0, 1, 25, 4)),
+        history,
+    )
+    stage_without_future, lifecycle_without_future = _oriented_rangefinder_evidence(
+        ((20.0, 2.0, 0, 25, 4),),
+        history,
+    )
+
+    assert [(item.rangefinder_distance_m, item.rangefinder_status) for item in stage_evidence] == [
+        (2.0, 4),
+        (2.0, 4),
+    ]
+    assert stage_evidence == stage_without_future
+    assert lifecycle is not None
+    assert lifecycle == lifecycle_without_future
+
+
+def test_rfnd_frame_straddling_attempt_end_uses_only_owned_prefix() -> None:
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0})
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((39.999999, 2.0, 0, 25, 3), (40.000001, 1.0, 1, 25, 4)),
+        history,
+    )
+
+    assert [(item.rangefinder_distance_m, item.rangefinder_status) for item in stage_evidence] == [
+        (2.0, 3),
+        (2.0, 3),
+    ]
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s, lifecycle.first_nonzero_distance_m) == (39.999999, 2.0)
+
+
+def test_rfnd_stage_restart_endpoint_is_exclusive_before_frame_selection() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((19.999999, 5.0, 0, 25, 3), (20.0, 1.0, 1, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+        attempt_bounds=(10.0, 20.0, PlaneLandingEndReason.STAGE_RESTART),
+    )
+
+    assert [(item.rangefinder_distance_m, item.rangefinder_status) for item in stage_evidence] == [(5.0, 3)]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 5.0
+
+
+def test_rfnd_incomplete_owned_frame_prefix_degrades_only_that_frame() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 8.0, 0, 25, 4),
+            (14.000001, 7.0, 1, 25, 3),
+            (19.999999, 2.0, 0, 25, 4),
+            (20.000001, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+        attempt_bounds=(10.0, 20.0, PlaneLandingEndReason.DISARM),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [8.0, 8.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_distance_m == 8.0
+
+
+def test_rfnd_logical_frame_has_no_invented_numeric_time_bound() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((20.0, 2.0, 0, 25, 3), (21.0, 1.0, 1, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [1.0, 1.0]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_time_s == 21.0
+
+
+def test_rfnd_repeated_instance_starts_new_logical_frame() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 4),
+            (14.000001, 8.0, 1, 25, 4),
+            (15.0, 7.0, 0, 25, 4),
+            (15.0, 6.0, 0, 25, 4),
+            (15.000001, 4.0, 1, 25, 4),
+            (20.0, 2.0, 0, 25, 4),
+            (20.000001, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [6.0, 2.0]
+    assert lifecycle is not None
+
+
+def test_rfnd_duplicate_middle_frame_breaks_acquisition_continuity() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (10.0, 5.0, 0, 25, 4),
+            (10.000001, 4.0, 1, 25, 3),
+            (10.25, 5.0, 0, 25, 4),
+            (10.250001, 4.0, 1, 25, 3),
+            (10.5, 5.0, 0, 25, 4),
+            (10.5, 4.5, 0, 25, 4),
+            (10.500001, 4.0, 1, 25, 3),
+            (10.75, 5.0, 0, 25, 4),
+            (10.750001, 4.0, 1, 25, 3),
+            (11.0, 5.0, 0, 25, 4),
+            (11.000001, 4.0, 1, 25, 3),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+    )
+
+    assert lifecycle is not None
+    assert lifecycle.continuous_time_s is None
+    assert lifecycle.continuous_samples is None
+    assert lifecycle.disengagement_count == 0
+
+
+def test_rfnd_malformed_middle_frame_degrades_locally() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (14.0, 12.0, 0, 25, 4),
+            (14.000001, 8.0, 1, 25, 4),
+            (15.0, 7.0, 0, 25, 4),
+            (15.000001, 4.0, 1, 25, "bad"),
+            (20.0, 2.0, 0, 25, 4),
+            (20.000001, 1.0, 1, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0, "RNGFND2_MAX": 10.0}),
+        dtype=[("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "O"), ("Orient", "O"), ("Stat", "O")],
+    )
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [12.0, 2.0]
+    assert lifecycle is not None
+
+
+def test_analysis_prepares_rfnd_once_and_reuses_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 3), (20.0, 0), (30.0, 1), (35.0, 3)),
+        messages=((18.0, "Landing aborted"), (45.0, "Throttle disarmed")),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((14.0, 5.0, 0, 25, 4), (34.0, 3.0, 0, 25, 4)),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+    selector = data_model_plane_landing._PlaneLandingRangefinderSelector  # pylint: disable=protected-access
+    original_prepare = selector.prepare
+    prepare_calls = 0
+
+    def counted_prepare(cls: type[object], prepared_log: LogData) -> object:
+        nonlocal prepare_calls
+        prepare_calls += 1
+        del cls
+        return original_prepare(prepared_log)
+
+    monkeypatch.setattr(selector, "prepare", classmethod(counted_prepare))
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    assert result.available is True
+    assert prepare_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "has_current_observation", "has_acquisition", "has_in_range"),
+    [
+        (0, False, False, False),
+        (1, False, False, False),
+        (2, True, True, False),
+        (3, True, True, False),
+        (4, True, True, True),
+    ],
+)
+def test_rfnd_status_separates_current_observation_and_usable_range(
+    status: int,
+    has_current_observation: bool,
+    has_acquisition: bool,
+    has_in_range: bool,
+) -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 5.0, 0, 25, status), (15.0, 4.0, 0, 25, status), (20.0, 2.0, 0, 25, status)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert lifecycle is not None
+    assert (lifecycle.first_nonzero_time_s is not None) is has_acquisition
+    assert (lifecycle.first_in_range_time_s is not None) is has_in_range
+    assert [item.rangefinder_distance_m is not None for item in stage_evidence] == [
+        has_current_observation,
+        has_current_observation,
+    ]
+    assert [item.rangefinder_status for item in stage_evidence] == [status, status]
+
+
+def test_rfnd_out_of_range_low_zero_is_current_observation_not_acquisition() -> None:
+    stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 0.0, 0, 25, 2), (15.0, 0.0, 0, 25, 2), (20.0, 0.0, 0, 25, 2)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert [(item.rangefinder_distance_m, item.rangefinder_status) for item in stage_evidence] == [(0.0, 2), (0.0, 2)]
+    assert lifecycle is not None
+    assert lifecycle.first_nonzero_time_s is None
+    assert lifecycle.first_in_range_time_s is None
+
+
+@pytest.mark.parametrize(
+    ("status", "status_name", "distance_is_present", "usability_text"),
+    [
+        (0, "NotConnected", False, "no current range measurement"),
+        (1, "NoData", False, "no current range measurement"),
+        (2, "OutOfRangeLow", True, "not usable as Plane landing-height evidence"),
+        (3, "OutOfRangeHigh", True, "not usable as Plane landing-height evidence"),
+        (4, "Good", True, None),
+    ],
+)
+def test_rfnd_stage_flat_output_reports_observation_status_and_usability(
+    status: int,
+    status_name: str,
+    distance_is_present: bool,
+    usability_text: str | None,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((14.0, 5.0, 0, 25, status), (15.0, 4.0, 0, 25, status), (20.0, 2.0, 0, 25, status)),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    stage_messages = [outcome.message for outcome in result.outcomes if "Attempt 1 preflare" in outcome.message]
+    assert any(f"RFND status {status_name} ({status})" in message for message in stage_messages) is (status != 4)
+    if usability_text is not None:
+        assert any(usability_text in message for message in stage_messages)
+    assert any("RFND distance" in message for message in stage_messages) is distance_is_present
+
+
+def test_unknown_rfnd_status_is_reported_numerically_without_current_distance() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((15.0, 4.0, 0, 25, 5),),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    stage_messages = [outcome.message for outcome in result.outcomes if "Attempt 1 preflare" in outcome.message]
+    assert any(message.endswith("RFND status 5") for message in stage_messages)
+    assert not any("RFND distance" in message for message in stage_messages)
+
+
+def test_rfnd_good_nodata_good_breaks_acquisition_without_using_retained_distance() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 5.0, 0, 25, 4), (15.0, 5.0, 0, 25, 1), (20.0, 2.0, 0, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert lifecycle is not None
+    assert lifecycle.disengagement_count == 1
+    assert lifecycle.last_disengagement_time_s == 15.0
+    assert lifecycle.last_disengagement_distance_m is None
+    assert lifecycle.last_disengagement_status == 1
+    assert lifecycle.continuous_time_s is None
+    assert lifecycle.continuous_samples is None
+
+
+def test_rfnd_nodata_resets_multi_sample_continuous_acquisition() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        (
+            (10.0, 5.0, 0, 25, 4),
+            (10.25, 5.0, 0, 25, 4),
+            (10.5, 5.0, 0, 25, 4),
+            (10.75, 5.0, 0, 25, 1),
+            (11.0, 5.0, 0, 25, 4),
+            (11.25, 5.0, 0, 25, 4),
+            (11.5, 5.0, 0, 25, 4),
+        ),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert lifecycle is not None
+    assert lifecycle.continuous_time_s is None
+    assert lifecycle.continuous_samples is None
+    assert lifecycle.last_disengagement_status == 1
+
+
+@pytest.mark.parametrize(("status", "status_name"), [(0, "NotConnected"), (1, "NoData")])
+def test_rfnd_no_current_data_disengagement_flat_output_preserves_status_without_distance(
+    status: int,
+    status_name: str,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((14.0, 5.0, 0, 25, 4), (16.0, 5.0, 0, 25, status), (20.0, 2.0, 0, 25, 4)),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+    lifecycle_messages = [outcome for outcome in result.outcomes if "RFND lifecycle" in outcome.message]
+
+    status_outcome = next(outcome for outcome in lifecycle_messages if "last disengagement status" in outcome.message)
+    assert status_name in status_outcome.message
+    assert "distance unavailable" in status_outcome.message
+    assert (status_outcome.timestamp_us, status_outcome.value) == (16_000_000, float(status))
+    assert not any("last disengagement distance" in outcome.message for outcome in lifecycle_messages)
+
+
+def test_rfnd_good_status_is_reported_when_distance_is_unavailable() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((15.0, float("nan"), 0, 25, 4),),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1"), ("Orient", "u1"), ("Stat", "u1")],
+    )
+    history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    assert any("RFND status Good (4) — distance unavailable" in outcome.message for outcome in result.outcomes)
+    assert not any("RFND distance" in outcome.message for outcome in result.outcomes)
+
+
+def test_rfnd_nodata_retained_distance_is_not_stage_point_evidence() -> None:
+    stage_evidence, _lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 7.5, 0, 25, 1), (15.0, 7.5, 0, 25, 1), (20.0, 7.5, 0, 25, 1)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0}),
+    )
+
+    assert all(item.rangefinder_distance_m is None for item in stage_evidence)
+    assert [item.rangefinder_status for item in stage_evidence] == [1, 1]
+
+
+def test_rfnd_instance_nine_uses_rngfnda_max() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 8.0, 9, 25, 4), (15.0, 6.0, 9, 25, 4), (20.0, 2.0, 9, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFNDA_MAX": 7.0}),
+    )
+
+    assert lifecycle is not None
+    assert (lifecycle.first_in_range_time_s, lifecycle.first_in_range_distance_m) == (15.0, 6.0)
+
+
+def test_rfnd_selected_nonzero_instance_does_not_use_rngfnd1_max() -> None:
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 8.0, 1, 25, 4), (15.0, 6.0, 1, 25, 4), (20.0, 2.0, 1, 25, 4)),
+        ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 100.0, "RNGFND2_MAX": 5.0}),
+    )
+
+    assert lifecycle is not None
+    assert (lifecycle.first_in_range_time_s, lifecycle.first_in_range_distance_m) == (20.0, 2.0)
+
+
+def test_rfnd_selected_instance_uses_event_time_max_change() -> None:
+    history = ParameterHistory(
+        {"RNGFND_LND_ORNT": 25.0, "RNGFND2_MAX": 5.0},
+        {"RNGFND2_MAX": (ParameterChange(time_s=15.0, value=7.0),)},
+    )
+    _stage_evidence, lifecycle = _oriented_rangefinder_evidence(
+        ((14.0, 8.0, 1, 25, 4), (15.0, 6.0, 1, 25, 4), (20.0, 2.0, 1, 25, 4)),
+        history,
+    )
+
+    assert lifecycle is not None
+    assert (lifecycle.first_in_range_time_s, lifecycle.first_in_range_distance_m) == (15.0, 6.0)
+
+
+def test_rfnd_active_threshold_and_first_active_sample() -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(((10.0, 0.05), (11.0, 0.051), (12.0, 0.0)))
+
+    assert evidence is not None
+    assert (evidence.first_nonzero_time_s, evidence.first_nonzero_distance_m) == (11.0, 0.05)
+    assert evidence.continuous_time_s is None
+    assert evidence.continuous_samples is None
+    assert evidence.disengagement_count == 1
+    assert (evidence.last_disengagement_time_s, evidence.last_disengagement_distance_m) == (12.0, 0.0)
+
+
+def test_rfnd_first_in_range_uses_parameter_value_at_each_sample_time() -> None:
+    history = ParameterHistory(
+        {"RNGFND1_MAX": 5.0},
+        {"RNGFND1_MAX": (ParameterChange(time_s=12.0, value=7.0),)},
+    )
+    _log_data, _attempt, evidence = _rangefinder_evidence(
+        ((10.0, 8.0), (11.0, 6.0), (12.0, 6.0)),
+        history,
+    )
+
+    assert evidence is not None
+    assert (evidence.first_nonzero_time_s, evidence.first_nonzero_distance_m) == (10.0, 8.0)
+    assert (evidence.first_in_range_time_s, evidence.first_in_range_distance_m) == (12.0, 6.0)
+
+
+def test_rfnd_median_sample_rate_and_exact_continuous_threshold() -> None:
+    assert (
+        PlaneLandingRangefinderEvidenceExtractor._required_continuous_samples(  # pylint: disable=protected-access
+            (10.0, 10.2, 10.4, 11.4)
+        )
+        == 5
+    )
+    _log_data, _attempt, evidence = _rangefinder_evidence(((10.0, 1.0), (10.2, 1.0), (10.4, 1.0), (10.6, 1.0), (10.8, 1.0)))
+
+    assert evidence is not None
+    assert (evidence.continuous_time_s, evidence.continuous_samples) == (10.0, 5)
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        ((10.0, 1.0),),
+        ((10.0, 1.0), (10.0, 1.0)),
+        ((10.0, 1.0), (30.0, 1.0)),
+    ],
+    ids=("one-sample", "duplicate-timestamps", "twenty-second-gap"),
+)
+def test_rfnd_sparse_or_unusable_cadence_does_not_establish_continuity(
+    records: Sequence[tuple[float, float]],
+) -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(records)
+
+    assert evidence is not None
+    assert evidence.continuous_time_s is None
+    assert evidence.continuous_samples is None
+
+
+@pytest.mark.parametrize(
+    ("records", "expected_samples"),
+    [
+        (tuple((10.0 + index * 0.25, 1.0) for index in range(4)), 4),
+        (tuple((10.0 + index * 0.02, 1.0) for index in range(50)), 50),
+    ],
+    ids=("four-hertz", "fifty-hertz"),
+)
+def test_rfnd_normal_cadence_still_establishes_continuity(
+    records: Sequence[tuple[float, float]],
+    expected_samples: int,
+) -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(records)
+
+    assert evidence is not None
+    assert (evidence.continuous_time_s, evidence.continuous_samples) == (10.0, expected_samples)
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        (*tuple((10.0 + index * 0.25, 1.0) for index in range(8)), (11.75, 1.0)),
+        (*tuple((10.0 + index * 0.25, 1.0) for index in range(8)), (30.0, 1.0), (30.0, 1.0)),
+    ],
+    ids=("isolated-duplicate", "later-duplicate-pair"),
+)
+def test_rfnd_duplicate_timestamp_does_not_erase_valid_cadence(
+    records: Sequence[tuple[float, float]],
+) -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(records)
+
+    assert evidence is not None
+    assert (evidence.continuous_time_s, evidence.continuous_samples) == (10.0, 4)
+
+
+@pytest.mark.parametrize(
+    "timestamps_s",
+    [
+        (10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.25),
+        (10.0, 10.0, 10.0, 10.25),
+        (10.0, 12.0, 14.0, 16.0, 16.0),
+    ],
+    ids=("seven-duplicates", "three-duplicates", "sparse-trailing-duplicate"),
+)
+def test_rfnd_duplicate_timestamps_do_not_count_as_distinct_continuity_samples(
+    timestamps_s: Sequence[float],
+) -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(tuple((timestamp_s, 1.0) for timestamp_s in timestamps_s))
+
+    assert evidence is not None
+    assert evidence.continuous_time_s is None
+    assert evidence.continuous_samples is None
+
+
+def test_rfnd_sparse_old_observation_does_not_block_later_dense_qualifying_run() -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(((10.0, 1.0), (20.0, 1.0), (20.25, 1.0), (20.5, 1.0), (20.75, 1.0)))
+
+    assert evidence is not None
+    assert (evidence.continuous_time_s, evidence.continuous_samples) == (20.0, 4)
+
+
+def test_rfnd_interrupted_run_resets_continuity_and_tracks_multiple_disengagements() -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(
+        (
+            (10.0, 1.0),
+            (10.25, 1.0),
+            (10.5, 0.0),
+            (10.75, 2.0),
+            (11.0, 2.0),
+            (11.25, 2.0),
+            (11.5, 2.0),
+            (11.75, 0.04),
+        )
+    )
+
+    assert evidence is not None
+    assert (evidence.continuous_time_s, evidence.continuous_samples) == (10.75, 4)
+    assert evidence.disengagement_count == 2
+    assert (evidence.last_disengagement_time_s, evidence.last_disengagement_distance_m) == (11.75, 0.04)
+
+
+def test_rfnd_active_run_without_inactive_sample_has_no_disengagement() -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(((10.0, 1.0), (11.0, 1.0)))
+
+    assert evidence is not None
+    assert evidence.disengagement_count == 0
+    assert evidence.last_disengagement_time_s is None
+    assert evidence.last_disengagement_distance_m is None
+
+
+def test_rfnd_lifecycle_is_restricted_to_attempt_and_does_not_change_boundaries() -> None:
+    log_data = _plane_log(messages=((40.0, "Throttle disarmed"),))
+    _add_columns(
+        log_data,
+        "RFND",
+        ((9.0, 9.0), (10.0, 1.0), (39.0, 1.0), (41.0, 0.0)),
+        [("TimeUS", "f8"), ("Dist", "f8")],
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    boundaries_before = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    evidence = PlaneLandingRangefinderEvidenceExtractor.extract(log_data, boundaries_before[0], ParameterHistory())
+    boundaries_after = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert evidence is not None
+    assert (evidence.first_nonzero_time_s, evidence.first_nonzero_distance_m) == (10.0, 1.0)
+    assert evidence.disengagement_count == 0
+    assert boundaries_after == boundaries_before
+
+
+def test_non_finite_and_malformed_rfnd_values_are_conservatively_invalid() -> None:
+    _log_data, _attempt, evidence = _rangefinder_evidence(
+        ((10.0, "bad"), ("bad", 9.0), (11.0, 1.0), (12.0, float("nan")), (float("inf"), 0.0)),
+        dtype=[("TimeUS", "O"), ("Dist", "O")],
+    )
+
+    assert evidence is not None
+    assert (evidence.first_nonzero_time_s, evidence.first_nonzero_distance_m) == (11.0, 1.0)
+    assert evidence.disengagement_count == 1
+    assert evidence.last_disengagement_time_s == 12.0
+    assert evidence.last_disengagement_distance_m is None
+
+
+def test_rfnd_lifecycle_flat_outcomes_leave_stage_point_measurement_unchanged() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0, 0.0), (10.0, 1, 20.0), (15.0, 2, 5.5), (20.0, 3, 1.2)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        ((14.7, 6.0), (15.0, 5.5), (20.2, 1.5), (21.0, 0.0)),
+        [("TimeUS", "f8"), ("Dist", "f8")],
+    )
+    history = ParameterHistory({"RNGFND1_MAX": 5.5})
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    stage_evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, history)
+    lifecycle_evidence = PlaneLandingRangefinderEvidenceExtractor.extract(log_data, attempt, history)
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    preflare, flare = stage_evidence
+    assert (preflare.rangefinder_distance_m, flare.rangefinder_distance_m) == (5.5, 1.5)
+    assert lifecycle_evidence is not None
+    assert (lifecycle_evidence.first_nonzero_time_s, lifecycle_evidence.first_nonzero_distance_m) == (14.7, 6.0)
+    assert (lifecycle_evidence.first_in_range_time_s, lifecycle_evidence.first_in_range_distance_m) == (15.0, 5.5)
+    lifecycle_outcomes = [outcome for outcome in result.outcomes if "RFND lifecycle" in outcome.message]
+    assert [(outcome.timestamp_us, outcome.value) for outcome in lifecycle_outcomes] == [
+        (14_700_000, 6.0),
+        (15_000_000, 5.5),
+        (14_700_000, 2.0),
+        (21_000_000, 0.0),
+        (40_000_000, 1.0),
+    ]
+
+
+def test_rfnd_lifecycle_and_stage_distance_use_only_instance_zero() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    _add_columns(
+        log_data,
+        "RFND",
+        (
+            (14.7, 0.0, 1),
+            (14.7, 6.0, 0),
+            (15.0, 0.0, 1),
+            (15.0, 5.5, 0),
+            (20.2, 0.0, 1),
+            (20.2, 1.5, 0),
+            (21.0, 0.0, 1),
+            (21.0, 1.0, 0),
+        ),
+        [("TimeUS", "f8"), ("Dist", "f8"), ("Instance", "u1")],
+    )
+    history = ParameterHistory({"RNGFND1_MAX": 10.0})
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    stage_evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, history)
+    lifecycle_evidence = PlaneLandingRangefinderEvidenceExtractor.extract(log_data, attempt, history)
+
+    assert [item.rangefinder_distance_m for item in stage_evidence] == [5.5, 1.5]
+    assert lifecycle_evidence is not None
+    assert (lifecycle_evidence.first_nonzero_time_s, lifecycle_evidence.first_nonzero_distance_m) == (14.7, 6.0)
+    assert lifecycle_evidence.disengagement_count == 0
+    assert lifecycle_evidence.last_disengagement_time_s is None
+
+
+@pytest.mark.parametrize("non_finite_value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_event_time_landing_parameters_are_unavailable(non_finite_value: float) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    parameter_names = ("LAND_PF_ALT", "LAND_PF_SEC", "LAND_FLARE_ALT", "LAND_FLARE_SEC", "LAND_PITCH_DEG")
+    history = ParameterHistory(dict.fromkeys(parameter_names, non_finite_value))
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+
+    evidence = PlaneLandingEvidenceExtractor.extract(log_data, attempt, history)
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    assert all(value is None for item in evidence for value in item.parameter_values.values())
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    assert attempt_outcome.value is None
+    assert "LAND_FLARE_ALT was unavailable" in attempt_outcome.message
+    assert not any(
+        parameter_name in outcome.message and "effective value" in outcome.message
+        for parameter_name in parameter_names
+        for outcome in result.outcomes
+    )
+
+
+def test_finite_event_time_landing_parameters_are_emitted() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    parameter_values = {
+        "LAND_PF_ALT": 6.0,
+        "LAND_PF_SEC": 2.0,
+        "LAND_FLARE_ALT": 3.0,
+        "LAND_FLARE_SEC": 1.5,
+        "LAND_PITCH_DEG": 4.0,
+    }
+
+    result = PlaneLandingAnalysis(log_data, _context(ParameterHistory(parameter_values))).analyse()
+
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    assert attempt_outcome.value == 3.0
+    parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
+    emitted_parameter_names = {
+        parameter_name
+        for parameter_name in parameter_values
+        if any(parameter_name in item.message for item in parameter_outcomes)
+    }
+    assert emitted_parameter_names == set(parameter_values)
+
+
+def test_finite_parameter_change_at_event_time_remains_effective() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2), (20.0, 3)),
+        messages=((40.0, "Throttle disarmed"),),
+    )
+    history = ParameterHistory(
+        {"LAND_PF_ALT": 5.0, "LAND_FLARE_ALT": 3.0},
+        {
+            "LAND_PF_ALT": (ParameterChange(time_s=15.0, value=6.0),),
+            "LAND_FLARE_ALT": (ParameterChange(time_s=20.0, value=4.0),),
+        },
+    )
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    assert attempt_outcome.value == 3.0
+    parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
+    assert [(outcome.timestamp_us, outcome.value) for outcome in parameter_outcomes] == [
+        (15_000_000, 6.0),
+        (20_000_000, 4.0),
+    ]
+
+
+def test_event_time_parameters_change_between_attempts_without_changing_boundaries() -> None:
+    log_data = _plane_log(
+        land=(
+            (5.0, 0, 0.0),
+            (10.0, 1, 20.0),
+            (15.0, 2, 5.0),
+            (18.0, 3, 2.0),
+            (21.0, 0, 0.0),
+            (30.0, 1, 20.0),
+            (35.0, 2, 6.0),
+            (38.0, 3, 2.5),
+        ),
+        messages=((20.0, "Landing aborted"), (50.0, "Throttle disarmed")),
+    )
+    history = ParameterHistory(
+        {"LAND_FLARE_ALT": 2.0},
+        {"LAND_FLARE_ALT": (ParameterChange(time_s=38.0, value=4.0),)},
+    )
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    boundaries_before = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+    boundaries_after = PlaneLandingAttemptDetector.detect(log_data, segment)
+
+    assert boundaries_after == boundaries_before
+    assert [(attempt.start_s, attempt.end_s, attempt.end_reason) for attempt in boundaries_after] == [
+        (10.0, 20.0, PlaneLandingEndReason.ABORT),
+        (30.0, 50.0, PlaneLandingEndReason.DISARM),
+    ]
+    flare_parameter_outcomes = [outcome for outcome in result.outcomes if "LAND_FLARE_ALT effective value" in outcome.message]
+    assert [outcome.timestamp_us for outcome in flare_parameter_outcomes] == [18_000_000, 38_000_000]
+    assert [outcome.value for outcome in flare_parameter_outcomes] == [2.0, 4.0]
+    assert all(outcome.suggested_value is None for outcome in result.outcomes)
+
+
+def test_analysis_resolves_landing_parameter_at_each_attempt_time() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (11.0, 2), (30.0, 1)),
+        messages=((20.0, "Landing aborted"), (50.0, "Throttle disarmed")),
+    )
+    history = ParameterHistory(
+        {"LAND_FLARE_ALT": 2.0},
+        {"LAND_FLARE_ALT": (ParameterChange(time_s=25.0, value=4.0),)},
+    )
+
+    result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
+
+    assert result.available is True
+    assert result.reason == "Detected 2 Plane landing attempt(s)"
+    attempt_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt")]
+    assert [outcome.timestamp_us for outcome in attempt_outcomes] == [10_000_000, 30_000_000]
+    assert [outcome.value for outcome in attempt_outcomes] == [2.0, 4.0]
+    assert all(outcome.param_name is None for outcome in attempt_outcomes)
+    assert all(outcome.suggested_value is None for outcome in result.outcomes)
+    assert "landing abort message" in attempt_outcomes[0].message
+    assert "throttle disarm message" in attempt_outcomes[1].message
+
+
+def test_plane_landing_models_are_registered_as_one_subsystem_pair() -> None:
+    spec = next(spec for spec in data_model_log_analysis.LOG_ANALYSIS_SUBSYSTEMS if spec.key == "plane_landing")
+
+    assert spec.availability_model is PlaneLandingAvailabilityModel
+    assert spec.analysis_model is PlaneLandingAnalysis


### PR DESCRIPTION
## Summary

Adds ArduPlane 4.7.x landing analysis to AMC using the existing
log-analysis architecture and flat result model.

The implementation is based on the validated landing behavior from
ArduPilotTools (APT), migrated onto AMC-native:

- LogData
- LogAnalysisContext
- PlaneFlightSegmentDetector
- ParameterHistory
- availability/analysis registry
- flat LogAnalysisResult findings

No Plane-specific backend orchestration or frontend path is introduced.

## Scope

Initial support is intentionally limited to ArduPlane 4.7.x.

Required evidence:
- GPS
- LAND
- MODE
- BARO

Optional evidence:
- ARSP
- RFND
- CMD
- MSG

The subsystem also requires at least one operational Plane flight segment.

## Landing attempt detection

Supports:

- multiple landing attempts within one flight
- aborted/restarted approaches
- go-arounds without splitting the parent flight
- AUTO landing-stage detection
- GPS-stop termination
- abort-message termination
- mode-exit termination
- disarm termination
- parent flight-segment termination

Across the four established APT regression logs:

- 10 operational flights
- 16 landing attempts
- 16/16 attempt boundaries and associations match the validated APT behavior

## Landing evidence

Adds objective flat findings for:

- LAND stage 2 preflare timing/height
- LAND stage 3 flare timing/height
- preflare/flare GPS speed
- ARSP evidence where available
- BARO altitude and preflare sink rate
- RFND stage-point evidence
- event-time landing parameters using ParameterHistory
- firmware landing glide-slope messages
- firmware flare altitude/sink/airspeed/distance
- flare-to-GPS-stop duration

Firmware comparison against the reference logs:

- 16/16 glide-slope events match
- 14/14 firmware flare events match

## Mission LAND target evidence

Implements conservative CMD snapshot reconstruction matching APT:

- complete ordered mission snapshots only
- latest complete snapshot applicable at attempt start
- exactly one MAV_CMD_NAV_LAND
- malformed/incomplete/ambiguous mission state rejected
- independently computed GPS-stop to mission LAND-target distance

Reference comparison:

- 16/16 mission LAND-target selections match APT
- 3/3 computed target distances match APT

## Rangefinder lifecycle evidence

Adds the validated APT RFND lifecycle evidence:

- first nonzero sample
- first in-range sample
- continuous acquisition
- disengagement count
- last disengagement

All nine RFND lifecycle fields match across all 16 reference landing attempts.

RFND remains optional.

## AMC-specific correctness

Landing GPS consumers use AMC's existing active-receiver convention:

- if GPS.U exists, only U == 1 is used
- otherwise all GPS records are used

Event-time landing parameter findings also reject non-finite values rather
than emitting NaN/Inf evidence.

## Architecture

Follows `ARCHITECTURE_log_analysis.md` and the documented
"Extending the Log Analysis System" path.

The PR:

- uses existing LogData and LogAnalysisContext
- uses the existing Plane flight segmentation infrastructure
- uses shared ParameterHistory
- registers the Plane landing subsystem through the existing registry
- emits existing flat analysis results
- makes no extraction/backend/frontend architecture changes

## Deliberately out of scope

Not included in this PR:

- touchdown detection
- post-attempt rollout evidence
- firmware `Distance from LAND point=...`
- widening completed FlightSegments
- runway/cross-track/along-track geometry
- qualitative landing scoring
- parameter recommendations
- Plane landing configuration-step/frontend changes
- hierarchical per-flight/per-attempt results
- firmware support outside ArduPlane 4.7.x

## Validation

Final applicable non-SITL AMC test run:

- 4901 passed
- 55 skipped
- 4 xfailed

Additional validation:

- focused Plane landing tests pass
- APT landing regression passes
- APT event/timeline regression passes
- Ruff lint passes
- Ruff format check passes
- changed-file mypy passes
- changed-file pylint 10.00/10
- git diff --check passes