### PR TITLE
feat(log-analysis): improve report readability and grouping

### DIFF
--- a/ardupilot_methodic_configurator/formatting.py
+++ b/ardupilot_methodic_configurator/formatting.py
@@ -14,3 +14,14 @@ def format_filesize(size_bytes: int) -> str:
     if size_bytes < 1024 * 1024:
         return f"{size_bytes / 1024:.1f} KB"
     return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def format_elapsed_time(seconds: float) -> str:
+    """Format elapsed seconds as M:SS.s or H:MM:SS.s for display."""
+    total_tenths = round(seconds * 10)
+    hours, remainder_tenths = divmod(total_tenths, 36_000)
+    minutes, second_tenths = divmod(remainder_tenths, 600)
+    seconds_text = f"{second_tenths / 10:04.1f}"
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds_text}"
+    return f"{minutes}:{seconds_text}"

--- a/ardupilot_methodic_configurator/frontend_tkinter_log_analysis.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_log_analysis.py
@@ -332,12 +332,12 @@ class LogAnalysisReportWindow(BaseWindow):  # pylint: disable=too-many-instance-
         label.bind("<Configure>", partial(self._set_wraplength, label))
 
     def _outcome_line(self, outcome: LogAnalysis) -> None:
-        timestamp_text = f" ({format_elapsed_time(outcome.timestamp_us / 1e6)})" if outcome.timestamp_us is not None else ""
+        timestamp_text = f"{format_elapsed_time(outcome.timestamp_us / 1e6)}  " if outcome.timestamp_us is not None else ""
         row = ttk.Frame(self.body_frame)
         row.pack(anchor=tk.W, padx=(10, 0), pady=5, fill=tk.X)
         label = ttk.Label(
             row,
-            text=f"{outcome.message}{timestamp_text}",
+            text=f"{timestamp_text}{outcome.message}",
             font=("TkDefaultFont", 14),
             justify=tk.LEFT,
         )

--- a/ardupilot_methodic_configurator/frontend_tkinter_log_analysis.py
+++ b/ardupilot_methodic_configurator/frontend_tkinter_log_analysis.py
@@ -27,6 +27,7 @@ from ardupilot_methodic_configurator.backend_filesystem import LocalFilesystem
 from ardupilot_methodic_configurator.backend_internet import webbrowser_open_url
 from ardupilot_methodic_configurator.common_arguments import add_common_arguments
 from ardupilot_methodic_configurator.data_model_par_dict import Par
+from ardupilot_methodic_configurator.formatting import format_elapsed_time
 from ardupilot_methodic_configurator.frontend_tkinter_autoresize_combobox import AutoResizeCombobox
 from ardupilot_methodic_configurator.frontend_tkinter_base_window import BaseWindow
 from ardupilot_methodic_configurator.frontend_tkinter_scroll_frame import ScrollFrame
@@ -155,7 +156,7 @@ class LogAnalysisReportWindow(BaseWindow):  # pylint: disable=too-many-instance-
                 self._report_analysis_by_name[name.removesuffix(" Analysis")] = entry
 
         self.root.title(_("Log Analysis"))
-        self.root.geometry(self.calculate_scaled_geometry(1050, 800))
+        self.root.geometry(self.calculate_scaled_geometry(1200, 800))
         self.center_window(self.root, root_tk if root_tk is not None else self.root)
         self.root.resizable(width=True, height=True)
 
@@ -289,17 +290,35 @@ class LogAnalysisReportWindow(BaseWindow):  # pylint: disable=too-many-instance-
         elif not analysis_result.outcomes:
             self._section_body(_("No findings."))
         else:
-            for outcome in analysis_result.outcomes:
-                self._outcome_line(outcome)
+            self._render_outcomes(analysis_result.outcomes)
 
     def _section_heading(self, text: str) -> None:
         ttk.Label(self.body_frame, text=text, font=("TkDefaultFont", 16, "bold"), foreground="#333333").pack(
             anchor=tk.W, pady=(16, 6)
         )
 
+    @staticmethod
+    def _set_wraplength(label: ttk.Label, event: tk.Event) -> None:
+        """Wrap report text to the width allocated to its label."""
+        label.configure(wraplength=max(10, event.width - 15))
+
+    def _render_outcomes(self, outcomes: list[LogAnalysis]) -> None:
+        """Render outcomes in list order with optional consecutive group headings."""
+        previous_group: str | None = None
+        for outcome in outcomes:
+            if outcome.group is not None and outcome.group != previous_group:
+                self._group_heading(outcome.group)
+            self._outcome_line(outcome)
+            previous_group = outcome.group
+
+    def _group_heading(self, text: str) -> None:
+        ttk.Label(self.body_frame, text=text, font=("TkDefaultFont", 13, "bold")).pack(anchor=tk.W, padx=(10, 0), pady=(12, 3))
+
     def _section_body(self, text: str, *, bold: bool = False) -> None:
         font = ("TkDefaultFont", 14, "bold") if bold else ("TkDefaultFont", 14)
-        ttk.Label(self.body_frame, text=text, font=font, wraplength=950, justify=tk.LEFT).pack(anchor=tk.W, pady=2, fill=tk.X)
+        label = ttk.Label(self.body_frame, text=text, font=font, justify=tk.LEFT)
+        label.pack(anchor=tk.W, pady=2, fill=tk.X)
+        label.bind("<Configure>", partial(self._set_wraplength, label))
 
     def _bullet_line(self, text: str) -> None:
         row = ttk.Frame(self.body_frame)
@@ -308,21 +327,22 @@ class LogAnalysisReportWindow(BaseWindow):  # pylint: disable=too-many-instance-
         ttk.Label(row, text="\u2022", font=("TkDefaultFont", 16), foreground="#666666").pack(
             side=tk.LEFT, padx=(10, 8), anchor=tk.N, pady=(0, 0)
         )
-        ttk.Label(row, text=text, font=("TkDefaultFont", 14), wraplength=920, justify=tk.LEFT).pack(
-            side=tk.LEFT, fill=tk.X, expand=True
-        )
+        label = ttk.Label(row, text=text, font=("TkDefaultFont", 14), justify=tk.LEFT)
+        label.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        label.bind("<Configure>", partial(self._set_wraplength, label))
 
     def _outcome_line(self, outcome: LogAnalysis) -> None:
-        timestamp_text = f" ({outcome.timestamp_us / 1e6:.1f}s)" if outcome.timestamp_us is not None else ""
+        timestamp_text = f" ({format_elapsed_time(outcome.timestamp_us / 1e6)})" if outcome.timestamp_us is not None else ""
         row = ttk.Frame(self.body_frame)
-        row.pack(anchor=tk.W, padx=(10, 0), pady=3, fill=tk.X)
-        ttk.Label(
+        row.pack(anchor=tk.W, padx=(10, 0), pady=5, fill=tk.X)
+        label = ttk.Label(
             row,
             text=f"{outcome.message}{timestamp_text}",
             font=("TkDefaultFont", 14),
-            wraplength=950,
             justify=tk.LEFT,
-        ).pack(side=tk.LEFT, fill=tk.X, expand=True)
+        )
+        label.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        label.bind("<Configure>", partial(self._set_wraplength, label))
 
         fixes = self._fix_for_outcome(outcome)
         if fixes:

--- a/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
@@ -12,6 +12,7 @@ import math
 from typing import TYPE_CHECKING
 
 from ardupilot_methodic_configurator import _
+from ardupilot_methodic_configurator.formatting import format_elapsed_time
 from ardupilot_methodic_configurator.log_analysis.data_model_availability_base import (
     BaseLogAnalysisModel,
     BaseLogAvailabilityModel,
@@ -30,6 +31,7 @@ from ardupilot_methodic_configurator.log_analysis.data_model_plane_landing impor
     PlaneLandingEvidenceExtractor,
     PlaneLandingFirmwareEvidence,
     PlaneLandingFirmwareFlareEvidence,
+    PlaneLandingFirmwareGlideSlopeEvidence,
     PlaneLandingFirmwareMessageExtractor,
     PlaneLandingMissionTargetExtractor,
     PlaneLandingRangefinderEvidence,
@@ -161,21 +163,26 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
             start=1,
         ):
             stage_evidence_items, rangefinder_evidence = attempt_evidence
+            firmware_evidence_items = PlaneLandingFirmwareMessageExtractor.extract(self.log_data, attempt)
             outcomes.append(self._attempt_outcome(attempt_number, attempt))
+            outcomes.append(self._start_of_final_altitude_outcome(attempt_number, attempt))
+            for firmware_evidence in firmware_evidence_items:
+                if isinstance(firmware_evidence, PlaneLandingFirmwareGlideSlopeEvidence):
+                    outcomes.extend(self._firmware_message_outcomes(attempt_number, firmware_evidence))
             for stage_evidence in stage_evidence_items:
                 outcomes.extend(self._stage_outcomes(attempt_number, stage_evidence))
-            for firmware_evidence in PlaneLandingFirmwareMessageExtractor.extract(self.log_data, attempt):
-                outcomes.extend(self._firmware_message_outcomes(attempt_number, firmware_evidence))
+            for firmware_evidence in firmware_evidence_items:
+                if not isinstance(firmware_evidence, PlaneLandingFirmwareGlideSlopeEvidence):
+                    outcomes.extend(self._firmware_message_outcomes(attempt_number, firmware_evidence))
             if rangefinder_evidence is not None:
                 outcomes.extend(self._rangefinder_outcomes(attempt_number, rangefinder_evidence))
             target_distance = PlaneLandingMissionTargetExtractor.distance_at_gps_stop(self.log_data, attempt)
             if target_distance is not None:
                 outcomes.append(
                     self._measurement_outcome(
-                        attempt_number,
-                        _("GPS-stop"),
                         round(target_distance.time_s * 1_000_000),
-                        (_("computed distance to mission LAND target"), target_distance.distance_m, _("m")),
+                        (_("Computed distance to mission LAND target"), target_distance.distance_m, _("m")),
+                        group=self._group_label(attempt_number, _("Mission-target evidence")),
                     )
                 )
         reason = (
@@ -194,38 +201,49 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
         flare_altitude_m = self._finite_parameter_value(self.parameter_history.value_at("LAND_FLARE_ALT", attempt.start_s))
         mode_name = self._mode_name(attempt.mode_number)
         parameter_evidence = (
-            _("LAND_FLARE_ALT at attempt start: {value:.2f} m").format(value=flare_altitude_m)
+            _("LAND_FLARE_ALT at start: {value:.1f} m").format(value=flare_altitude_m)
             if flare_altitude_m is not None
-            else _("LAND_FLARE_ALT was unavailable at attempt start")
+            else _("LAND_FLARE_ALT at start: unavailable")
         )
         return LogAnalysis(
-            message=_(
-                "{mode_name} landing attempt {number}: {start:.3f} s to {end:.3f} s; "
-                "termination evidence: {end_reason}; {parameter_evidence}"
-            ).format(
+            message=_("{mode_name} landing: {start} → {end}\nTermination: {end_reason}\n{parameter_evidence}").format(
                 mode_name=mode_name,
-                number=attempt_number,
-                start=attempt.start_s,
-                end=attempt.end_s,
+                start=format_elapsed_time(attempt.start_s),
+                end=format_elapsed_time(attempt.end_s),
                 end_reason=self._end_reason_text(attempt.end_reason),
                 parameter_evidence=parameter_evidence,
             ),
             timestamp_us=round(attempt.start_s * 1_000_000),
             value=flare_altitude_m,
+            group=self._group_label(attempt_number, _("Summary")),
+        )
+
+    def _start_of_final_altitude_outcome(self, attempt_number: int, attempt: PlaneLandingAttempt) -> LogAnalysis:
+        altitude_m = PlaneLandingEvidenceExtractor.start_of_final_altitude_m(self.log_data, attempt)
+        group = self._group_label(attempt_number, _("Summary"))
+        timestamp_us = round(attempt.start_s * 1_000_000)
+        if altitude_m is not None:
+            return self._measurement_outcome(
+                timestamp_us,
+                (_("Start-of-final altitude"), altitude_m, _("m")),
+                group=group,
+            )
+        return LogAnalysis(
+            message=_("Start-of-final altitude: unavailable"),
+            timestamp_us=timestamp_us,
+            group=group,
         )
 
     def _stage_outcomes(self, attempt_number: int, evidence: PlaneLandingStageEvidence) -> list[LogAnalysis]:
-        stage_name = _("preflare") if evidence.stage is PlaneLandingStage.PREFLARE else _("flare")
+        group_name = _("Preflare") if evidence.stage is PlaneLandingStage.PREFLARE else _("Flare")
+        group = self._group_label(attempt_number, group_name)
         timestamp_us = round(evidence.time_s * 1_000_000)
         outcomes = [
             LogAnalysis(
-                message=_("Attempt {number}: LAND stage {stage} ({stage_name}) entered").format(
-                    number=attempt_number,
-                    stage=int(evidence.stage),
-                    stage_name=stage_name,
-                ),
+                message=_("LAND stage {stage} entered").format(stage=int(evidence.stage)),
                 timestamp_us=timestamp_us,
                 value=float(evidence.stage),
+                group=group,
             )
         ]
         measurements = (
@@ -241,10 +259,9 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
             if value is not None:
                 outcomes.append(
                     self._measurement_outcome(
-                        attempt_number,
-                        stage_name,
                         timestamp_us,
                         (measurement_name, value, unit),
+                        group=group,
                     )
                 )
         if evidence.rangefinder_status is not None and not (
@@ -252,34 +269,31 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
         ):
             outcomes.append(
                 self._rangefinder_status_outcome(
-                    attempt_number,
-                    stage_name,
                     timestamp_us,
                     evidence.rangefinder_status,
+                    group,
                 )
             )
         for parameter_name, value in evidence.parameter_values.items():
             if value is not None:
                 outcomes.append(
                     LogAnalysis(
-                        message=_("Attempt {number} {stage_name}: {parameter} effective value {value:g}").format(
-                            number=attempt_number,
-                            stage_name=stage_name,
+                        message=_("{parameter} effective value: {value:g}").format(
                             parameter=parameter_name,
                             value=value,
                         ),
                         timestamp_us=timestamp_us,
                         value=value,
+                        group=group,
                     )
                 )
         return outcomes
 
     @staticmethod
     def _rangefinder_status_outcome(
-        attempt_number: int,
-        stage_name: str,
         timestamp_us: int,
         status: int,
+        group: str,
     ) -> LogAnalysis:
         """Report selected RFND firmware status without conflating it with lifecycle evidence."""
         status_name = _RFND_STATUS_NAMES.get(status)
@@ -300,13 +314,10 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
                 status=status,
             )
         return LogAnalysis(
-            message=_("Attempt {number} {stage_name}: {status_evidence}").format(
-                number=attempt_number,
-                stage_name=stage_name,
-                status_evidence=status_evidence,
-            ),
+            message=status_evidence,
             timestamp_us=timestamp_us,
             value=float(status),
+            group=group,
         )
 
     @staticmethod
@@ -321,22 +332,26 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
     ) -> list[LogAnalysis]:
         timestamp_us = round(evidence.time_s * 1_000_000)
         if isinstance(evidence, PlaneLandingFirmwareFlareEvidence):
+            group = self._group_label(attempt_number, _("Firmware evidence"))
             measurements = (
-                (_("altitude"), evidence.altitude_m, _("m")),
-                (_("sink rate"), evidence.sink_rate_m_s, _("m/s")),
-                (_("groundspeed"), evidence.groundspeed_m_s, _("m/s")),
-                (_("distance to target"), evidence.distance_to_target_m, _("m")),
+                (_("Flare altitude"), evidence.altitude_m, _("m")),
+                (_("Flare sink rate"), evidence.sink_rate_m_s, _("m/s")),
+                (_("Flare groundspeed"), evidence.groundspeed_m_s, _("m/s")),
+                (_("Flare distance to target"), evidence.distance_to_target_m, _("m")),
             )
             return [
-                self._measurement_outcome(attempt_number, _("firmware flare"), timestamp_us, measurement)
+                self._measurement_outcome(
+                    timestamp_us,
+                    measurement,
+                    group=group,
+                )
                 for measurement in measurements
             ]
         return [
             self._measurement_outcome(
-                attempt_number,
-                _("firmware landing"),
                 timestamp_us,
-                (_("glide slope"), evidence.glide_slope_degrees, _("degrees")),
+                (_("Glide slope"), evidence.glide_slope_degrees, _("degrees")),
+                group=self._group_label(attempt_number, _("Summary")),
             )
         ]
 
@@ -347,29 +362,30 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
     ) -> list[LogAnalysis]:
         """Flatten optional RFND lifecycle evidence into objective findings."""
         outcomes: list[LogAnalysis] = []
+        group = self._group_label(attempt_number, _("Rangefinder evidence"))
         timed_measurements = (
             (
                 evidence.first_nonzero_time_s,
                 evidence.first_nonzero_distance_m,
-                _("first non-zero distance"),
+                _("First non-zero distance"),
                 _("m"),
             ),
             (
                 evidence.first_in_range_time_s,
                 evidence.first_in_range_distance_m,
-                _("first in-range distance"),
+                _("First in-range distance"),
                 _("m"),
             ),
             (
                 evidence.continuous_time_s,
                 evidence.continuous_samples,
-                _("continuous acquisition sample count"),
+                _("Continuous acquisition sample count"),
                 _("samples"),
             ),
             (
                 evidence.last_disengagement_time_s,
                 evidence.last_disengagement_distance_m,
-                _("last disengagement distance"),
+                _("Last disengagement distance"),
                 _("m"),
             ),
         )
@@ -377,10 +393,9 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
             if timestamp_s is not None and value is not None:
                 outcomes.append(
                     self._measurement_outcome(
-                        attempt_number,
-                        _("RFND lifecycle"),
                         round(timestamp_s * 1_000_000),
                         (measurement_name, float(value), unit),
+                        group=group,
                     )
                 )
         if (
@@ -390,11 +405,7 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
         ):
             outcomes.append(
                 LogAnalysis(
-                    message=_(
-                        "Attempt {number} RFND lifecycle: last disengagement status {status_name} ({status}); "
-                        "distance unavailable"
-                    ).format(
-                        number=attempt_number,
+                    message=_("Last disengagement status: {status_name} ({status}); distance unavailable").format(
                         status_name=_RFND_STATUS_NAMES.get(
                             evidence.last_disengagement_status,
                             _("Unknown"),
@@ -403,36 +414,46 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
                     ),
                     timestamp_us=round(evidence.last_disengagement_time_s * 1_000_000),
                     value=float(evidence.last_disengagement_status),
+                    group=group,
                 )
             )
         outcomes.append(
             self._measurement_outcome(
-                attempt_number,
-                _("RFND lifecycle"),
                 round(evidence.attempt.end_s * 1_000_000),
-                (_("disengagement count"), float(evidence.disengagement_count), _("events")),
+                (_("Disengagement count"), float(evidence.disengagement_count), _("events")),
+                group=group,
             )
         )
         return outcomes
 
     @staticmethod
+    def _group_label(attempt_number: int, category: str) -> str:
+        """Return a one-level presentation group for an attempt's existing evidence."""
+        return _("Attempt {number} — {category}").format(number=attempt_number, category=category)
+
+    @staticmethod
     def _measurement_outcome(
-        attempt_number: int,
-        stage_name: str,
         timestamp_us: int,
         measurement: tuple[str, float, str],
+        *,
+        group: str | None = None,
     ) -> LogAnalysis:
         measurement_name, value, unit = measurement
-        return LogAnalysis(
-            message=_("Attempt {number} {stage_name}: {measurement} {value:.3f} {unit}").format(
-                number=attempt_number,
-                stage_name=stage_name,
+        if unit == _("degrees"):
+            measurement_text = _("{measurement}: {value:.1f}°").format(measurement=measurement_name, value=value)
+        elif unit in {_("samples"), _("events")}:
+            measurement_text = _("{measurement}: {value:.0f}").format(measurement=measurement_name, value=value)
+        else:
+            measurement_text = _("{measurement}: {value:.1f} {unit}").format(
                 measurement=measurement_name,
                 value=value,
                 unit=unit,
-            ),
+            )
+        return LogAnalysis(
+            message=measurement_text,
             timestamp_us=timestamp_us,
             value=value,
+            group=group,
         )
 
     @staticmethod

--- a/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_availability_plane_landing.py
@@ -206,9 +206,8 @@ class PlaneLandingAnalysis(BaseLogAnalysisModel):
             else _("LAND_FLARE_ALT at start: unavailable")
         )
         return LogAnalysis(
-            message=_("{mode_name} landing: {start} → {end}\nTermination: {end_reason}\n{parameter_evidence}").format(
+            message=_("{mode_name} landing → {end}\nTermination: {end_reason}\n{parameter_evidence}").format(
                 mode_name=mode_name,
-                start=format_elapsed_time(attempt.start_s),
                 end=format_elapsed_time(attempt.end_s),
                 end_reason=self._end_reason_text(attempt.end_reason),
                 parameter_evidence=parameter_evidence,

--- a/ardupilot_methodic_configurator/log_analysis/data_model_log_analysis_result.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_log_analysis_result.py
@@ -22,6 +22,7 @@ class LogAnalysis:
     related_step: str | None = None
     param_name: str | None = None
     suggested_value: int | float | None = None
+    group: str | None = None
 
 
 @dataclass

--- a/ardupilot_methodic_configurator/log_analysis/data_model_plane_landing.py
+++ b/ardupilot_methodic_configurator/log_analysis/data_model_plane_landing.py
@@ -1289,6 +1289,11 @@ class PlaneLandingEvidenceExtractor:  # pylint: disable=too-many-locals
     }
 
     @classmethod
+    def start_of_final_altitude_m(cls, log_data: LogData, attempt: PlaneLandingAttempt) -> float | None:
+        """Return nearest attempt-scoped BARO altitude at the start of final approach."""
+        return cls._nearest_value(log_data, attempt, ("BARO", "Alt"), attempt.start_s)
+
+    @classmethod
     def extract(
         cls,
         log_data: LogData,

--- a/ardupilot_methodic_configurator/log_analysis/log_analysis_report_schema.json
+++ b/ardupilot_methodic_configurator/log_analysis/log_analysis_report_schema.json
@@ -236,6 +236,10 @@
           "type": ["number", "null"],
           "description": "Suggested value for param_name, used to drive the Fix button in the UI."
         },
+        "group": {
+          "type": ["string", "null"],
+          "description": "Optional presentation group for consecutive analysis outcomes."
+        },
         "step_info": {
           "$ref": "#/$defs/step_info"
         },

--- a/tests/test_data_model_log_analysis.py
+++ b/tests/test_data_model_log_analysis.py
@@ -8,6 +8,9 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import json
+from dataclasses import asdict
+from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
@@ -23,6 +26,7 @@ from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis import
     validate_log_matches_vehicle,
 )
 from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_context import LogAnalysisContext
+from ardupilot_methodic_configurator.log_analysis.data_model_log_analysis_result import LogAnalysis
 from ardupilot_methodic_configurator.log_analysis.data_model_log_availability import (
     LogAvailabilityResult,
     LogAvailabilityState,
@@ -82,6 +86,20 @@ class RecordingParameterDeriver:
     def derived_and_forced_parameters_matching(self, pattern: str, _inputs: object) -> dict[str, str]:
         self.matching_pattern = pattern
         return {"TEST_PARAM": "01_test.param"}
+
+
+def test_log_analysis_optional_group_is_serializable_and_declared_in_schema() -> None:
+    """Keep grouping optional while preserving it in the dataclass and report schema."""
+    grouped = LogAnalysis("finding", group="Attempt 1 — Summary")
+
+    assert LogAnalysis("ungrouped").group is None
+    assert asdict(grouped)["group"] == "Attempt 1 — Summary"
+
+    schema_path = Path(__file__).parents[1] / "ardupilot_methodic_configurator/log_analysis/log_analysis_report_schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    analysis_outcome = schema["$defs"]["analysis_outcome"]
+    assert analysis_outcome["properties"]["group"]["type"] == ["string", "null"]
+    assert "group" not in analysis_outcome["required"]
 
 
 def test_analyze_log_passes_context_to_availability_models(monkeypatch: Any) -> None:  # noqa: ANN401

--- a/tests/test_data_model_plane_landing.py
+++ b/tests/test_data_model_plane_landing.py
@@ -378,7 +378,7 @@ def test_autoland_only_attempt_preserves_mode_and_flat_result_label() -> None:
 
     assert len(attempts) == 1
     assert attempts[0].mode_number == PlaneLandingAttemptDetector.AUTOLAND_MODE_NUMBER
-    assert any(outcome.message.startswith("AUTOLAND landing:") for outcome in result.outcomes)
+    assert any(outcome.message.startswith("AUTOLAND landing →") for outcome in result.outcomes)
 
 
 def test_stage_one_transition_is_ignored_when_current_mode_is_not_auto() -> None:
@@ -969,7 +969,8 @@ def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
     assert all(outcome.suggested_value is None for outcome in result.outcomes)
     assert all(isinstance(outcome, LogAnalysis) for outcome in result.outcomes)
     assert result.outcomes[0].group == "Attempt 1 — Summary"
-    assert result.outcomes[0].message.startswith("AUTO landing: 0:10.0 → 0:40.0\nTermination:")
+    assert result.outcomes[0].message.startswith("AUTO landing → 0:40.0\nTermination:")
+    assert result.outcomes[0].timestamp_us == 10_000_000
     assert any(outcome.message == "ARSP airspeed: 12.2 m/s" and outcome.value == 12.154 for outcome in result.outcomes)
     assert all(not outcome.message.startswith("Attempt 1") for outcome in result.outcomes)
     assert any(outcome.group == "Attempt 1 — Preflare" for outcome in result.outcomes)
@@ -2948,7 +2949,7 @@ def test_non_finite_event_time_landing_parameters_are_unavailable(non_finite_val
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
     assert all(value is None for item in evidence for value in item.parameter_values.values())
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing →"))
     assert attempt_outcome.value is None
     assert "LAND_FLARE_ALT at start: unavailable" in attempt_outcome.message
     assert not any(
@@ -2973,7 +2974,7 @@ def test_finite_event_time_landing_parameters_are_emitted() -> None:
 
     result = PlaneLandingAnalysis(log_data, _context(ParameterHistory(parameter_values))).analyse()
 
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing →"))
     assert attempt_outcome.value == 3.0
     parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
     emitted_parameter_names = {
@@ -2999,7 +3000,7 @@ def test_finite_parameter_change_at_event_time_remains_effective() -> None:
 
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing →"))
     assert attempt_outcome.value == 3.0
     parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
     assert [(outcome.timestamp_us, outcome.value) for outcome in parameter_outcomes] == [
@@ -3057,7 +3058,7 @@ def test_analysis_resolves_landing_parameter_at_each_attempt_time() -> None:
 
     assert result.available is True
     assert result.reason == "Detected 2 Plane landing attempt(s)"
-    attempt_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:")]
+    attempt_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing →")]
     assert [outcome.timestamp_us for outcome in attempt_outcomes] == [10_000_000, 30_000_000]
     assert [outcome.value for outcome in attempt_outcomes] == [2.0, 4.0]
     assert all(outcome.param_name is None for outcome in attempt_outcomes)

--- a/tests/test_data_model_plane_landing.py
+++ b/tests/test_data_model_plane_landing.py
@@ -305,6 +305,7 @@ def test_optional_sensor_and_message_evidence_is_not_required() -> None:
     assert analysis.available is True
     assert not PlaneLandingFirmwareMessageExtractor.extract(log_data, attempt)
     assert not any("firmware" in outcome.message.lower() for outcome in analysis.outcomes)
+    assert not any("glide slope" in outcome.message.lower() for outcome in analysis.outcomes)
     for optional_message in ("ARSP", "RFND", "CMD", "MSG"):
         assert log_data.get_message_columns(optional_message) is None
 
@@ -377,7 +378,7 @@ def test_autoland_only_attempt_preserves_mode_and_flat_result_label() -> None:
 
     assert len(attempts) == 1
     assert attempts[0].mode_number == PlaneLandingAttemptDetector.AUTOLAND_MODE_NUMBER
-    assert any(outcome.message.startswith("AUTOLAND landing attempt 1") for outcome in result.outcomes)
+    assert any(outcome.message.startswith("AUTOLAND landing:") for outcome in result.outcomes)
 
 
 def test_stage_one_transition_is_ignored_when_current_mode_is_not_auto() -> None:
@@ -902,7 +903,7 @@ def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
         land=((5.0, 0, 0.0), (10.0, 1, 20.0), (15.0, 2, 5.5), (20.0, 3, 1.2)),
         messages=((40.0, "Throttle disarmed"),),
     )
-    _add_columns(log_data, "ARSP", ((14.8, 12.0), (15.1, 13.0), (19.8, 9.0)), [("TimeUS", "f8"), ("Airspeed", "f8")])
+    _add_columns(log_data, "ARSP", ((14.8, 12.0), (15.1, 12.154), (19.8, 9.0)), [("TimeUS", "f8"), ("Airspeed", "f8")])
     _add_columns(
         log_data,
         "BARO",
@@ -929,7 +930,7 @@ def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
     preflare, flare = evidence
     assert (preflare.time_s, preflare.flight_height_m) == (15.0, 5.5)
     assert (preflare.airspeed_m_s, preflare.barometric_altitude_m, preflare.rangefinder_distance_m) == (
-        13.0,
+        12.154,
         100.0,
         6.0,
     )
@@ -951,8 +952,8 @@ def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
     }
     outcome_messages = [outcome.message for outcome in result.outcomes]
     for expected_measurement in (
-        "LAND stage 2 (preflare) entered",
-        "LAND stage 3 (flare) entered",
+        "LAND stage 2 entered",
+        "LAND stage 3 entered",
         "LAND flight height",
         "ARSP airspeed",
         "GPS groundspeed",
@@ -967,9 +968,62 @@ def test_stage_evidence_uses_land_and_nearest_optional_telemetry() -> None:
     assert all(outcome.param_name is None for outcome in result.outcomes)
     assert all(outcome.suggested_value is None for outcome in result.outcomes)
     assert all(isinstance(outcome, LogAnalysis) for outcome in result.outcomes)
+    assert result.outcomes[0].group == "Attempt 1 — Summary"
+    assert result.outcomes[0].message.startswith("AUTO landing: 0:10.0 → 0:40.0\nTermination:")
+    assert any(outcome.message == "ARSP airspeed: 12.2 m/s" and outcome.value == 12.154 for outcome in result.outcomes)
+    assert all(not outcome.message.startswith("Attempt 1") for outcome in result.outcomes)
+    assert any(outcome.group == "Attempt 1 — Preflare" for outcome in result.outcomes)
+    assert any(outcome.group == "Attempt 1 — Flare" for outcome in result.outcomes)
     assert not any(
         label in outcome.message.lower() for outcome in result.outcomes for label in ("good", "poor", "safe", "unsafe")
     )
+
+
+def test_start_of_final_altitude_uses_nearest_attempt_scoped_primary_baro_observation() -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    _add_columns(
+        log_data,
+        "BARO",
+        ((9.99, 20.0, 0), (10.05, 999.0, 1), (10.2, 18.8, 0)),
+        [("TimeUS", "f8"), ("Alt", "f8"), ("I", "u1")],
+    )
+
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    altitude_outcome = next(outcome for outcome in result.outcomes if "start-of-final altitude" in outcome.message.lower())
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (10.0, 40.0, PlaneLandingEndReason.DISARM)
+    assert (altitude_outcome.timestamp_us, altitude_outcome.value) == (10_000_000, 18.8)
+    assert altitude_outcome.group == "Attempt 1 — Summary"
+
+
+@pytest.mark.parametrize("baro_records", [None, ((10.1, np.nan),)])
+def test_missing_or_invalid_start_of_final_altitude_is_reported_unavailable(
+    baro_records: tuple[tuple[float, float], ...] | None,
+) -> None:
+    log_data = _plane_log(
+        land=((5.0, 0), (10.0, 1), (15.0, 2)),
+        messages=((40.0, "Throttle disarmed"),),
+        include_baro=False,
+    )
+    if baro_records is not None:
+        _add_columns(log_data, "BARO", baro_records, [("TimeUS", "f8"), ("Alt", "f8")])
+
+    segment = PlaneFlightSegmentDetector.detect(log_data, {}).segments[0]
+    attempt = PlaneLandingAttemptDetector.detect(log_data, segment)[0]
+    result = PlaneLandingAnalysis(log_data, _context()).analyse()
+
+    altitude_outcome = next(outcome for outcome in result.outcomes if "start-of-final altitude" in outcome.message.lower())
+    assert (attempt.start_s, attempt.end_s, attempt.end_reason) == (10.0, 40.0, PlaneLandingEndReason.DISARM)
+    assert altitude_outcome.timestamp_us == 10_000_000
+    assert altitude_outcome.value is None
+    assert "unavailable" in altitude_outcome.message
+    assert altitude_outcome.group == "Attempt 1 — Summary"
 
 
 @pytest.mark.parametrize(("nonprimary_used", "nonprimary_healthy"), [(1, 1), (0, 1), (1, 0)])
@@ -1366,13 +1420,25 @@ def test_firmware_flare_and_glide_slope_messages_are_separate_from_land_stage() 
     assert stage_flare.airspeed_m_s == 17.0
     assert firmware_flare.groundspeed_m_s == 13.5
     assert firmware_flare.time_s != stage_flare.time_s
-    firmware_outcomes = [outcome for outcome in result.outcomes if "firmware" in outcome.message.lower()]
-    assert [outcome.timestamp_us for outcome in firmware_outcomes] == [10_100_000] + [19_999_900] * 4
-    assert [outcome.value for outcome in firmware_outcomes] == [4.7, -160.1, 1.13, 13.5, 32.6]
-    assert any("firmware flare: groundspeed 13.500 m/s" in outcome.message for outcome in firmware_outcomes)
-    assert not any("firmware flare: airspeed" in outcome.message for outcome in firmware_outcomes)
-    assert all(isinstance(outcome, LogAnalysis) for outcome in firmware_outcomes)
+    glide_slope_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("Glide slope:")]
+    firmware_outcomes = [outcome for outcome in result.outcomes if outcome.group == "Attempt 1 — Firmware evidence"]
+    start_altitude_index = next(
+        index for index, outcome in enumerate(result.outcomes) if "start-of-final altitude" in outcome.message.lower()
+    )
+    glide_slope_indices = [
+        index for index, outcome in enumerate(result.outcomes) if outcome.message.startswith("Glide slope:")
+    ]
+    preflare_index = next(index for index, outcome in enumerate(result.outcomes) if "LAND stage 2" in outcome.message)
+    assert len(glide_slope_indices) == 1
+    assert start_altitude_index < glide_slope_indices[0] < preflare_index
+    assert [(outcome.timestamp_us, outcome.value) for outcome in glide_slope_outcomes] == [(10_100_000, 4.7)]
+    assert [outcome.timestamp_us for outcome in firmware_outcomes] == [19_999_900] * 4
+    assert [outcome.value for outcome in firmware_outcomes] == [-160.1, 1.13, 13.5, 32.6]
+    assert glide_slope_outcomes[0].message == "Glide slope: 4.7°"
+    assert any(outcome.message == "Flare groundspeed: 13.5 m/s" for outcome in firmware_outcomes)
+    assert all(isinstance(outcome, LogAnalysis) for outcome in glide_slope_outcomes + firmware_outcomes)
     assert all(outcome.param_name is None and outcome.suggested_value is None for outcome in firmware_outcomes)
+    assert glide_slope_outcomes[0].group == "Attempt 1 — Summary"
     assert not any(
         label in outcome.message.lower() for outcome in firmware_outcomes for label in ("good", "poor", "safe", "unsafe")
     )
@@ -1709,13 +1775,15 @@ def test_complete_cmd_snapshot_produces_independent_mission_target_distance() ->
     assert (distance.time_s, distance.aircraft_position_time_s) == (20.0, 20.0)
     assert (distance.aircraft_latitude_deg, distance.aircraft_longitude_deg) == (0.0, 1.001)
     assert distance.distance_m == pytest.approx(111.1949266)
-    firmware_distance = [outcome for outcome in result.outcomes if "firmware flare: distance to target" in outcome.message]
+    firmware_distance = [outcome for outcome in result.outcomes if outcome.message.startswith("Flare distance to target:")]
     computed_distance = [
-        outcome for outcome in result.outcomes if "computed distance to mission LAND target" in outcome.message
+        outcome for outcome in result.outcomes if "computed distance to mission land target" in outcome.message.lower()
     ]
     assert [(outcome.timestamp_us, outcome.value) for outcome in firmware_distance] == [(13_999_900, 32.6)]
+    assert {outcome.group for outcome in firmware_distance} == {"Attempt 1 — Firmware evidence"}
     assert len(computed_distance) == 1
     assert (computed_distance[0].timestamp_us, computed_distance[0].value) == pytest.approx((20_000_000, 111.1949266))
+    assert computed_distance[0].group == "Attempt 1 — Mission-target evidence"
     assert all(isinstance(outcome, LogAnalysis) for outcome in result.outcomes)
     assert all(outcome.param_name is None and outcome.suggested_value is None for outcome in result.outcomes)
     assert not any(
@@ -1735,7 +1803,7 @@ def test_missing_cmd_keeps_analysis_available_and_omits_target_evidence() -> Non
     assert availability.available is True
     assert PlaneLandingMissionTargetExtractor.target_for_attempt(log_data, attempt) is None
     assert PlaneLandingMissionTargetExtractor.distance_at_gps_stop(log_data, attempt) is None
-    assert not any("computed distance to mission LAND target" in outcome.message for outcome in result.outcomes)
+    assert not any("computed distance to mission land target" in outcome.message.lower() for outcome in result.outcomes)
 
 
 @pytest.mark.parametrize(
@@ -1922,7 +1990,7 @@ def test_missing_rfnd_omits_lifecycle_evidence_without_affecting_availability() 
 
     assert _availability(log_data).available is True
     assert evidence is None
-    assert not any("RFND lifecycle" in outcome.message for outcome in result.outcomes)
+    assert not any(outcome.group == "Attempt 1 — Rangefinder evidence" for outcome in result.outcomes)
 
 
 def test_rfnd_uses_configured_landing_orientation_instead_of_instance_zero() -> None:
@@ -2461,7 +2529,7 @@ def test_rfnd_stage_flat_output_reports_observation_status_and_usability(
 
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
-    stage_messages = [outcome.message for outcome in result.outcomes if "Attempt 1 preflare" in outcome.message]
+    stage_messages = [outcome.message for outcome in result.outcomes if outcome.group == "Attempt 1 — Preflare"]
     assert any(f"RFND status {status_name} ({status})" in message for message in stage_messages) is (status != 4)
     if usability_text is not None:
         assert any(usability_text in message for message in stage_messages)
@@ -2483,8 +2551,8 @@ def test_unknown_rfnd_status_is_reported_numerically_without_current_distance() 
 
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
-    stage_messages = [outcome.message for outcome in result.outcomes if "Attempt 1 preflare" in outcome.message]
-    assert any(message.endswith("RFND status 5") for message in stage_messages)
+    stage_messages = [outcome.message for outcome in result.outcomes if outcome.group == "Attempt 1 — Preflare"]
+    assert "RFND status 5" in stage_messages
     assert not any("RFND distance" in message for message in stage_messages)
 
 
@@ -2541,13 +2609,13 @@ def test_rfnd_no_current_data_disengagement_flat_output_preserves_status_without
     history = ParameterHistory({"RNGFND_LND_ORNT": 25.0, "RNGFND1_MAX": 10.0})
 
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
-    lifecycle_messages = [outcome for outcome in result.outcomes if "RFND lifecycle" in outcome.message]
+    lifecycle_messages = [outcome for outcome in result.outcomes if outcome.group == "Attempt 1 — Rangefinder evidence"]
 
-    status_outcome = next(outcome for outcome in lifecycle_messages if "last disengagement status" in outcome.message)
+    status_outcome = next(outcome for outcome in lifecycle_messages if "disengagement status" in outcome.message.lower())
     assert status_name in status_outcome.message
     assert "distance unavailable" in status_outcome.message
     assert (status_outcome.timestamp_us, status_outcome.value) == (16_000_000, float(status))
-    assert not any("last disengagement distance" in outcome.message for outcome in lifecycle_messages)
+    assert not any("disengagement distance" in outcome.message.lower() for outcome in lifecycle_messages)
 
 
 def test_rfnd_good_status_is_reported_when_distance_is_unavailable() -> None:
@@ -2818,7 +2886,8 @@ def test_rfnd_lifecycle_flat_outcomes_leave_stage_point_measurement_unchanged() 
     assert lifecycle_evidence is not None
     assert (lifecycle_evidence.first_nonzero_time_s, lifecycle_evidence.first_nonzero_distance_m) == (14.7, 6.0)
     assert (lifecycle_evidence.first_in_range_time_s, lifecycle_evidence.first_in_range_distance_m) == (15.0, 5.5)
-    lifecycle_outcomes = [outcome for outcome in result.outcomes if "RFND lifecycle" in outcome.message]
+    lifecycle_outcomes = [outcome for outcome in result.outcomes if outcome.group == "Attempt 1 — Rangefinder evidence"]
+    assert {outcome.group for outcome in lifecycle_outcomes} == {"Attempt 1 — Rangefinder evidence"}
     assert [(outcome.timestamp_us, outcome.value) for outcome in lifecycle_outcomes] == [
         (14_700_000, 6.0),
         (15_000_000, 5.5),
@@ -2826,6 +2895,8 @@ def test_rfnd_lifecycle_flat_outcomes_leave_stage_point_measurement_unchanged() 
         (21_000_000, 0.0),
         (40_000_000, 1.0),
     ]
+    assert any(outcome.message == "Continuous acquisition sample count: 2" for outcome in lifecycle_outcomes)
+    assert lifecycle_outcomes[-1].message == "Disengagement count: 1"
 
 
 def test_rfnd_lifecycle_and_stage_distance_use_only_instance_zero() -> None:
@@ -2877,9 +2948,9 @@ def test_non_finite_event_time_landing_parameters_are_unavailable(non_finite_val
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
     assert all(value is None for item in evidence for value in item.parameter_values.values())
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
     assert attempt_outcome.value is None
-    assert "LAND_FLARE_ALT was unavailable" in attempt_outcome.message
+    assert "LAND_FLARE_ALT at start: unavailable" in attempt_outcome.message
     assert not any(
         parameter_name in outcome.message and "effective value" in outcome.message
         for parameter_name in parameter_names
@@ -2902,7 +2973,7 @@ def test_finite_event_time_landing_parameters_are_emitted() -> None:
 
     result = PlaneLandingAnalysis(log_data, _context(ParameterHistory(parameter_values))).analyse()
 
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
     assert attempt_outcome.value == 3.0
     parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
     emitted_parameter_names = {
@@ -2928,7 +2999,7 @@ def test_finite_parameter_change_at_event_time_remains_effective() -> None:
 
     result = PlaneLandingAnalysis(log_data, _context(history)).analyse()
 
-    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt"))
+    attempt_outcome = next(outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:"))
     assert attempt_outcome.value == 3.0
     parameter_outcomes = [outcome for outcome in result.outcomes if "effective value" in outcome.message]
     assert [(outcome.timestamp_us, outcome.value) for outcome in parameter_outcomes] == [
@@ -2986,7 +3057,7 @@ def test_analysis_resolves_landing_parameter_at_each_attempt_time() -> None:
 
     assert result.available is True
     assert result.reason == "Detected 2 Plane landing attempt(s)"
-    attempt_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing attempt")]
+    attempt_outcomes = [outcome for outcome in result.outcomes if outcome.message.startswith("AUTO landing:")]
     assert [outcome.timestamp_us for outcome in attempt_outcomes] == [10_000_000, 30_000_000]
     assert [outcome.value for outcome in attempt_outcomes] == [2.0, 4.0]
     assert all(outcome.param_name is None for outcome in attempt_outcomes)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -8,10 +8,19 @@ SPDX-FileCopyrightText: 2024-2026 Amilcar do Carmo Lucas <amilcar.lucas@iav.de>
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-from ardupilot_methodic_configurator.formatting import format_filesize
+from ardupilot_methodic_configurator.formatting import format_elapsed_time, format_filesize
 
 
 def test_format_filesize() -> None:
     assert format_filesize(512) == "512 B"
     assert format_filesize(2048) == "2.0 KB"
     assert format_filesize(2 * 1024 * 1024) == "2.0 MB"
+
+
+def test_format_elapsed_time_under_at_and_over_one_hour() -> None:
+    assert format_elapsed_time(0.0) == "0:00.0"
+    assert format_elapsed_time(65.4) == "1:05.4"
+    assert format_elapsed_time(1039.9) == "17:19.9"
+    assert format_elapsed_time(3599.9) == "59:59.9"
+    assert format_elapsed_time(3600.0) == "1:00:00.0"
+    assert format_elapsed_time(8263.2) == "2:17:43.2"

--- a/tests/test_frontend_tkinter_log_analysis.py
+++ b/tests/test_frontend_tkinter_log_analysis.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import sys
 from argparse import Namespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -75,12 +75,14 @@ def _make_outcome(
     timestamp_us: float | None = None,
     param_name: str | None = None,
     suggested_value: float | None = None,
+    group: str | None = None,
 ) -> MagicMock:
     outcome = MagicMock()
     outcome.message = message
     outcome.timestamp_us = timestamp_us
     outcome.param_name = param_name
     outcome.suggested_value = suggested_value
+    outcome.group = group
     return outcome
 
 
@@ -480,6 +482,97 @@ class TestWindowConstruction:
         window = self._build_window(mocker, patched_widgets, [], [])
 
         cast("MagicMock", window.selector.set).assert_not_called()
+
+
+class TestResponsiveWrapping:
+    """Cover width-responsive wrapping used by report text labels."""
+
+    def test_wraplength_tracks_allocated_label_width(self) -> None:
+        """Keep a small edge inset while using the label's available width."""
+        label = MagicMock()
+
+        LogAnalysisReportWindow._set_wraplength(label, MagicMock(width=600))
+
+        label.configure.assert_called_once_with(wraplength=585)
+
+    def test_wraplength_has_a_safe_minimum(self) -> None:
+        """Avoid invalid wrapping when a label receives an initial tiny width."""
+        label = MagicMock()
+
+        LogAnalysisReportWindow._set_wraplength(label, MagicMock(width=1))
+
+        label.configure.assert_called_once_with(wraplength=10)
+
+    def test_outcome_timestamp_uses_clock_display_without_mutating_evidence(
+        self,
+        bare_window: LogAnalysisReportWindow,
+        patched_widgets: dict[str, MagicMock],
+    ) -> None:
+        """Format the timestamp suffix while retaining the original microseconds."""
+        outcome = _make_outcome(message="Finding", timestamp_us=3_600_000_000)
+        bare_window.body_frame = MagicMock()
+
+        bare_window._outcome_line(outcome)
+
+        assert patched_widgets["label"].call_args.kwargs["text"] == "Finding (1:00:00.0)"
+        assert outcome.timestamp_us == 3_600_000_000
+
+
+class TestOutcomeGrouping:
+    """Cover optional consecutive grouping in the shared outcome renderer."""
+
+    def test_ungrouped_outcomes_render_without_headings(self, bare_window: LogAnalysisReportWindow) -> None:
+        """Preserve the rendering behavior of analyses that do not provide groups."""
+        outcomes = [_make_outcome(message="first"), _make_outcome(message="second")]
+
+        with (
+            patch.object(bare_window, "_group_heading") as group_heading,
+            patch.object(bare_window, "_outcome_line") as outcome_line,
+        ):
+            bare_window._render_outcomes(outcomes)
+
+        group_heading.assert_not_called()
+        assert outcome_line.call_args_list == [call(outcomes[0]), call(outcomes[1])]
+
+    def test_consecutive_same_group_renders_one_heading(self, bare_window: LogAnalysisReportWindow) -> None:
+        """Share one heading between consecutive outcomes with the same group."""
+        outcomes = [_make_outcome(group="Summary"), _make_outcome(group="Summary")]
+
+        with (
+            patch.object(bare_window, "_group_heading") as group_heading,
+            patch.object(bare_window, "_outcome_line"),
+        ):
+            bare_window._render_outcomes(outcomes)
+
+        group_heading.assert_called_once_with("Summary")
+
+    def test_group_change_renders_new_heading(self, bare_window: LogAnalysisReportWindow) -> None:
+        """Render a heading whenever the current outcome's group changes."""
+        outcomes = [_make_outcome(group="Summary"), _make_outcome(group="Flare")]
+
+        with (
+            patch.object(bare_window, "_group_heading") as group_heading,
+            patch.object(bare_window, "_outcome_line"),
+        ):
+            bare_window._render_outcomes(outcomes)
+
+        assert group_heading.call_args_list == [call("Summary"), call("Flare")]
+
+    def test_returning_to_previous_group_renders_heading_again(self, bare_window: LogAnalysisReportWindow) -> None:
+        """Follow list order instead of globally collecting outcomes by group."""
+        outcomes = [
+            _make_outcome(group="Summary"),
+            _make_outcome(group="Flare"),
+            _make_outcome(group="Summary"),
+        ]
+
+        with (
+            patch.object(bare_window, "_group_heading") as group_heading,
+            patch.object(bare_window, "_outcome_line"),
+        ):
+            bare_window._render_outcomes(outcomes)
+
+        assert group_heading.call_args_list == [call("Summary"), call("Flare"), call("Summary")]
 
 
 class TestTuningGraphButton:

--- a/tests/test_frontend_tkinter_log_analysis.py
+++ b/tests/test_frontend_tkinter_log_analysis.py
@@ -503,19 +503,43 @@ class TestResponsiveWrapping:
 
         label.configure.assert_called_once_with(wraplength=10)
 
-    def test_outcome_timestamp_uses_clock_display_without_mutating_evidence(
+    @pytest.mark.parametrize(
+        ("timestamp_us", "expected_text"),
+        [
+            (65_400_000, "1:05.4  Finding"),
+            (3_600_000_000, "1:00:00.0  Finding"),
+            (8_263_200_000, "2:17:43.2  Finding"),
+        ],
+    )
+    def test_outcome_timestamp_precedes_message_without_mutating_evidence(
         self,
         bare_window: LogAnalysisReportWindow,
         patched_widgets: dict[str, MagicMock],
+        timestamp_us: int,
+        expected_text: str,
     ) -> None:
-        """Format the timestamp suffix while retaining the original microseconds."""
-        outcome = _make_outcome(message="Finding", timestamp_us=3_600_000_000)
+        """Format the timestamp first while retaining the original microseconds."""
+        outcome = _make_outcome(message="Finding", timestamp_us=timestamp_us)
         bare_window.body_frame = MagicMock()
 
         bare_window._outcome_line(outcome)
 
-        assert patched_widgets["label"].call_args.kwargs["text"] == "Finding (1:00:00.0)"
-        assert outcome.timestamp_us == 3_600_000_000
+        assert patched_widgets["label"].call_args.kwargs["text"] == expected_text
+        assert outcome.timestamp_us == timestamp_us
+
+    def test_untimestamped_outcome_renders_message_without_placeholder(
+        self,
+        bare_window: LogAnalysisReportWindow,
+        patched_widgets: dict[str, MagicMock],
+    ) -> None:
+        """Leave untimestamped outcome text clean and unchanged."""
+        outcome = _make_outcome(message="Static finding")
+        bare_window.body_frame = MagicMock()
+
+        bare_window._outcome_line(outcome)
+
+        assert patched_widgets["label"].call_args.kwargs["text"] == "Static finding"
+        assert outcome.timestamp_us is None
 
 
 class TestOutcomeGrouping:


### PR DESCRIPTION
## Description

Improve the shared log-analysis report presentation and use Plane landing
analysis as the first consumer of optional result grouping.

This adds a small generic `group` field to `LogAnalysis` so contiguous outcomes
can be displayed under shared headings without introducing subsystem-specific
frontend code or a hierarchical result model.

Shared report readability improvements include:

- responsive text wrapping;
- a wider default report window;
- slightly increased outcome spacing;
- elapsed timestamps formatted as `m:ss.s` / `h:mm:ss.s`;
- timestamps displayed first so rows align.

Plane landing presentation is cleaned up with:

- Summary / Preflare / Flare / Firmware / Rangefinder / mission-target groups;
- start-of-final BARO altitude in the Summary;
- existing firmware glide-slope evidence moved into the Summary;
- concise outcome wording;
- one-decimal operator-facing physical measurements.

No Plane-specific frontend renderer was added. Underlying analysis values,
timestamps and landing-attempt semantics are unchanged.

## Testing

- Focused tests: 268 passed
- Full AMC suite: 5085 passed, 53 skipped, 4 xfailed
- Ruff: PASS
- Ruff format check: PASS
- `git diff --check`: PASS
- Manual testing performed with real Plane landing-analysis logs