### PR TITLE
fix: uv installation fail from Setup.sh on Mac

### DIFF
--- a/SetupDeveloperPC.sh
+++ b/SetupDeveloperPC.sh
@@ -35,10 +35,18 @@ if command -v brew &> /dev/null; then
     fi
 
     echo "Found Python $PY_VER, installing python-tk..."
-    brew install uv@0.10.9 python-tk@"$PY_VER"
+    brew install python-tk@"$PY_VER"
+
+    if command -v uv &> /dev/null; then
+        echo "uv is already installed. Using existing uv installation."
+    else
+        echo "uv not found. Installing uv with Homebrew..."
+        brew install uv
+    fi
 
     echo "Creating Python virtual environment with uv..."
     uv venv --python "$PY_VER"
+
 else
     # Create a local virtual environment if it doesn't exist
     if [ ! -d ".venv" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ download = "https://github.com/ArduPilot/MethodicConfigurator/releases"
 changelog = "https://github.com/ArduPilot/MethodicConfigurator/releases"
 
 [tool.uv]
-required-version = "==0.12.6"
+required-version = ">=0.12.6,<0.13.0"
 
 [tool.setuptools]
 # Rely on discovery for just the top-level package and specify data via package-data


### PR DESCRIPTION
fix: version range

# Description

Fix macOS uv installation by replacing the unavailable version-specific Homebrew version with a standard installation.
## Checklist

- [ ] Run pre-commit checks locally
- [ ] Verified by a human programmer
- [ ] All commits are signed off (use `git commit --signoff`)
- [ ] Code follows our [coding standards](../CONTRIBUTING.md#code-quality--standards)
- [ ] Documentation updated if needed
- [ ] No breaking changes or properly documented

## Testing

Describe how you tested these changes:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] Tested on flight controller hardware
