### PR TITLE
test(acceptance): sort vehicle template discovery for deterministic order

### DIFF
--- a/tests/acceptance_template_import_from_params.py
+++ b/tests/acceptance_template_import_from_params.py
@@ -237,6 +237,11 @@ def perform_component_inference(
     return True, ""
 
 
+def _sort_key(path: Path) -> str:
+    """Case-insensitive sort key, so directory order does not depend on the filesystem."""
+    return path.name.lower()
+
+
 def get_vehicle_template_directories() -> list[Path]:
     """
     Get all vehicle template directories that contain param files.
@@ -248,19 +253,21 @@ def get_vehicle_template_directories() -> list[Path]:
     template_base = Path(__file__).parent.parent / "ardupilot_methodic_configurator" / "vehicle_templates"
 
     vehicle_dirs = []
-    for vehicle_type_dir in template_base.iterdir():
+    # Path.iterdir() yields entries in filesystem order, so sort by lower-cased name to keep the
+    # discovery order identical on every platform. Tests below only examine the first few entries.
+    for vehicle_type_dir in sorted(template_base.iterdir(), key=_sort_key):
         if not vehicle_type_dir.is_dir():
             continue
 
         # Iterate through specific vehicle directories (e.g., diatone_taycan_mxc)
-        for vehicle_dir in vehicle_type_dir.iterdir():
+        for vehicle_dir in sorted(vehicle_type_dir.iterdir(), key=_sort_key):
             if not vehicle_dir.is_dir():
                 continue
 
             param_subdirs = [d for d in vehicle_dir.iterdir() if d.is_dir()]
 
             if param_subdirs:
-                vehicle_dirs.extend(param_subdirs)
+                vehicle_dirs.extend(sorted(param_subdirs, key=_sort_key))
             else:
                 # Check if this directory directly contains .param files
                 param_files = list(vehicle_dir.glob("*.param"))


### PR DESCRIPTION
# Description

`Pytest` and `Docker CI` have been red on every push to `master` for weeks. The single failing test is

```
tests/acceptance_template_import_from_params.py::TestComponentInferenceValidation::test_component_inference_from_params_file_matches_original
```

The bug is in the test's template discovery, not in the product code.

## Root cause

`get_vehicle_template_directories()` returned templates in raw `Path.iterdir()` order, which is filesystem dependent. The two tests that consume the `compounded_params_files` fixture only examine a prefix of that list:

- line 611: `list(compounded_params_files.items())[:10]`
- line 895: `list(compounded_params_files.items())[:5]`

The fixture builds its dict directly from `get_vehicle_template_directories()` (line 341), so *which* templates get exercised is decided by the filesystem.

On the `ubuntu-latest` runners `iterdir()` yields the non-ArduCopter vehicle types first, so the entire `[:5]` window lands on ArduPlane / Heli / Rover templates. `get_empty_template_dir()` only resolves `empty_4.6.x`, and that directory ships for **ArduCopter only**:

```
ArduCopter: empty_4.5.x empty_4.6.x empty_4.7.x
ArduPlane:  empty_4.7.x
Heli:       (none)
Rover:      (none)
```

So every one of the five iterations is skipped by the `except ... continue` path, `all_comparisons` stays empty, and line 938 fails.

The platform split proves this is an ordering bug rather than a product bug. On commit `f87497de` (run [33964524674](https://github.com/ArduPilot/MethodicConfigurator/actions/runs/33964524674)):

| job | result |
| --- | --- |
| pytest (ubuntu-latest, 3.10) | **failure** |
| pytest (ubuntu-latest, 3.14) | **failure** |
| pytest (macos-latest, 3.14) | success |
| pytest (windows-latest, 3.14) | success |

with `1 failed, 4906 passed, 8 skipped, 4 xfailed` and the sole failure being the test above.

## The change

Sort every directory listing in `get_vehicle_template_directories()` by lower-cased name, so discovery no longer depends on the filesystem. 10 added / 3 removed lines in one test file; no product code touched.

One subtlety worth flagging: a plain `sorted()` over the `Path` objects would **not** have been enough. `PurePath` comparison is case-insensitive on Windows and case-sensitive on POSIX, so `sorted()` alone still yields a different `[:5]` window per platform. Sorting on `path.name.lower()` is genuinely platform independent.

I deliberately did **not** widen `get_empty_template_dir()`'s hardcoded `empty_4.6.x`, and did **not** soften the `assert len(all_comparisons) > 0`. The module docstring already documents that the non-ArduCopter skips are expected, so changing that behaviour is a separate decision for you; determinism alone fixes the red CI, and the assertion stays meaningful.

## How it was verified

All runs on this branch, Python 3.12.10, `pip install -e ".[dev]"`.

**1. Reproduced the Linux CI failure locally.** With the *unpatched* function and `return vehicle_dirs[::-1]` to emulate the ext4 ordering:

```
>       assert len(all_comparisons) > 0, "No component comparisons were performed"
E       AssertionError: No component comparisons were performed
E       assert 0 > 0
E        +  where 0 = len([])

tests\acceptance_template_import_from_params.py:938: AssertionError
============================= 1 failed in 17.74s ==============================
```

That is byte-for-byte the CI failure.

**2. With the fix, the whole module passes** (the `[:10]` window at line 611 matters here too, so I ran the module, not just the one test):

```
tests\acceptance_template_import_from_params.py ......s
================== 6 passed, 1 skipped in 115.60s (0:01:55) ===================
```

The single skip is the pre-existing `KNOWN ISSUE` skip at line 1395, unrelated to this change.

**3. No behaviour change on the platforms that were already green.** Running the same module on unpatched `master` on this machine gives an identical result:

```
tests\acceptance_template_import_from_params.py ......s
================== 6 passed, 1 skipped in 137.27s (0:02:17) ===================
```

The sorted `[:5]` and `[:10]` windows are exactly the ones the passing `windows-latest` job already exercises, so `assert match_percentage > 90.0` at line 964 is evaluated over the same templates as before:

```
[:5]  ArduCopter/AirCar_v1, ArduCopter/Big_Owl, ArduCopter/Chimera7,
      ArduCopter/Demo32Motor_PeterHall, ArduCopter/diatone_taycan_mxc/4.3.8-params
[:10] + diatone_taycan_mxc/{4.4.4,4.5.x,4.6.x}-params, empty_4.5.x, empty_4.6.x
```

**4. Order independence.** Monkeypatching `Path.iterdir()` to shuffle its results, over 20 different seeds:

```
20 shuffled filesystem orders -> identical discovery list: True
every template in [:10] is ArduCopter: True
ArduCopter has empty_4.6.x: True
```

**5. Lint.** `pre-commit run --files tests/acceptance_template_import_from_params.py`:

```
codespell.......................................................................Passed
ruff check......................................................................Passed
ruff format.....................................................................Passed
reuse lint-file.................................................................Passed
Detect hardcoded secrets........................................................Passed
```

`pylint tests/acceptance_template_import_from_params.py` → `rated at 10.00/10`. `mypy` reports only pre-existing findings at lines 792 and 1008, both outside the lines this PR touches.

## Limitation

I could only run on Windows locally, so the Linux path is verified by emulating its ordering (step 1) plus the shuffle proof (step 4) rather than on a real ext4 runner. CI on this PR will exercise the real `ubuntu-latest` job.

## Checklist

- [x] Run pre-commit checks locally
- [ ] Verified by a human programmer — *this patch was prepared with AI assistance; please treat the review as unverified on that axis*
- [x] All commits are signed off (use `git commit --signoff`)
- [x] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [x] Documentation updated if needed — no doc change needed, test-only fix
- [x] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [x] Unit tests pass — full `tests/acceptance_template_import_from_params.py` module, before/after, plus the reversed-order reproduction
- [ ] Integration tests pass — I did not run the full repository suite locally
- [x] Manual testing performed — shuffled-`iterdir()` determinism check described above
- [ ] Tested on flight controller hardware — not applicable, test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
