### PR TITLE
Revert "build(dist): update pyinstaller"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,22 +102,22 @@ pypi_dist = [
 win_dist = [
     "pip==26.2.1",
     "pywin32==312",
-    "pyinstaller==6.22.2",
-    "pyinstaller-hooks-contrib==2026.7",
+    "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.3",
 ]
 
 mac_dist = [
     "pip==26.2.1",
-    "pyinstaller==6.22.2",
-    "pyinstaller-hooks-contrib==2026.7",
+    "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.3",
 ]
 
 linux_dist = [
     "pip==26.2.1",
-    "pyinstaller==6.22.2",
-    "pyinstaller-hooks-contrib==2026.7",
+    "pyinstaller==6.20.0",
+    "pyinstaller-hooks-contrib==2026.6",
     "packaging==26.3",
 ]
 


### PR DESCRIPTION
This reverts commit 9439965b1947a92212d60eb9fd016d1f4716b68f.

# Description

It broke windows binary again! :(

## Checklist

- [ ] Run pre-commit checks locally
- [ ] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [ ] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [ ] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
